### PR TITLE
ui: polish feed details and mobile navigation

### DIFF
--- a/client/src/services/FrontEnd/src/components/FeedItem.tsx
+++ b/client/src/services/FrontEnd/src/components/FeedItem.tsx
@@ -566,7 +566,13 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
             `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=${targetLang}&dt=t&q=${encodeURIComponent(useItem.content)}`
           )
           const data = await response.json()
-          const translated = data[0]?.[0]?.[0]
+          // Google returns translation in multiple segments: data[0] = [[translatedChunk, originalChunk, ...], ...]
+          const translated = Array.isArray(data?.[0])
+            ? (data[0] as unknown[])
+                .map((seg) => (Array.isArray(seg) ? (seg as unknown[])[0] : ''))
+                .filter((s): s is string => typeof s === 'string')
+                .join('')
+            : undefined
 
           if (translated && translated !== useItem.content) {
             setTranslatedText(translated)
@@ -576,7 +582,12 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
               `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=en&dt=t&q=${encodeURIComponent(useItem.content)}`
             )
             const enData = await enResponse.json()
-            const enTranslated = enData[0]?.[0]?.[0]
+            const enTranslated = Array.isArray(enData?.[0])
+              ? (enData[0] as unknown[])
+                  .map((seg) => (Array.isArray(seg) ? (seg as unknown[])[0] : ''))
+                  .filter((s): s is string => typeof s === 'string')
+                  .join('')
+              : undefined
             if (enTranslated) {
               setTranslatedText(enTranslated)
             }
@@ -728,7 +739,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
 
           {/* Recawed header */}
           {headline && (
-            <div className="text-xs mb-3 transition-all duration-300 text-yellow-500">
+            <div className="text-xs font-medium mb-3 transition-all duration-300 text-yellow-500">
               {headline}
             </div>
           )}
@@ -765,7 +776,43 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
               {/* User info */}
               <div className="flex-1">
                 <div>
-                  {/* First line: Display name and status badges */}
+                  {/* Inline translate / translated status (same spot) */}
+                  {!isTranslating && useItem.content?.trim() && (
+                    translatedText ? (
+                      <div className="mb-1 flex items-center justify-between gap-2 min-w-0">
+                        <span className={`min-w-0 truncate text-xs ${isDark ? 'text-gray-500' : 'text-gray-500'}`}>
+                          Translated from original
+                        </span>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            setTranslatedText(null)
+                          }}
+                          className="inline-flex shrink-0 items-center gap-1 text-xs text-yellow-500/80 hover:text-yellow-500 transition-colors cursor-pointer"
+                        >
+                          <HiOutlineTranslate className="w-3.5 h-3.5" />
+                          Show original
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault()
+                          e.stopPropagation()
+                          void handleMenuAction('translate')
+                        }}
+                        className="mb-1 inline-flex items-center gap-1 text-xs text-yellow-500/80 hover:text-yellow-500 transition-colors cursor-pointer"
+                      >
+                        <HiOutlineTranslate className="w-3.5 h-3.5" />
+                        Translate
+                      </button>
+                    )
+                  )}
+
+                  {/* First line: Display name, username, time, and status badges */}
                   <div className="flex items-center space-x-2 mb-0.5">
                     <Link
                       to={`/users/${useItem.user.username}`}
@@ -775,6 +822,18 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                     >
                       {useItem.user.displayName || useItem.user.username}
                     </Link>
+
+                    <span className={`text-sm transition-colors duration-300 ${
+                      isDark ? 'text-gray-400' : 'text-gray-600'
+                    }`}>
+                      @{useItem.user.username}
+                    </span>
+
+                    <span className={`text-sm transition-colors duration-300 ${
+                      isDark ? 'text-gray-500' : 'text-gray-500'
+                    }`}>
+                      · {formatTimeAgo(useItem.timestamp)}
+                    </span>
                     {item.status === 'FAILED' && (
                       <>
                         <span className="relative group">
@@ -807,21 +866,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                         Hide
                       </button>
                     </>
-                  )}
-                  </div>
-
-                  {/* Second line: Username and time */}
-                  <div className="flex items-center space-x-2">
-                    <span className={`text-sm transition-colors duration-300 ${
-                      isDark ? 'text-gray-400' : 'text-gray-600'
-                    }`}>
-                      @{useItem.user.username}
-                    </span>
-                    <span className={`text-sm transition-colors duration-300 ${
-                      isDark ? 'text-gray-500' : 'text-gray-500'
-                    }`}>
-                      · {formatTimeAgo(useItem.timestamp)}
-                    </span>
+                    )}
                   </div>
                 </div>
               </div>
@@ -860,24 +905,16 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                   isDark ? 'text-gray-200' : 'text-gray-800'
                 }`}
               />
-              <div className={`mt-2 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
-                <HiOutlineTranslate className="inline-block w-4 h-4 mr-1" />
-                Translated from original •{' '}
-                <button
-                  onClick={() => setTranslatedText(null)}
-                  className="underline hover:no-underline"
-                >
-                  Show original
-                </button>
-              </div>
             </div>
           ) : (
-            <ContentWithHashtags
-              content={useItem.content}
-              className={`mb-4 transition-colors duration-300 pl-2 md:pl-0 ${
-                isDark ? 'text-gray-200' : 'text-gray-800'
-              }`}
-            />
+            <div className="mb-4 pl-2 md:pl-0">
+              <ContentWithHashtags
+                content={useItem.content}
+                className={`transition-colors duration-300 ${
+                  isDark ? 'text-gray-200' : 'text-gray-800'
+                }`}
+              />
+            </div>
           )}
 
           {/* Video Display */}
@@ -963,26 +1000,65 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                     return (
                       <div className="relative">
                         {collapseBtn}
-                        <div className={urls.length > 1 ? 'grid grid-cols-2 gap-2 w-full' : 'w-full'}>
-                          {urls.map((url, index) => (
-                            <div key={index} className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 w-full">
-                              <img
-                                src={url}
-                                alt={`Caw image ${index + 1}`}
-                                className="w-full max-h-96 h-auto cursor-pointer hover:opacity-90 transition-opacity"
-                                onClick={(e) => {
-                                  e.preventDefault()
-                                  e.stopPropagation()
-                                  // TODO: Open image in modal
-                                }}
-                                onError={(e) => {
-                                  console.error('Failed to load image from URL:', url)
-                                  e.currentTarget.style.display = 'none'
-                                }}
-                              />
+                        {(() => {
+                          const count = urls.length
+                          if (count <= 0) return null
+
+                          if (count === 1) {
+                            const url = urls[0]
+                            return (
+                              <div className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 w-full">
+                                <img
+                                  src={url}
+                                  alt="Caw image"
+                                  className="block w-full max-h-96 h-auto cursor-pointer hover:opacity-90 transition-opacity"
+                                  onClick={(e) => {
+                                    e.preventDefault()
+                                    e.stopPropagation()
+                                    // TODO: Open image in modal
+                                  }}
+                                  onError={(e) => {
+                                    console.error('Failed to load image from URL:', url)
+                                    e.currentTarget.style.display = 'none'
+                                  }}
+                                />
+                              </div>
+                            )
+                          }
+
+                          const gridClass =
+                            count === 2
+                                ? 'grid grid-cols-2 gap-2 aspect-video rounded-lg overflow-hidden'
+                                : count === 3
+                                  ? 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden'
+                                  : 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden'
+
+                          const cellClass = (i: number) =>
+                            count === 3 && i === 0 ? 'row-span-2 w-full h-full' : 'w-full h-full'
+
+                          return (
+                            <div className={gridClass}>
+                              {urls.slice(0, 4).map((url, index) => (
+                                <div key={index} className={`relative w-full h-full overflow-hidden border border-gray-200 dark:border-gray-700 ${cellClass(index)}`}>
+                                  <img
+                                    src={url}
+                                    alt={`Caw image ${index + 1}`}
+                                    className="block w-full h-full object-cover cursor-pointer hover:opacity-90 transition-opacity"
+                                    onClick={(e) => {
+                                      e.preventDefault()
+                                      e.stopPropagation()
+                                      // TODO: Open image in modal
+                                    }}
+                                    onError={(e) => {
+                                      console.error('Failed to load image from URL:', url)
+                                      e.currentTarget.style.display = 'none'
+                                    }}
+                                  />
+                                </div>
+                              ))}
                             </div>
-                          ))}
-                        </div>
+                          )
+                        })()}
                       </div>
                     )
                   } else {
@@ -991,29 +1067,71 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                     return (
                       <div className="relative">
                         {collapseBtn}
-                        <div className={images.length > 1 ? 'grid grid-cols-2 gap-2 w-full' : 'w-full'}>
-                          {images.map((imageBase64, index) => (
-                            <div key={index} className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 w-full">
-                              <img
-                                src={`data:image/jpeg;base64,${imageBase64}`}
-                                alt={`Caw image ${index + 1}`}
-                                className="w-full max-h-96 h-auto cursor-pointer hover:opacity-90 transition-opacity"
-                                onClick={(e) => {
-                                  e.preventDefault()
-                                  e.stopPropagation()
-                                  // TODO: Open image in modal
-                                }}
-                                onError={(e) => {
-                                  console.error('Failed to load on-chain image')
-                                  e.currentTarget.style.display = 'none'
-                                }}
-                              />
-                              <div className="absolute top-2 right-2 px-2 py-1 bg-black/70 text-white text-xs rounded-full">
-                                On-chain
+                        {(() => {
+                          const count = images.length
+                          if (count <= 0) return null
+
+                          if (count === 1) {
+                            const imageBase64 = images[0]
+                            return (
+                              <div className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 w-full">
+                                <img
+                                  src={`data:image/jpeg;base64,${imageBase64}`}
+                                  alt="Caw image"
+                                  className="block w-full max-h-96 h-auto cursor-pointer hover:opacity-90 transition-opacity"
+                                  onClick={(e) => {
+                                    e.preventDefault()
+                                    e.stopPropagation()
+                                    // TODO: Open image in modal
+                                  }}
+                                  onError={(e) => {
+                                    console.error('Failed to load on-chain image')
+                                    e.currentTarget.style.display = 'none'
+                                  }}
+                                />
+                                <div className="absolute top-2 right-2 px-2 py-1 bg-black/70 text-white text-xs rounded-full">
+                                  On-chain
+                                </div>
                               </div>
+                            )
+                          }
+
+                          const gridClass =
+                            count === 2
+                                ? 'grid grid-cols-2 gap-2 aspect-video rounded-lg overflow-hidden'
+                                : count === 3
+                                  ? 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden'
+                                  : 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden'
+
+                          const cellClass = (i: number) =>
+                            count === 3 && i === 0 ? 'row-span-2 w-full h-full' : 'w-full h-full'
+
+                          return (
+                            <div className={gridClass}>
+                              {images.slice(0, 4).map((imageBase64, index) => (
+                                <div key={index} className={`relative w-full h-full overflow-hidden border border-gray-200 dark:border-gray-700 ${cellClass(index)}`}>
+                                  <img
+                                    src={`data:image/jpeg;base64,${imageBase64}`}
+                                    alt={`Caw image ${index + 1}`}
+                                    className="block w-full h-full object-cover cursor-pointer hover:opacity-90 transition-opacity"
+                                    onClick={(e) => {
+                                      e.preventDefault()
+                                      e.stopPropagation()
+                                      // TODO: Open image in modal
+                                    }}
+                                    onError={(e) => {
+                                      console.error('Failed to load on-chain image')
+                                      e.currentTarget.style.display = 'none'
+                                    }}
+                                  />
+                                  <div className="absolute top-2 right-2 px-2 py-1 bg-black/70 text-white text-xs rounded-full">
+                                    On-chain
+                                  </div>
+                                </div>
+                              ))}
                             </div>
-                          ))}
-                        </div>
+                          )
+                        })()}
                       </div>
                     )
                   }
@@ -1025,7 +1143,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                       <img
                         src={useItem.imageUrl}
                         alt="Caw image"
-                        className="w-full max-h-96 h-auto cursor-pointer hover:opacity-90 transition-opacity"
+                        className="block w-full max-h-96 h-auto cursor-pointer hover:opacity-90 transition-opacity"
                         onClick={(e) => {
                           e.preventDefault()
                           e.stopPropagation()

--- a/client/src/services/FrontEnd/src/components/GifPicker.tsx
+++ b/client/src/services/FrontEnd/src/components/GifPicker.tsx
@@ -92,10 +92,10 @@ const GifPicker: React.FC<GifPickerProps> = ({ initialQuery = '', onSelect, onCl
 
   return (
     <div className={`rounded-xl border overflow-hidden ${
-      isDark ? 'bg-gray-900 border-gray-700' : 'bg-white border-gray-200'
+      isDark ? 'bg-black border-white/20' : 'bg-white border-gray-200'
     }`}>
       {/* Header with search */}
-      <div className={`p-3 border-b ${isDark ? 'border-gray-700' : 'border-gray-200'}`}>
+      <div className={`p-3 border-b ${isDark ? 'border-white/20' : 'border-gray-200'}`}>
         <div className="flex items-center justify-between mb-2">
           <span className={`text-sm font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
             Choose a GIF
@@ -103,7 +103,7 @@ const GifPicker: React.FC<GifPickerProps> = ({ initialQuery = '', onSelect, onCl
           <button
             onClick={onClose}
             className={`p-1 rounded-full transition-colors ${
-              isDark ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-100 text-gray-500'
+              isDark ? 'hover:bg-white/10 text-gray-400' : 'hover:bg-gray-100 text-gray-500'
             }`}
           >
             <HiX className="w-5 h-5" />
@@ -123,7 +123,7 @@ const GifPicker: React.FC<GifPickerProps> = ({ initialQuery = '', onSelect, onCl
             placeholder="Search GIFs..."
             className={`w-full pl-9 pr-3 py-2 rounded-lg text-sm transition-colors ${
               isDark
-                ? 'bg-gray-800 text-white placeholder-gray-500 border-gray-600 focus:border-yellow-500'
+                ? 'bg-white/5 text-white placeholder-white/40 border-white/20 focus:border-yellow-500'
                 : 'bg-gray-100 text-gray-900 placeholder-gray-500 border-gray-200 focus:border-yellow-500'
             } border focus:outline-none`}
           />
@@ -131,7 +131,7 @@ const GifPicker: React.FC<GifPickerProps> = ({ initialQuery = '', onSelect, onCl
             <button
               onClick={() => setQuery('')}
               className={`absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full ${
-                isDark ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-200 text-gray-500'
+                isDark ? 'hover:bg-white/10 text-gray-400' : 'hover:bg-gray-200 text-gray-500'
               }`}
             >
               <HiX className="w-3 h-3" />
@@ -148,7 +148,7 @@ const GifPicker: React.FC<GifPickerProps> = ({ initialQuery = '', onSelect, onCl
               <div
                 key={i}
                 className={`aspect-square rounded-lg animate-pulse ${
-                  isDark ? 'bg-gray-800' : 'bg-gray-200'
+                  isDark ? 'bg-white/10' : 'bg-gray-200'
                 }`}
               />
             ))}

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -1530,7 +1530,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
         {/* Mobile Emoji Picker */}
         {showEmojiPicker && (
           <div className={`mt-4 p-4 border rounded-lg ${
-            isDark ? 'border-gray-600 bg-gray-800' : 'border-gray-200 bg-gray-50'
+            isDark ? 'border-white/20 bg-black' : 'border-gray-200 bg-gray-50'
           }`}>
             <div className="grid grid-cols-6 gap-2 max-h-32 overflow-y-auto">
               {['😀', '😂', '🤣', '😊', '😍', '🤔', '😎', '🔥', '💯', '❤️', '👍', '👎'].map(emoji => (
@@ -1540,7 +1540,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                     setText(prev => prev + emoji)
                     setShowEmojiPicker(false)
                   }}
-                  className="p-1 text-xl hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+                  className="p-1 text-xl hover:bg-gray-200 dark:hover:bg-white/10 rounded transition-colors"
                 >
                   {emoji}
                 </button>
@@ -1627,7 +1627,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
         {/* Emoji Picker */}
         {showEmojiPicker && (
           <div className={`mt-4 p-4 border rounded-lg ${
-            isDark ? 'border-gray-600 bg-gray-800' : 'border-gray-200 bg-gray-50'
+            isDark ? 'border-white/20 bg-black' : 'border-gray-200 bg-gray-50'
           }`}>
             <div className="grid grid-cols-8 gap-2 max-h-48 overflow-y-auto">
               {['😀', '😂', '🤣', '😊', '😍', '🤔', '😎', '🔥', '💯', '❤️', '👍', '👎', '👏', '🙏', '💪', '🚀'].map(emoji => (
@@ -1637,7 +1637,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                     setText(prev => prev + emoji)
                     setShowEmojiPicker(false)
                   }}
-                  className="p-2 text-2xl hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+                  className="p-2 text-2xl hover:bg-gray-200 dark:hover:bg-white/10 rounded transition-colors"
                 >
                   {emoji}
                 </button>
@@ -1649,7 +1649,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
         {/* Scheduler */}
         {showScheduler && (
           <div className={`mt-4 p-4 border rounded-lg ${
-            isDark ? 'border-gray-600 bg-gray-800' : 'border-gray-200 bg-gray-50'
+            isDark ? 'border-white/20 bg-black' : 'border-gray-200 bg-gray-50'
           }`}>
             <div className="flex items-center space-x-2 mb-3">
               <HiCalendar className={`w-5 h-5 ${isDark ? 'text-yellow-400' : 'text-yellow-600'}`} />

--- a/client/src/services/FrontEnd/src/components/ProfileChooser.tsx
+++ b/client/src/services/FrontEnd/src/components/ProfileChooser.tsx
@@ -393,13 +393,19 @@ const ProfileChooser: React.FC<{ compact?: boolean }> = ({ compact = false }) =>
 
       {isDropdownOpen && (
         <ul
-          className={`${window.innerWidth < 1350 ? 'fixed' : 'absolute'} mt-2 rounded-md overflow-y-auto z-[9999] transition-all duration-300 max-h-[95vh] ${
+          className={`${compact ? 'absolute left-0 right-0 bottom-full mb-2 w-full max-w-full' : (window.innerWidth < 1350 ? 'fixed mt-2' : 'absolute mt-2')} rounded-md overflow-y-auto z-[9999] transition-all duration-300 max-h-[95vh] ${
+            compact ? '' : 'max-w-[calc(100vw-20px)] w-[min(420px,calc(100vw-20px))]'
+          } ${
             isDark ? 'bg-black border border-white/20' : 'bg-white border border-gray-200'
           }`}
           style={{
-            right: window.innerWidth < 1350 ? 'auto' : '0',
-            left: window.innerWidth < 1350 ? '10px' : 'auto',
-            bottom: window.innerWidth < 1350 ? '15px' : '0',
+            ...(compact
+              ? {}
+              : {
+                  right: window.innerWidth < 1350 ? '10px' : '0',
+                  left: window.innerWidth < 1350 ? '10px' : 'auto',
+                  bottom: window.innerWidth < 1350 ? '15px' : '0',
+                }),
           }}
         >
           {Object.entries(visibleTokensByAddress).map(([ownerAddress, tokenList]) => (
@@ -407,10 +413,10 @@ const ProfileChooser: React.FC<{ compact?: boolean }> = ({ compact = false }) =>
               isDark ? 'border-gray-700' : 'border-gray-200'
             }`}>
               {/* group header */}
-              <div className={`sticky top-0 z-10 px-4 py-2 text-xs font-semibold flex space-between transition-all duration-300 hover-parent ${
+              <div className={`sticky top-0 z-10 px-4 py-2 text-xs font-semibold flex items-center justify-between gap-2 min-w-0 transition-all duration-300 hover-parent ${
                 isDark ? 'bg-gray-900 text-white' : 'bg-gray-100 text-black'
               }`}>
-                <div className="">
+                <div className="flex-1 min-w-0 truncate" title={ownerAddress}>
                   {ownerAddress}
                 </div>
                 {normalizedAddress == ownerAddress ? (

--- a/client/src/services/FrontEnd/src/components/Sidebar.tsx
+++ b/client/src/services/FrontEnd/src/components/Sidebar.tsx
@@ -25,6 +25,8 @@ import {
   HiOutlineColorSwatch,
   HiOutlineUser,
   HiOutlinePencilAlt,
+  HiOutlineSun,
+  HiOutlineMoon,
 } from 'react-icons/hi'
 import cawLogo from '~/assets/images/caw-logo.png'
 import { useInstanceStore } from '~/store/instanceStore'
@@ -333,6 +335,18 @@ const Sidebar: React.FC = () => {
 
       <div className="pl-3 pr-0 mt-2 pb-0 sm:pl-4 sm:pr-0 sm:py-3 sm:mt-0 w-full shrink-0">
         <ProfileChooser compact />
+        {/* Theme toggle — mobile only (desktop has it elsewhere) */}
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+          className={`sm:hidden -ml-1 mt-8 mb-4 mr-3 flex items-center gap-2.5 pl-2 pr-3 py-2 rounded-2xl transition-colors duration-200 ${
+            isDark ? 'text-gray-300 hover:text-white hover:bg-white/10' : 'text-gray-600 hover:text-black hover:bg-gray-200/50'
+          }`}
+        >
+          {isDark ? <HiOutlineSun className="w-6 h-6" /> : <HiOutlineMoon className="w-6 h-6" />}
+          <span className="font-medium text-base">{isDark ? 'Light mode' : 'Dark mode'}</span>
+        </button>
       </div>
     </div>
   )

--- a/client/src/services/FrontEnd/src/components/Sidebar.tsx
+++ b/client/src/services/FrontEnd/src/components/Sidebar.tsx
@@ -143,12 +143,12 @@ const Sidebar: React.FC = () => {
   }
 
   return (
-    <div className={`flex flex-col h-screen sm:h-full sm:justify-between w-full sm:w-[200px] border-r-0.5 sm:border-r transition-all duration-300 ${
+    <div className={`flex flex-col h-screen h-[100dvh] sm:h-full sm:justify-between w-full sm:w-[200px] border-r-0.5 sm:border-r transition-all duration-300 ${
       isDark 
         ? 'bg-black border-white/20' 
         : 'bg-white border-gray-300'
     }`}>
-      <div className="flex flex-col sm:flex-1 sm:min-h-0">
+      <div className="flex flex-col flex-1 min-h-0">
         {/* Logo Section - Hidden on mobile */}
         <div className="hidden sm:block p-4">
           <NavLink
@@ -180,60 +180,60 @@ const Sidebar: React.FC = () => {
         </div>
 
         {/* Navigation */}
-        <nav className="px-2 py-2 pt-20 sm:px-4 sm:py-3 sm:pr-2 sm:pl-2 sm:pt-1 space-y-0.5 sm:flex-1 sm:overflow-y-auto sm:min-h-0 thin-scrollbar">
+        <nav className="px-2 py-2 pt-[calc(72px+env(safe-area-inset-top))] sm:px-4 sm:py-3 sm:pr-2 sm:pl-2 sm:pt-1 space-y-0.5 flex-1 min-h-0 overflow-y-auto overscroll-contain thin-scrollbar">
           <NavLink
           to="/home"
           onClick={guardClick}
           className={({ isActive }) =>
-            `relative flex items-center gap-3 px-4 py-4 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
+            `relative flex items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
           }>
-            <HiOutlineHome className="w-7 h-7 sm:w-7 sm:h-7" />
-            <span className="font-medium text-lg sm:text-lg">Home</span>
+            <HiOutlineHome className="w-6 h-6 sm:w-7 sm:h-7" />
+            <span className="font-medium text-base sm:text-lg">Home</span>
           </NavLink>
 
-          <NavLink
-            to="/explore"
-            className={({ isActive }) =>
-               `relative flex items-center gap-3 px-4 py-4 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
-            }
-          >
-            <HiOutlineSearch className="w-7 h-7 sm:w-7 sm:h-7" />
-            <span className="font-medium text-lg sm:text-lg">Explore</span>
-          </NavLink>
+           <NavLink
+             to="/explore"
+             className={({ isActive }) =>
+               `relative flex items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
+             }
+           >
+            <HiOutlineSearch className="w-6 h-6 sm:w-7 sm:h-7" />
+            <span className="font-medium text-base sm:text-lg">Explore</span>
+           </NavLink>
 
-          <NavLink
-            to="/notifications"
-            onClick={guardClick}
-            className={({ isActive }) =>
-               `relative flex items-center gap-3 px-4 py-4 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
-            }
-          >
-            <div className="relative">
-              <HiOutlineBell className="w-7 h-7 sm:w-7 sm:h-7" />
+           <NavLink
+             to="/notifications"
+             onClick={guardClick}
+             className={({ isActive }) =>
+               `relative flex items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
+             }
+           >
+             <div className="relative">
+              <HiOutlineBell className="w-6 h-6 sm:w-7 sm:h-7" />
               {notifUnreadCount > 0 && (
                 <span className={`absolute -top-2 -right-2 min-w-[18px] h-[18px] flex items-center justify-center text-[11px] font-bold rounded-full bg-yellow-500 text-black px-1 border-2 ${isDark ? 'border-black' : 'border-white'}`}>
                   {notifUnreadCount > 99 ? '99+' : notifUnreadCount}
                 </span>
               )}
-            </div>
-            <span className="font-medium text-lg sm:text-lg">Notifications</span>
-          </NavLink>
+             </div>
+            <span className="font-medium text-base sm:text-lg">Notifications</span>
+           </NavLink>
 
-          <NavLink
-            to="/messages"
-            onClick={(e) => {
-              if (isCaptive) { e.preventDefault(); showSignIn(); return }
-              if (location.pathname.startsWith('/messages')) {
-                e.preventDefault()
-                navigate('/messages')
-              }
-            }}
-            className={({ isActive }) =>
-               `relative flex items-center gap-3 px-4 py-4 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive || location.pathname.startsWith('/messages/'))}`
-            }
-          >
-            <div className="relative">
-              <HiOutlineChat className="w-7 h-7 sm:w-7 sm:h-7" />
+           <NavLink
+             to="/messages"
+             onClick={(e) => {
+               if (isCaptive) { e.preventDefault(); showSignIn(); return }
+               if (location.pathname.startsWith('/messages')) {
+                 e.preventDefault()
+                 navigate('/messages')
+               }
+             }}
+             className={({ isActive }) =>
+               `relative flex items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive || location.pathname.startsWith('/messages/'))}`
+             }
+           >
+             <div className="relative">
+              <HiOutlineChat className="w-6 h-6 sm:w-7 sm:h-7" />
               {activeToken && dmEnabled === false && (
                 <span className={`absolute -top-1 -right-1 w-3 h-3 bg-yellow-500 rounded-full border-2 ${isDark ? 'border-black' : 'border-white'}`} />
               )}
@@ -242,81 +242,81 @@ const Sidebar: React.FC = () => {
                   {dmUnreadCount > 99 ? '99+' : dmUnreadCount}
                 </span>
               )}
-            </div>
-            <span className="font-medium text-lg sm:text-lg">Messages</span>
-          </NavLink>
+             </div>
+            <span className="font-medium text-base sm:text-lg">Messages</span>
+           </NavLink>
 
-          <NavLink
-            to="/bookmarks"
-            onClick={guardClick}
-            className={({ isActive }) =>
-               `relative flex items-center gap-3 px-4 py-4 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
-            }
-          >
-            <HiOutlineBookmark className="w-7 h-7 sm:w-7 sm:h-7" />
-            <span className="font-medium text-lg sm:text-lg">Bookmarks</span>
-          </NavLink>
+           <NavLink
+             to="/bookmarks"
+             onClick={guardClick}
+             className={({ isActive }) =>
+               `relative flex items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
+             }
+           >
+            <HiOutlineBookmark className="w-6 h-6 sm:w-7 sm:h-7" />
+            <span className="font-medium text-base sm:text-lg">Bookmarks</span>
+           </NavLink>
 
-          <NavLink
-            to="/scheduled"
-            onClick={guardClick}
-            className={({ isActive }) =>
-               `relative flex items-center gap-3 px-4 py-4 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
-            }
-          >
-            <HiOutlineClock className="w-7 h-7 sm:w-7 sm:h-7" />
-            <span className="font-medium text-lg sm:text-lg">Scheduled</span>
-          </NavLink>
+           <NavLink
+             to="/scheduled"
+             onClick={guardClick}
+             className={({ isActive }) =>
+               `relative flex items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
+             }
+           >
+            <HiOutlineClock className="w-6 h-6 sm:w-7 sm:h-7" />
+            <span className="font-medium text-base sm:text-lg">Scheduled</span>
+           </NavLink>
 
-          <NavLink
-            to="/staking"
-            onClick={guardClick}
-            className={({ isActive }) =>
-               `relative flex items-center gap-3 px-4 py-4 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
-            }
-          >
-            <HiOutlineCube className="w-7 h-7 sm:w-7 sm:h-7" />
-            <span className="font-medium text-lg sm:text-lg">Staking</span>
-          </NavLink>
+           <NavLink
+             to="/staking"
+             onClick={guardClick}
+             className={({ isActive }) =>
+               `relative flex items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
+             }
+           >
+            <HiOutlineCube className="w-6 h-6 sm:w-7 sm:h-7" />
+            <span className="font-medium text-base sm:text-lg">Staking</span>
+           </NavLink>
 
-          <NavLink
-            to="/usernames"
-            className={({ isActive }) =>
-               `relative flex items-center gap-3 px-4 py-4 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
-            }
-          >
-            <div className="relative">
-              <HiOutlineColorSwatch className="w-7 h-7 sm:w-7 sm:h-7" />
+           <NavLink
+             to="/usernames"
+             className={({ isActive }) =>
+               `relative flex items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
+             }
+           >
+             <div className="relative">
+              <HiOutlineColorSwatch className="w-6 h-6 sm:w-7 sm:h-7" />
               {offersUnreadCount > 0 && (
                 <span className={`absolute -top-2 -right-2 min-w-[18px] h-[18px] flex items-center justify-center text-[11px] font-bold rounded-full bg-yellow-500 text-black px-1 border-2 ${isDark ? 'border-black' : 'border-white'}`}>
                   {offersUnreadCount > 99 ? '99+' : offersUnreadCount}
                 </span>
               )}
-            </div>
-            <span className="font-medium text-lg sm:text-lg">Usernames</span>
-          </NavLink>
+             </div>
+            <span className="font-medium text-base sm:text-lg">Usernames</span>
+           </NavLink>
 
-          <NavLink
-            to={activeToken?.username ? `/users/${activeToken.username}` : "/welcome"}
-            onClick={guardClick}
-            className={({ isActive }) =>
-               `relative flex items-center gap-3 px-4 py-4 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
-            }
-          >
-            <HiOutlineUser className="w-7 h-7 sm:w-7 sm:h-7" />
-            <span className="font-medium text-lg sm:text-lg">Profile</span>
-          </NavLink>
+           <NavLink
+             to={activeToken?.username ? `/users/${activeToken.username}` : "/welcome"}
+             onClick={guardClick}
+             className={({ isActive }) =>
+               `relative flex items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
+             }
+           >
+            <HiOutlineUser className="w-6 h-6 sm:w-7 sm:h-7" />
+            <span className="font-medium text-base sm:text-lg">Profile</span>
+           </NavLink>
 
-          <NavLink
-            to="/settings"
-            onClick={guardClick}
-            className={({ isActive }) =>
-               `relative flex items-center gap-3 px-4 py-4 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
-            }
-          >
-            <HiOutlineCog className="w-7 h-7 sm:w-7 sm:h-7" />
-            <span className="font-medium text-lg sm:text-lg">Settings</span>
-          </NavLink>
+           <NavLink
+             to="/settings"
+             onClick={guardClick}
+             className={({ isActive }) =>
+               `relative flex items-center gap-3 px-4 py-3.5 sm:gap-4 sm:px-5 sm:py-3.5 rounded-2xl transition-colors duration-200 ${getNavLinkClasses(isActive)}`
+             }
+           >
+            <HiOutlineCog className="w-6 h-6 sm:w-7 sm:h-7" />
+            <span className="font-medium text-base sm:text-lg">Settings</span>
+           </NavLink>
         </nav>
 
         {!isCaptive && (
@@ -333,7 +333,7 @@ const Sidebar: React.FC = () => {
         )}
       </div>
 
-      <div className="pl-3 pr-0 mt-2 pb-0 sm:pl-4 sm:pr-0 sm:py-3 sm:mt-0 w-full shrink-0">
+      <div className="pl-3 pr-0 mt-2 pb-[env(safe-area-inset-bottom)] sm:pl-4 sm:pr-0 sm:py-3 sm:mt-0 w-full shrink-0">
         <ProfileChooser compact />
         {/* Theme toggle — mobile only (desktop has it elsewhere) */}
         <button

--- a/client/src/services/FrontEnd/src/components/forms/ThemedListbox.tsx
+++ b/client/src/services/FrontEnd/src/components/forms/ThemedListbox.tsx
@@ -1,0 +1,81 @@
+import React, { Fragment, useMemo } from 'react'
+import { Listbox, Transition } from '@headlessui/react'
+import { themeBorder, themeInput, themeTextMuted } from '~/utils/theme'
+
+export type ThemedListboxOption<T extends string | number> = {
+  value: T
+  label: string
+}
+
+type Props<T extends string | number> = {
+  isDark: boolean
+  value: T
+  onChange: (value: T) => void
+  options: ThemedListboxOption<T>[]
+  disabled?: boolean
+  className?: string
+}
+
+export default function ThemedListbox<T extends string | number>({
+  isDark,
+  value,
+  onChange,
+  options,
+  disabled = false,
+  className = '',
+}: Props<T>) {
+  const selected = useMemo(() => options.find(o => o.value === value), [options, value])
+
+  const buttonClass = `w-full px-3 py-2 rounded-lg text-sm border outline-none transition cursor-pointer flex items-center justify-between ${themeInput(isDark)} ${themeBorder(isDark)}`
+  const panelClass = `absolute mt-1 w-full rounded-xl border shadow-lg z-[60] overflow-hidden ${
+    isDark ? 'bg-neutral-900' : 'bg-white'
+  } ${themeBorder(isDark)}`
+
+  return (
+    <Listbox value={value} onChange={onChange} disabled={disabled}>
+      <div className={`relative ${className}`}>
+        <Listbox.Button className={buttonClass}>
+          <span className="truncate">{selected?.label ?? 'Select'}</span>
+          <svg className={`h-4 w-4 flex-shrink-0 ${themeTextMuted(isDark)}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </Listbox.Button>
+
+        <Transition as={Fragment} leave="transition ease-in duration-100" leaveFrom="opacity-100" leaveTo="opacity-0">
+          <Listbox.Options className={panelClass}>
+            <div className="max-h-60 overflow-auto p-1">
+              {options.map(opt => (
+                <Listbox.Option key={String(opt.value)} value={opt.value}>
+                  {({ active, selected }) => (
+                    <div
+                      className={`px-3 py-2 rounded-lg text-sm cursor-pointer select-none flex items-center justify-between gap-2 ${
+                        selected
+                          ? isDark
+                            ? 'bg-yellow-500/20 text-yellow-200'
+                            : 'bg-yellow-100 text-yellow-800'
+                          : ''
+                      } ${
+                        active && !selected
+                          ? isDark
+                            ? 'bg-white/10 text-white'
+                            : 'bg-gray-100 text-gray-900'
+                          : ''
+                      } ${!active && !selected ? (isDark ? 'text-white' : 'text-gray-900') : ''}`}
+                    >
+                      <span className="truncate">{opt.label}</span>
+                      {selected && (
+                        <svg className={`h-4 w-4 flex-shrink-0 ${isDark ? 'text-yellow-300' : 'text-yellow-700'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        </svg>
+                      )}
+                    </div>
+                  )}
+                </Listbox.Option>
+              ))}
+            </div>
+          </Listbox.Options>
+        </Transition>
+      </div>
+    </Listbox>
+  )
+}

--- a/client/src/services/FrontEnd/src/components/marketplace/ListingFilters.tsx
+++ b/client/src/services/FrontEnd/src/components/marketplace/ListingFilters.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useTheme } from '~/hooks/useTheme'
 import { themeTextSecondary, themeBgSubtle, themeBorder, themeInput } from '~/utils/theme'
 import { useMarketplaceStore, ListingType, PaymentToken, SortOption } from '~/store/marketplaceStore'
+import ThemedListbox from '~/components/forms/ThemedListbox'
 
 const LISTING_TYPES: { value: ListingType; label: string }[] = [
   { value: 'all', label: 'All Types' },
@@ -37,24 +38,22 @@ const ListingFilters: React.FC = () => {
     <div className={`grid grid-cols-1 sm:grid-cols-2 gap-3 p-4 rounded-xl ${themeBgSubtle(isDark)} ${themeBorder(isDark)} border`}>
       <div className="flex flex-col gap-1">
         <label className={`text-xs font-medium ${themeTextSecondary(isDark)}`}>Type</label>
-        <select
+        <ThemedListbox
+          isDark={isDark}
           value={filters.listingType}
-          onChange={e => setFilter('listingType', e.target.value as ListingType)}
-          className={selectClass}
-        >
-          {LISTING_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
-        </select>
+          onChange={(v: ListingType) => setFilter('listingType', v)}
+          options={LISTING_TYPES}
+        />
       </div>
 
       <div className="flex flex-col gap-1">
         <label className={`text-xs font-medium ${themeTextSecondary(isDark)}`}>Payment</label>
-        <select
+        <ThemedListbox
+          isDark={isDark}
           value={filters.paymentToken}
-          onChange={e => setFilter('paymentToken', e.target.value as PaymentToken)}
-          className={selectClass}
-        >
-          {PAYMENT_TOKENS.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
-        </select>
+          onChange={(v: PaymentToken) => setFilter('paymentToken', v)}
+          options={PAYMENT_TOKENS}
+        />
       </div>
 
       <div className="flex flex-col gap-1">
@@ -84,13 +83,12 @@ const ListingFilters: React.FC = () => {
 
       <div className="flex flex-col gap-1">
         <label className={`text-xs font-medium ${themeTextSecondary(isDark)}`}>Sort</label>
-        <select
+        <ThemedListbox
+          isDark={isDark}
           value={filters.sort}
-          onChange={e => setFilter('sort', e.target.value as SortOption)}
-          className={selectClass}
-        >
-          {SORT_OPTIONS.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
-        </select>
+          onChange={(v: SortOption) => setFilter('sort', v)}
+          options={SORT_OPTIONS}
+        />
       </div>
     </div>
   )

--- a/client/src/services/FrontEnd/src/components/modals/ComposePostModal.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/ComposePostModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PostForm from '~/components/PostForm'
 import ModalWrapper from './ModalWrapper'
+import { useTheme } from '~/hooks/useTheme'
 
 interface ComposePostModalProps {
   isOpen: boolean
@@ -8,8 +9,12 @@ interface ComposePostModalProps {
 }
 
 const ComposePostModal: React.FC<ComposePostModalProps> = ({ isOpen, onClose }) => {
+  const { isDark } = useTheme()
+  // Mobile: stronger backdrop so the page underneath fully recedes.
+  // Desktop: keep the existing theme defaults.
+  const backdropClass = `bg-black/85 ${isDark ? 'md:bg-black/70' : 'md:bg-black/40'}`
   return (
-    <ModalWrapper isOpen={isOpen} onClose={onClose} maxWidth="max-w-xl" className="overflow-hidden md:-translate-x-[2.75rem]">
+    <ModalWrapper isOpen={isOpen} onClose={onClose} maxWidth="max-w-xl" className="overflow-hidden md:-translate-x-[2.75rem]" backdropClass={backdropClass}>
       <PostForm onSuccess={onClose} placeholder="Write something.." />
     </ModalWrapper>
   )

--- a/client/src/services/FrontEnd/src/components/modals/CreateListingModal.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/CreateListingModal.tsx
@@ -7,6 +7,7 @@ import ModalHeader from './ModalHeader'
 import { useTheme } from '~/hooks/useTheme'
 import { useEnsureWallet } from '~/hooks/useEnsureWallet'
 import { themeTextSecondary, themeTextMuted, themeBgSubtle, themeSecondaryButton, themeInput, themeBorder } from '~/utils/theme'
+import ThemedListbox from '~/components/forms/ThemedListbox'
 import { useMarketplaceStore } from '~/store/marketplaceStore'
 import { usePriceStore, useTokenDataStore } from '~/store/tokenDataStore'
 import { chains } from '~/config/chains'
@@ -342,20 +343,12 @@ const CreateListingModal: React.FC = () => {
           <div className="space-y-4 mb-4">
             <div>
               <label className={`block text-sm font-medium mb-1 ${themeTextSecondary(isDark)}`}>Payment Token</label>
-              <div className="relative">
-                <select
-                  value={paymentToken}
-                  onChange={e => handleCurrencyChange(e.target.value)}
-                  className={`${inputClass} appearance-none pr-8`}
-                >
-                  {PAYMENT_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </select>
-                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
-                  <svg className={`h-4 w-4 ${isDark ? 'text-gray-400' : 'text-gray-500'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                  </svg>
-                </div>
-              </div>
+              <ThemedListbox
+                isDark={isDark}
+                value={paymentToken}
+                onChange={(v: string) => handleCurrencyChange(v)}
+                options={PAYMENT_OPTIONS}
+              />
             </div>
 
             <div>

--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -8,8 +8,9 @@ import BugIcon from "~/components/icons/BugIcon";
 import { useTheme } from "~/hooks/useTheme";
 import Tooltip from "~/components/Tooltip";
 import { useState, lazy, Suspense } from "react";
-import { HiOutlineMenu, HiOutlineX } from "react-icons/hi";
+import { HiOutlineMenu, HiOutlineX, HiOutlinePencilAlt } from "react-icons/hi";
 import { Link, useLocation } from "react-router-dom";
+import { useModalStore } from "~/store";
 import { useActiveToken } from "~/store/tokenDataStore";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { useAccount } from "wagmi";
@@ -31,6 +32,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
   const activeToken = useActiveToken()
   const { isConnected } = useAccount()
   const { openConnectModal } = useConnectModal()
+  const openModal = useModalStore(s => s.openModal)
 
   // Captive mode: no username and on a public page like /help/*
   const isCaptive = !activeToken?.username
@@ -76,7 +78,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
       {/* Mobile Sidebar Overlay */}
       {!hideSidebars && (
         <div
-          className={`md:hidden fixed inset-0 z-40 transition-all duration-300 ${
+          className={`md:hidden fixed inset-0 z-[70] transition-all duration-300 ${
             isMobileMenuOpen ? 'bg-black/50 opacity-100' : 'bg-black/0 opacity-0 pointer-events-none'
           }`}
           onClick={() => setIsMobileMenuOpen(false)}
@@ -191,6 +193,22 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
             )}
           </div>
         </div>
+      )}
+
+      {/* Mobile compose FAB */}
+      {!hideSidebars && !isCaptive && !(
+        location.pathname.startsWith('/messages') ||
+        location.pathname.startsWith('/usernames') ||
+        location.pathname.startsWith('/staking') ||
+        location.pathname.startsWith('/settings')
+      ) && (
+        <button
+          onClick={() => openModal('post')}
+          aria-label="Post"
+          className="md:hidden fixed right-10 bottom-12 z-[60] w-16 h-16 rounded-full bg-yellow-500 hover:bg-yellow-400 active:bg-yellow-600 text-black flex items-center justify-center shadow-lg shadow-black/30 transition-all cursor-pointer"
+        >
+          <HiOutlinePencilAlt className="w-8 h-8" />
+        </button>
       )}
 
       {/* Floating feedback button */}

--- a/client/src/services/FrontEnd/src/pages/Messages.tsx
+++ b/client/src/services/FrontEnd/src/pages/Messages.tsx
@@ -75,6 +75,7 @@ const MessagesPage: React.FC = () => {
   const [showSearchModal, setShowSearchModal] = useState(false)
   const [showFileUpload, setShowFileUpload] = useState(false)
   const [showGifPicker, setShowGifPicker] = useState(false)
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [gifPreview, setGifPreview] = useState<{ url: string; preview: string } | null>(null)
   const [isDragOver, setIsDragOver] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
@@ -385,6 +386,7 @@ const MessagesPage: React.FC = () => {
 
     const content = newMessageContent.trim()
     setNewMessageContent('')
+    setShowEmojiPicker(false)
 
     // Stop typing indicator
     if (typingTimeoutRef.current) {
@@ -486,6 +488,22 @@ const MessagesPage: React.FC = () => {
       setIsTyping(false)
       sendTyping(selectedConversationId, false)
     }, 2000)
+  }
+
+  const emojiOnlyTextClass = (text: string): string => {
+    const t = (text ?? '').trim()
+    if (!t) return 'text-sm'
+
+    // Emoji-only messages should render larger (WhatsApp/Twitter style)
+    const emojiOnly = /^(?:\p{Extended_Pictographic}|\p{Emoji_Component}|\u200D|\uFE0F|\s)+$/u.test(t)
+    if (!emojiOnly) return 'text-sm'
+
+    const emojiCount = (t.match(/\p{Extended_Pictographic}/gu) ?? []).length
+    if (emojiCount <= 0) return 'text-sm'
+    if (emojiCount === 1) return 'text-5xl leading-none'
+    if (emojiCount === 2) return 'text-4xl leading-none'
+    if (emojiCount <= 4) return 'text-3xl leading-none'
+    return 'text-xl leading-tight'
   }
 
   // Redirect legacy ?user= param to /messages/:username
@@ -1410,7 +1428,7 @@ const MessagesPage: React.FC = () => {
                                 />
                               )
                             }
-                            return <p className="text-sm whitespace-pre-wrap">{messageContent}</p>
+                            return <p className={`${emojiOnlyTextClass(messageContent)} whitespace-pre-wrap`}>{messageContent}</p>
                           })()}
 
                           {/* Edited indicator */}
@@ -1654,6 +1672,30 @@ const MessagesPage: React.FC = () => {
                 </div>
               )}
 
+              {/* Emoji Picker */}
+              {showEmojiPicker && !gifPreview && !filePreview && (
+                <div className={`border-t p-3 ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
+                  <div className={`p-4 border rounded-lg ${
+                    isDark ? 'border-white/20 bg-black' : 'border-gray-200 bg-gray-50'
+                  }`}>
+                    <div className="grid grid-cols-6 gap-2 max-h-32 overflow-y-auto">
+                      {['😀', '😂', '🤣', '😊', '😍', '🤔', '😎', '🔥', '💯', '❤️', '👍', '👎'].map((emoji) => (
+                        <button
+                          key={emoji}
+                          onClick={() => {
+                            setNewMessageContent((prev) => prev + emoji)
+                            setShowEmojiPicker(false)
+                          }}
+                          className={`p-1 text-xl rounded transition-colors ${isDark ? 'hover:bg-white/10' : 'hover:bg-gray-200'}`}
+                        >
+                          {emoji}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+
               {/* Message Input */}
               <div className="border-t border-white/10 p-2 md:p-4">
               <div className={`flex items-center rounded-full border transition-all duration-300 focus-within:ring-2 focus-within:ring-gray-500/30 ${
@@ -1687,7 +1729,10 @@ const MessagesPage: React.FC = () => {
 
                   {/* GIF picker */}
                   <button
-                    onClick={() => setShowGifPicker(!showGifPicker)}
+                    onClick={() => {
+                      setShowEmojiPicker(false)
+                      setShowGifPicker(!showGifPicker)
+                    }}
                     className={`px-2 py-1 rounded-full text-sm font-medium transition-all duration-200 cursor-pointer ${
                       showGifPicker
                         ? isDark
@@ -1701,11 +1746,19 @@ const MessagesPage: React.FC = () => {
                   </button>
 
                   {/* Emoji icon */}
-                  <button className={`p-1 rounded-full transition-all duration-200 cursor-pointer ${
-                    isDark
-                      ? 'text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-400/10'
-                      : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50'
-                  }`}>
+                  <button
+                    onClick={() => {
+                      setShowGifPicker(false)
+                      setShowEmojiPicker(!showEmojiPicker)
+                    }}
+                    className={`p-1 rounded-full transition-all duration-200 cursor-pointer ${
+                      showEmojiPicker
+                        ? (isDark ? 'text-yellow-400 bg-yellow-400/20' : 'text-yellow-600 bg-yellow-200')
+                        : (isDark
+                          ? 'text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-400/10'
+                          : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50')
+                    }`}
+                  >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>

--- a/client/src/services/FrontEnd/src/pages/Messages.tsx
+++ b/client/src/services/FrontEnd/src/pages/Messages.tsx
@@ -1175,7 +1175,7 @@ const MessagesPage: React.FC = () => {
         {currentView === 'chat' && selectedConversationId && (
           <div className="flex flex-col flex-1 md:flex-1 h-screen md:h-auto">
             {/* Encryption Status Banner */}
-            <div className={`flex items-center justify-center py-4 px-6 -mx-3 sm:-mx-6 ${
+            <div className={`flex items-center justify-center py-4 px-6 mx-3 sm:mx-6 ${
               isDark ? 'bg-green-900/20 border-b border-green-800/30' : 'bg-green-50 border-b border-green-200'
             }`}>
               <div className="flex items-center space-x-2">

--- a/client/src/services/FrontEnd/src/pages/MutedContent.tsx
+++ b/client/src/services/FrontEnd/src/pages/MutedContent.tsx
@@ -133,6 +133,7 @@ const MutedContentPage: React.FC = () => {
           }
         }))
       } catch (err) {
+        console.error('Failed to fetch user data:', err)
         setUserData(prev => ({
           ...prev,
           [tokenId]: { tokenId: Number(tokenId), username: '', loading: false, error: true }
@@ -175,6 +176,7 @@ const MutedContentPage: React.FC = () => {
           }
         }))
       } catch (err) {
+        console.error('Failed to fetch post data:', err)
         setPostData(prev => ({
           ...prev,
           [postId]: { id: postId, username: '', content: '', timestamp: '', loading: false, error: true }
@@ -480,39 +482,105 @@ const MutedContentPage: React.FC = () => {
                                   // Off-chain images stored as URLs (including Giphy)
                                   const urls = post.imageData.replace('urls:', '').split('|||')
                                   return (
-                                    <div className={`grid ${urls.length > 1 ? 'grid-cols-2 gap-2' : 'grid-cols-1'} max-w-md`}>
-                                      {urls.map((url, index) => (
-                                        <div key={index} className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
-                                          <img
-                                            src={url}
-                                            alt={`Post image ${index + 1}`}
-                                            className="w-full h-auto"
-                                            onError={(e) => {
-                                              e.currentTarget.style.display = 'none'
-                                            }}
-                                          />
+                                    (() => {
+                                      const count = urls.length
+                                      if (count <= 0) return null
+
+                                      if (count === 1) {
+                                        const url = urls[0]
+                                        return (
+                                          <div className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 w-full max-w-md">
+                                            <img
+                                              src={url}
+                                              alt="Post image"
+                                              className="block w-full h-auto"
+                                              onError={(e) => {
+                                                e.currentTarget.style.display = 'none'
+                                              }}
+                                            />
+                                          </div>
+                                        )
+                                      }
+
+                                      const gridClass =
+                                        count === 2
+                                            ? 'grid grid-cols-2 gap-2 aspect-video rounded-lg overflow-hidden max-w-md'
+                                            : count === 3
+                                              ? 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden max-w-md'
+                                              : 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden max-w-md'
+
+                                      const cellClass = (i: number) =>
+                                        count === 3 && i === 0 ? 'row-span-2 w-full h-full' : 'w-full h-full'
+
+                                      return (
+                                        <div className={gridClass}>
+                                          {urls.slice(0, 4).map((url, index) => (
+                                            <div key={index} className={`relative w-full h-full overflow-hidden border border-gray-200 dark:border-gray-700 ${cellClass(index)}`}>
+                                              <img
+                                                src={url}
+                                                alt={`Post image ${index + 1}`}
+                                                className="block w-full h-full object-cover"
+                                                onError={(e) => {
+                                                  e.currentTarget.style.display = 'none'
+                                                }}
+                                              />
+                                            </div>
+                                          ))}
                                         </div>
-                                      ))}
-                                    </div>
+                                      )
+                                    })()
                                   )
                                 } else {
                                   // On-chain images stored as base64
                                   const images = post.imageData.split('|||')
                                   return (
-                                    <div className={`grid ${images.length > 1 ? 'grid-cols-2 gap-2' : 'grid-cols-1'} max-w-md`}>
-                                      {images.map((imageBase64, index) => (
-                                        <div key={index} className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
-                                          <img
-                                            src={`data:image/jpeg;base64,${imageBase64}`}
-                                            alt={`Post image ${index + 1}`}
-                                            className="w-full h-auto"
-                                            onError={(e) => {
-                                              e.currentTarget.style.display = 'none'
-                                            }}
-                                          />
+                                    (() => {
+                                      const count = images.length
+                                      if (count <= 0) return null
+
+                                      if (count === 1) {
+                                        const imageBase64 = images[0]
+                                        return (
+                                          <div className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 w-full max-w-md">
+                                            <img
+                                              src={`data:image/jpeg;base64,${imageBase64}`}
+                                              alt="Post image"
+                                              className="block w-full h-auto"
+                                              onError={(e) => {
+                                                e.currentTarget.style.display = 'none'
+                                              }}
+                                            />
+                                          </div>
+                                        )
+                                      }
+
+                                      const gridClass =
+                                        count === 2
+                                            ? 'grid grid-cols-2 gap-2 aspect-video rounded-lg overflow-hidden max-w-md'
+                                            : count === 3
+                                              ? 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden max-w-md'
+                                              : 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden max-w-md'
+
+                                      const cellClass = (i: number) =>
+                                        count === 3 && i === 0 ? 'row-span-2 w-full h-full' : 'w-full h-full'
+
+                                      return (
+                                        <div className={gridClass}>
+                                          {images.slice(0, 4).map((imageBase64, index) => (
+                                            <div key={index} className={`relative w-full h-full overflow-hidden border border-gray-200 dark:border-gray-700 ${cellClass(index)}`}>
+                                              <img
+                                                src={`data:image/jpeg;base64,${imageBase64}`}
+                                                alt={`Post image ${index + 1}`}
+                                                className="block w-full h-full object-cover"
+                                                onError={(e) => {
+                                                  e.currentTarget.style.display = 'none'
+                                                }}
+                                              />
+                                            </div>
+                                          ))}
                                         </div>
-                                      ))}
-                                    </div>
+                                      )
+                                    })()
                                   )
                                 }
                               } else if (post.imageUrl) {
@@ -522,7 +590,7 @@ const MutedContentPage: React.FC = () => {
                                     <img
                                       src={post.imageUrl}
                                       alt="Post image"
-                                      className="w-full h-auto"
+                                      className="block w-full h-auto"
                                       onError={(e) => {
                                         e.currentTarget.style.display = 'none'
                                       }}

--- a/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
+++ b/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
@@ -1177,7 +1177,7 @@ export const Profile: React.FC = () => {
                             onClick={() => setShowOwnProfileMenu(false)}
                           />
                           <div className={`absolute right-0 top-full mt-2 w-48 rounded-lg shadow-lg z-50 overflow-hidden ${
-                            isDark ? 'bg-gray-900 border border-white/20' : 'bg-white border border-gray-200'
+                            isDark ? 'bg-black border border-white/20' : 'bg-white border border-gray-200'
                           }`}>
                             <button
                               onClick={() => {


### PR DESCRIPTION
- Fix truncated post translations by joining all segments returned by Google Translate.
- Show translation status and “Show original” in the post header (same spot as the Translate button).
- Improve 2/3/4-image mosaic rendering in Feed and MutedContent.
- Stabilize mobile sidebar scrolling (100dvh + safe-area) and prevent account dropdown overflow in compact mode.
- Make “Recawed by ...” slightly more prominent.
- Add an emoji picker to DMs matching PostForm styling (dark/light) and render emoji-only messages larger.