### PR TITLE
Frontend UX polish: scheduled media, modals, notifications, and DM 

### DIFF
--- a/client/src/services/FrontEnd/src/App.tsx
+++ b/client/src/services/FrontEnd/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from "react-router";
+import { BrowserRouter, Route, Routes, useLocation } from "react-router";
 import { useCawonceSync } from '~/hooks/useCawonce'
 import { useSessionKeyWalletGuard } from '~/hooks/useSessionKey'
 import { useTxQueueMonitor } from '~/hooks/useTxQueueMonitor'
@@ -26,7 +26,31 @@ import { useBlockedUsersStore } from '~/store/blockedUsersStore'
 import { useTokenDataStore } from '~/store/tokenDataStore'
 import { useActionErrorStore } from '~/store/actionErrorStore'
 import ModalWrapper from '~/components/modals/ModalWrapper'
+import CawMediaModal from '~/components/modals/CawMediaModal'
 import { useEffect } from 'react'
+
+function AppRoutes() {
+  const location = useLocation() as any
+  const state = (location.state as { backgroundLocation?: any } | null) ?? null
+  const backgroundLocation = state?.backgroundLocation
+
+  return (
+    <>
+      <Routes location={backgroundLocation || location}>
+        {routes.map((route) => (
+          <Route key={route.path} path={route.path} element={route.component} />
+        ))}
+      </Routes>
+
+      {/* Modal routes (rendered on top of backgroundLocation) */}
+      {backgroundLocation && (
+        <Routes>
+          <Route path="/caws/:id" element={<CawMediaModal />} />
+        </Routes>
+      )}
+    </>
+  )
+}
 
 function App() {
   useCawonceSync();
@@ -55,11 +79,7 @@ function App() {
 
   return (
     <BrowserRouter>
-      <Routes>
-        {routes.map((route) => (
-          <Route key={route.path} path={route.path} element={route.component} />
-        ))}
-      </Routes>
+      <AppRoutes />
 
       <InsufficientStakeModal
         isOpen={stakeModal.isOpen}

--- a/client/src/services/FrontEnd/src/components/ContentWithHashtags.tsx
+++ b/client/src/services/FrontEnd/src/components/ContentWithHashtags.tsx
@@ -1,6 +1,6 @@
 // src/components/ContentWithHashtags.tsx
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import LinkPreview from './LinkPreview'
 import Tooltip from '~/components/Tooltip'
 import ImageLightbox from './ImageLightbox'
@@ -44,7 +44,15 @@ const ShortUrlImage: React.FC<{
   originHost?: string
   onError: (url: string) => void
   imageErrors: Set<string>
-}> = ({ code, originHost, onError, imageErrors }) => {
+  /** Optional wrapper class override (defaults keep legacy layout). */
+  wrapperClassName?: string
+  /** Optional img class override (defaults keep legacy layout). */
+  imgClassName?: string
+  /** Optional skeleton class override (defaults keep legacy layout). */
+  skeletonClassName?: string
+  /** When provided, click is forwarded instead of opening internal lightbox. */
+  onImageClick?: (originalUrl: string, e: React.MouseEvent) => void
+}> = ({ code, originHost, onError, imageErrors, wrapperClassName, imgClassName, skeletonClassName, onImageClick }) => {
   const { url: originalUrl, loading } = useCachedFetch(
     cacheKey(originHost, code),
     shortUrlCache,
@@ -54,7 +62,11 @@ const ShortUrlImage: React.FC<{
 
   const [lightboxOpen, setLightboxOpen] = useState(false)
 
-  if (loading) return <MediaSkeleton />
+  if (loading) {
+    return skeletonClassName
+      ? <div className={skeletonClassName} />
+      : <MediaSkeleton />
+  }
   if (!originalUrl || imageErrors.has(originalUrl)) return null
 
   // feedImageLargeUrl returns undefined for URLs outside /uploads/images/,
@@ -62,27 +74,36 @@ const ShortUrlImage: React.FC<{
   // safe to pass through unconditionally.
   const largeSrc = feedImageLargeUrl(originalUrl)
 
+  const wrapper = wrapperClassName ?? 'my-2 max-w-full'
+  const imgClass = imgClassName ?? 'max-w-full max-h-96 rounded-lg object-contain cursor-zoom-in'
+
   return (
     <>
-      <div className="my-2 max-w-full">
+      <div className={wrapper}>
         <img
           src={originalUrl}
           alt="Embedded content"
-          className="max-w-full max-h-96 rounded-lg object-contain cursor-zoom-in"
+          className={imgClass}
           loading="lazy"
           onError={() => onError(originalUrl)}
           onClick={(e) => {
             e.stopPropagation()
-            setLightboxOpen(true)
+            if (onImageClick) {
+              onImageClick(originalUrl, e)
+            } else {
+              setLightboxOpen(true)
+            }
           }}
         />
       </div>
-      <ImageLightbox
-        src={originalUrl}
-        largeSrc={largeSrc}
-        isOpen={lightboxOpen}
-        onClose={() => setLightboxOpen(false)}
-      />
+      {!onImageClick && (
+        <ImageLightbox
+          src={originalUrl}
+          largeSrc={largeSrc}
+          isOpen={lightboxOpen}
+          onClose={() => setLightboxOpen(false)}
+        />
+      )}
     </>
   )
 }
@@ -155,6 +176,12 @@ const ShortUrlVideo: React.FC<{
 interface Props {
   content: string
   className?: string
+  /** When provided, clicking an image navigates to the post media modal route. */
+  postId?: string
+  /** When false, do not extract/render embedded media (images/videos) from content. */
+  renderMedia?: boolean
+  /** When true, remove media URLs from the text output (prevents raw image links showing). */
+  stripMediaUrls?: boolean
 }
 
 // Regex to match Giphy URLs
@@ -170,8 +197,9 @@ const SHORT_URL_REGEX = /^(?:https?:\/\/[^\/]+)?\/s\/([a-zA-Z0-9]+(?:\.[a-zA-Z0-
 /**
  * Component that renders text content with clickable hashtags and embedded images/GIFs
  */
-const ContentWithHashtags: React.FC<Props> = ({ content, className = '' }) => {
+const ContentWithHashtags: React.FC<Props> = ({ content, className = '', postId, renderMedia = true, stripMediaUrls = true }) => {
   const navigate = useNavigate()
+  const location = useLocation()
   const { isDark } = useTheme()
   const linkClass = isDark
     ? 'text-yellow-400 hover:text-yellow-300'
@@ -180,6 +208,13 @@ const ContentWithHashtags: React.FC<Props> = ({ content, className = '' }) => {
   // One lightbox slot for the whole post — clicking any inline image
   // sets it; the modal closes on Esc / backdrop / swipe down.
   const [lightbox, setLightbox] = useState<{ src: string; largeSrc?: string } | null>(null)
+
+  const openPostMedia = (mediaIndex: number) => {
+    if (!postId) return
+    navigate(`/caws/${postId}?media=${mediaIndex}&source=content`, {
+      state: { backgroundLocation: location }
+    })
+  }
 
   const handleHashtagClick = (hashtag: string, event: React.MouseEvent) => {
     event.preventDefault()
@@ -232,7 +267,7 @@ const ContentWithHashtags: React.FC<Props> = ({ content, className = '' }) => {
     return /\.(gif|jpg|jpeg|png|webp)$/i.test(code)
   }
 
-  const parseTextWithHashtags = (text: string, keyPrefix: string) => {
+  const parseTextWithHashtags = (text: string, keyPrefix: string, renderMedia: boolean) => {
     // Matches hashtags, cashtags, @mentions, AND short URLs (so we can render
     // short URLs as clickable links pointing to the original URL).
     // - Short URLs: /s/code or https://host/s/code (with optional extension).
@@ -265,8 +300,22 @@ const ContentWithHashtags: React.FC<Props> = ({ content, className = '' }) => {
       if (shortUrlMatch) {
         const shortHref = shortUrlMatch[1]
         const code = shortUrlMatch[2]
-        // Skip media short URLs — they're handled by parseContent as images/videos
-        if (isMediaShortUrl(code) || isVideoShortUrl(code)) return part
+        // Media short URLs are normally handled by parseContent as images/videos.
+        // But when media rendering is disabled (e.g. inside the media modal post panel),
+        // render them as a regular short link instead.
+        if (isMediaShortUrl(code) || isVideoShortUrl(code)) {
+          if (!renderMedia) {
+            return (
+              <ShortUrlLink
+                key={`${keyPrefix}-${index}`}
+                code={code}
+                shortHref={shortHref}
+                originHost={extractShortUrlHost(shortHref)}
+              />
+            )
+          }
+          return part
+        }
         return (
           <ShortUrlLink key={`${keyPrefix}-${index}`} code={code} shortHref={shortHref} originHost={extractShortUrlHost(shortHref)} />
         )
@@ -329,9 +378,9 @@ const ContentWithHashtags: React.FC<Props> = ({ content, className = '' }) => {
     })
   }
 
-  const parseContent = (text: string) => {
-    // Extract all media in a single pass to preserve order
-    // Each match includes its position so we can sort by original order
+  const parseContent = (text: string, renderMedia: boolean, stripMediaUrls: boolean) => {
+    // Extract all media in a single pass to preserve order.
+    // Each match includes its position so we can sort by original order.
     const mediaMatches: { type: 'image' | 'shortImage' | 'shortVideo'; data: string; code?: string; originHost?: string; position: number }[] = []
 
     // Pattern for short URLs with extensions (e.g., /s/abc123.png, /s/abc123.mov)
@@ -342,39 +391,45 @@ const ContentWithHashtags: React.FC<Props> = ({ content, className = '' }) => {
     // Find all matches with their positions
     let match: RegExpExecArray | null
 
-    // Short URLs with media extensions (images and videos)
-    while ((match = shortUrlWithExtPattern.exec(text)) !== null) {
-      const code = match[1]
-      const isVideo = /\.(mp4|webm|mov)$/i.test(code)
-      mediaMatches.push({
-        type: isVideo ? 'shortVideo' : 'shortImage',
-        data: match[0],
-        code: code,
-        originHost: extractShortUrlHost(match[0]),
-        position: match.index
-      })
+    if (renderMedia) {
+      // Short URLs with media extensions (images and videos)
+      while ((match = shortUrlWithExtPattern.exec(text)) !== null) {
+        const code = match[1]
+        const isVideo = /\.(mp4|webm|mov)$/i.test(code)
+        mediaMatches.push({
+          type: isVideo ? 'shortVideo' : 'shortImage',
+          data: match[0],
+          code: code,
+          originHost: extractShortUrlHost(match[0]),
+          position: match.index
+        })
+      }
+
+      // Direct image URLs (excluding short URLs)
+      while ((match = imageUrlPattern.exec(text)) !== null) {
+        // Skip if it's a short URL (already handled)
+        if (match[0].includes('/s/')) continue
+        mediaMatches.push({
+          type: 'image',
+          data: match[0],
+          position: match.index
+        })
+      }
+
+      // Sort by position to maintain original order
+      mediaMatches.sort((a, b) => a.position - b.position)
     }
 
-    // Direct image URLs (excluding short URLs)
-    while ((match = imageUrlPattern.exec(text)) !== null) {
-      // Skip if it's a short URL (already handled)
-      if (match[0].includes('/s/')) continue
-      mediaMatches.push({
-        type: 'image',
-        data: match[0],
-        position: match.index
-      })
-    }
+    // Remove media URLs from the text when requested.
+    // NOTE: This is especially important in the media modal post panel where we
+    // hide inline media — we still don't want to show raw image URLs.
+    let processedText = stripMediaUrls
+      ? text
+          .replace(shortUrlWithExtPattern, '')
+          .replace(imageUrlPattern, (match) => match.includes('/s/') ? match : '')
+      : text
 
-    // Sort by position to maintain original order
-    mediaMatches.sort((a, b) => a.position - b.position)
-
-    // Remove all media from text
-    let processedText = text
-      .replace(shortUrlWithExtPattern, '')
-      .replace(imageUrlPattern, (match) => match.includes('/s/') ? match : '')
-
-    // Clean up extra spaces left by removed refs (but preserve newlines!)
+    // Clean up extra spaces (but preserve newlines!)
     processedText = processedText
       .replace(/[ \t]+/g, ' ')  // Collapse multiple spaces/tabs (not newlines)
       .replace(/^ +/gm, '')     // Remove leading spaces on each line
@@ -432,7 +487,7 @@ const ContentWithHashtags: React.FC<Props> = ({ content, className = '' }) => {
       // Regular text line with hashtag parsing
       result.push(
         <span key={`text-${lineIndex}`}>
-          {parseTextWithHashtags(line, `line-${lineIndex}`)}
+          {parseTextWithHashtags(line, `line-${lineIndex}`, renderMedia)}
         </span>
       )
 
@@ -463,56 +518,147 @@ const ContentWithHashtags: React.FC<Props> = ({ content, className = '' }) => {
       }
     }
 
+    const gridClassFor = (count: number) =>
+      count === 2
+        ? 'grid grid-cols-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
+        : count === 3
+          ? 'grid grid-cols-2 grid-rows-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
+          : 'grid grid-cols-2 grid-rows-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
+
+    const cellClassFor = (count: number, i: number) =>
+      count === 3 && i === 0 ? 'row-span-2 w-full h-full' : 'w-full h-full'
+
+    // Image index within the post (in render order). Used for deep-linking
+    // into the post media modal.
+    let mediaImageIndex = 0
+
+    if (!renderMedia) return result
+
     // Render all media in order (sorted by original position in text)
-    mediaMatches.forEach((media, idx) => {
-      if (media.type === 'shortImage' && media.code) {
+    // UX fix: when multiple images are present, render them as a grid
+    // (matching the pre-post MediaUpload layout) instead of stacking.
+    for (let i = 0; i < mediaMatches.length; i++) {
+      const m = mediaMatches[i]
+      const isImageLike = m.type === 'image' || m.type === 'shortImage'
+
+      if (isImageLike) {
+        const start = i
+        while (i < mediaMatches.length && (mediaMatches[i].type === 'image' || mediaMatches[i].type === 'shortImage')) i++
+        const run = mediaMatches.slice(start, i)
+        i--
+
+        // Single image keeps legacy behavior (object-contain)
+        if (run.length === 1) {
+          const only = run[0]
+          const imageIdx = mediaImageIndex
+          mediaImageIndex += 1
+          if (only.type === 'shortImage' && only.code) {
+            result.push(
+              <ShortUrlImage
+                key={`shortimg-${start}`}
+                code={only.code}
+                originHost={only.originHost}
+                onError={handleImageError}
+                imageErrors={imageErrors}
+                onImageClick={postId ? () => openPostMedia(imageIdx) : undefined}
+              />
+            )
+          } else if (only.type === 'image') {
+            const url = only.data
+            result.push(
+              <div key={`img-${start}`} className="my-2 max-w-full">
+                <img
+                  src={url}
+                  alt="Embedded content"
+                  className="max-w-full max-h-96 rounded-lg object-contain cursor-zoom-in"
+                  loading="lazy"
+                  onError={() => handleImageError(url)}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    if (postId) openPostMedia(imageIdx)
+                    else setLightbox({ src: url, largeSrc: feedImageLargeUrl(url) })
+                  }}
+                />
+              </div>
+            )
+          }
+          continue
+        }
+
+        const baseImageIndex = mediaImageIndex
+        // Even if we only *display* up to 4, keep indices consistent so
+        // +N overlays still deep-link correctly.
+        mediaImageIndex += run.length
+
+        const visible = run.slice(0, 4)
+        const count = visible.length
+
         result.push(
-          <ShortUrlImage
-            key={`shortimg-${idx}`}
-            code={media.code}
-            originHost={media.originHost}
-            onError={handleImageError}
-            imageErrors={imageErrors}
-          />
+          <div key={`imggrid-${start}`} className="my-2 max-w-full">
+            <div className={gridClassFor(count)}>
+              {visible.map((im, idx) => (
+                <div
+                  key={`imgcell-${start}-${idx}`}
+                  className={`relative w-full h-full overflow-hidden ${cellClassFor(count, idx)}`}
+                >
+                  {im.type === 'shortImage' && im.code ? (
+                    <ShortUrlImage
+                      code={im.code}
+                      originHost={im.originHost}
+                      onError={handleImageError}
+                      imageErrors={imageErrors}
+                      wrapperClassName="w-full h-full"
+                      imgClassName="block w-full h-full object-cover"
+                      skeletonClassName="w-full h-full bg-gray-200 dark:bg-gray-700 animate-pulse"
+                      onImageClick={postId ? () => openPostMedia(baseImageIndex + idx) : undefined}
+                    />
+                  ) : (
+                    <img
+                      src={im.data}
+                      alt={`Embedded content ${idx + 1}`}
+                      className="block w-full h-full object-cover cursor-zoom-in"
+                      loading="lazy"
+                      onError={() => handleImageError(im.data)}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        if (postId) openPostMedia(baseImageIndex + idx)
+                        else setLightbox({ src: im.data, largeSrc: feedImageLargeUrl(im.data) })
+                      }}
+                    />
+                  )}
+
+                  {run.length > 4 && idx === 3 && (
+                    <div className="absolute inset-0 bg-black/50 flex items-center justify-center text-white text-xl font-semibold pointer-events-none">
+                      +{run.length - 4}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
         )
-      } else if (media.type === 'shortVideo' && media.code) {
+        continue
+      }
+
+      if (m.type === 'shortVideo' && m.code) {
         result.push(
           <ShortUrlVideo
-            key={`shortvid-${idx}`}
-            code={media.code}
-            originHost={media.originHost}
+            key={`shortvid-${i}`}
+            code={m.code}
+            originHost={m.originHost}
             onError={handleImageError}
             videoErrors={imageErrors}
           />
         )
-      } else if (media.type === 'image') {
-        const url = media.data
-        // External images don't have variants — the inline render IS the
-        // biggest version we have. Lightbox just gives full-viewport space.
-        result.push(
-          <div key={`img-${idx}`} className="my-2 max-w-full">
-            <img
-              src={url}
-              alt="Embedded content"
-              className="max-w-full max-h-96 rounded-lg object-contain cursor-zoom-in"
-              loading="lazy"
-              onError={() => handleImageError(url)}
-              onClick={(e) => {
-                e.stopPropagation()
-                setLightbox({ src: url, largeSrc: feedImageLargeUrl(url) })
-              }}
-            />
-          </div>
-        )
       }
-    })
+    }
 
     return result
   }
 
   return (
     <div className={`break-words ${className}`}>
-      {parseContent(content)}
+      {parseContent(content, renderMedia, stripMediaUrls)}
       {lightbox && (
         <ImageLightbox
           src={lightbox.src}

--- a/client/src/services/FrontEnd/src/components/Feed.tsx
+++ b/client/src/services/FrontEnd/src/components/Feed.tsx
@@ -157,11 +157,15 @@ const Feed = forwardRef<FeedRef, Props>(({ filter, username, apiEndpoint, title 
     const pendingSig = (p: any) => `${p.user?.tokenId}:${(p.content || '').trim()}:${p.parent?.id || ''}`
     const pendingPostSignatures = new Set(pendingPosts.map(pendingSig))
 
+    const isReply = (it: CawItem) => it.parent?.id && !it.isQuote && it.action !== 'RECAW'
+
     const filtered = items.filter(item => {
       // Filter out muted content
       if (shouldFilterPost(item, preferences)) return false
       // Filter out blocked users
       if (blockedUserIds.includes(item.user.tokenId)) return false
+      // Main timeline feeds should not show replies — they belong on the post page.
+      if ((filter === 'For you' || filter === 'Following') && isReply(item)) return false
       // Filter out posts the current user just deleted — the on-chain hide
       // takes 5–60s to land, this keeps them gone immediately.
       if (item.cawonce != null && hiddenCawonces[Number(item.cawonce)]) return false
@@ -191,7 +195,6 @@ const Feed = forwardRef<FeedRef, Props>(({ filter, username, apiEndpoint, title 
     // window. In that case skip it for now and re-emit it the moment we
     // place its parent. Replies whose parent isn't in the nearby window are
     // dropped at their natural position (don't promote orphans).
-    const isReply = (it: CawItem) => it.parent?.id && !it.isQuote && it.action !== 'RECAW'
     const PARENT_LOOKAHEAD = 8
     // Map parentId -> queued replies waiting to be emitted under it.
     const pendingByParent = new Map<string, CawItem[]>()
@@ -638,6 +641,8 @@ const Feed = forwardRef<FeedRef, Props>(({ filter, username, apiEndpoint, title 
 
         const visiblePending = showPending
           ? pendingPosts
+              // Main feeds: don't render pending replies either.
+              .filter(p => (filter === 'For you' || filter === 'Following') ? !(p.replyToId || p.parent?.id) : true)
               .filter(p => filter === 'profile-replies' ? !!p.replyToId : true)
               .filter(p => {
                 if (!hashtagFilter) return true
@@ -794,4 +799,3 @@ const Feed = forwardRef<FeedRef, Props>(({ filter, username, apiEndpoint, title 
 Feed.displayName = 'Feed'
 
 export default Feed
-

--- a/client/src/services/FrontEnd/src/components/FeedItem.tsx
+++ b/client/src/services/FrontEnd/src/components/FeedItem.tsx
@@ -35,7 +35,7 @@ import { useModalStore } from '~/store/modalStore'
 import { useOptimisticLikesStore } from '~/store/optimisticLikesStore'
 import { useHiddenCawsStore } from '~/store/hiddenCawsStore'
 import { useBookmarksStore } from '~/store/bookmarksStore'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { User, CawItem } from '~/types'
 import { useTheme } from '~/hooks/useTheme'
 import ContentWithHashtags from './ContentWithHashtags'
@@ -55,7 +55,7 @@ import { chains } from '~/config/chains'
 
 import { formatTimeAgo } from '~/utils/formatTimeAgo'
 
-const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolean; hideParentPreview?: boolean; onBookmarkUpdate?: (cawId: number, isBookmarked: boolean) => void; onLikeStateChange?: (cawId: string, likePending: boolean) => void; onRecawStateChange?: (cawId: string, recawPending: boolean) => void; onReplyStateChange?: (cawId: string, replyPending: boolean) => void; onTipStateChange?: (cawId: string, tipPending: boolean) => void }> = ({ item, isMainPost = false, isReply = false, hideParentPreview = false, onBookmarkUpdate, onLikeStateChange, onRecawStateChange, onReplyStateChange, onTipStateChange }) => {
+const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolean; hideParentPreview?: boolean; hideMedia?: boolean; contentClassName?: string; uiDensity?: 'normal' | 'compact'; onBookmarkUpdate?: (cawId: number, isBookmarked: boolean) => void; onLikeStateChange?: (cawId: string, likePending: boolean) => void; onRecawStateChange?: (cawId: string, recawPending: boolean) => void; onReplyStateChange?: (cawId: string, replyPending: boolean) => void; onTipStateChange?: (cawId: string, tipPending: boolean) => void }> = ({ item, isMainPost = false, isReply = false, hideParentPreview = false, hideMedia = false, contentClassName, uiDensity = 'normal', onBookmarkUpdate, onLikeStateChange, onRecawStateChange, onReplyStateChange, onTipStateChange }) => {
   // For plain recaws, pending states and counts should reflect the original post (parent),
   // not the recaw wrapper. useItem is set to item.parent for recaws further below, but
   // we need the right source for initial state here. Quotes act as their own posts.
@@ -99,6 +99,13 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
   const { isDark } = useTheme()
   const qc = useQueryClient()
   const navigate = useNavigate()
+  const location = useLocation()
+
+  const openPostMedia = (postId: string, mediaIndex: number) => {
+    navigate(`/caws/${postId}?media=${mediaIndex}&source=imageData`, {
+      state: { backgroundLocation: location }
+    })
+  }
   const [busyLike, setBusyLike]     = useState(false)
   const [busyRecaw, setBusyRecaw]   = useState(false)
   const [pendingLikeAction, setPendingLikeAction] = useState<{ receiverId: number, receiverCawonce: number, actionType: 'like' | 'unlike' } | null>(null) // Track pending like data
@@ -109,7 +116,8 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [showShareModal, setShowShareModal] = useState(false)
   const [showTipModal, setShowTipModal] = useState(false)
-  const [imageCollapsed, setImageCollapsed] = useState(false)
+  // NOTE: Media collapse UI removed — posts should show attached media
+  // consistently without extra toggles in the feed.
   const [textCopied, setTextCopied] = useState(false)
   const bookmarksStore = useBookmarksStore()
   // Sync server-provided bookmark state into store on mount
@@ -916,24 +924,28 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
             <div className="mb-4 pl-2 md:pl-0">
               <ContentWithHashtags
                 content={translatedText}
+                postId={useItem.id}
+                renderMedia={!hideMedia}
                 className={`transition-colors duration-300 ${
                   isDark ? 'text-gray-200' : 'text-gray-800'
-                }`}
+                } ${contentClassName || ''}`}
               />
             </div>
           ) : (
             <div className="mb-4 pl-2 md:pl-0">
               <ContentWithHashtags
                 content={useItem.content}
+                postId={useItem.id}
+                renderMedia={!hideMedia}
                 className={`transition-colors duration-300 ${
                   isDark ? 'text-gray-200' : 'text-gray-800'
-                }`}
+                } ${contentClassName || ''}`}
               />
             </div>
           )}
 
           {/* Video Display */}
-          {useItem.hasVideo && (
+          {!hideMedia && useItem.hasVideo && (
             <div className="mb-4 pl-2 md:pl-0">
               {(() => {
                 // Check if videoData contains URLs
@@ -975,46 +987,16 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
           )}
 
           {/* Image Display */}
-          {useItem.hasImage && (
+          {!hideMedia && useItem.hasImage && (
             <div className="mb-4 pl-2 md:pl-0">
-              {imageCollapsed ? (
-                <button
-                  onClick={(e) => {
-                    e.preventDefault()
-                    e.stopPropagation()
-                    setImageCollapsed(false)
-                  }}
-                  className={`flex items-center gap-1 text-xs cursor-pointer ${isDark ? 'text-gray-500 hover:text-gray-400' : 'text-gray-400 hover:text-gray-500'} transition-colors`}
-                >
-                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                  </svg>
-                  Show media
-                </button>
-              ) : (() => {
+              {(() => {
                 // Check if imageData contains URLs or base64 data
-                const collapseBtn = (
-                  <Tooltip text="Hide media"><button
-                    onClick={(e) => {
-                      e.preventDefault()
-                      e.stopPropagation()
-                      setImageCollapsed(true)
-                    }}
-                    className="absolute top-2 left-2 z-10 p-1 rounded-full bg-black/60 hover:bg-black/80 text-white/70 hover:text-white transition-all cursor-pointer"
-                  >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-                    </svg>
-                  </button></Tooltip>
-                )
-
                 if (useItem.imageData) {
                   if (useItem.imageData.startsWith('urls:')) {
                     // Off-chain images stored as URLs
                     const urls = useItem.imageData.replace('urls:', '').split('|||')
                     return (
-                      <div className="relative">
-                        {collapseBtn}
+                      <div>
                         {(() => {
                           const count = urls.length
                           if (count <= 0) return null
@@ -1022,7 +1004,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                           if (count === 1) {
                             const url = urls[0]
                             return (
-                              <div className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 w-full">
+                              <div className="relative rounded-lg overflow-hidden w-full">
                                 <img
                                   src={url}
                                   alt="Caw image"
@@ -1030,7 +1012,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                                   onClick={(e) => {
                                     e.preventDefault()
                                     e.stopPropagation()
-                                    // TODO: Open image in modal
+                                    openPostMedia(useItem.id, 0)
                                   }}
                                   onError={(e) => {
                                     console.error('Failed to load image from URL:', url)
@@ -1043,10 +1025,10 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
 
                           const gridClass =
                             count === 2
-                                ? 'grid grid-cols-2 gap-2 aspect-video rounded-lg overflow-hidden'
+                                ? 'grid grid-cols-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
                                 : count === 3
-                                  ? 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden'
-                                  : 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden'
+                                  ? 'grid grid-cols-2 grid-rows-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
+                                  : 'grid grid-cols-2 grid-rows-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
 
                           const cellClass = (i: number) =>
                             count === 3 && i === 0 ? 'row-span-2 w-full h-full' : 'w-full h-full'
@@ -1054,7 +1036,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                           return (
                             <div className={gridClass}>
                               {urls.slice(0, 4).map((url, index) => (
-                                <div key={index} className={`relative w-full h-full overflow-hidden border border-gray-200 dark:border-gray-700 ${cellClass(index)}`}>
+                                <div key={index} className={`relative w-full h-full overflow-hidden ${cellClass(index)}`}>
                                   <img
                                     src={url}
                                     alt={`Caw image ${index + 1}`}
@@ -1062,7 +1044,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                                     onClick={(e) => {
                                       e.preventDefault()
                                       e.stopPropagation()
-                                      // TODO: Open image in modal
+                                      openPostMedia(useItem.id, index)
                                     }}
                                     onError={(e) => {
                                       console.error('Failed to load image from URL:', url)
@@ -1080,8 +1062,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                     // On-chain images stored as base64
                     const images = useItem.imageData.split('|||')
                     return (
-                      <div className="relative">
-                        {collapseBtn}
+                      <div>
                         {(() => {
                           const count = images.length
                           if (count <= 0) return null
@@ -1089,7 +1070,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                           if (count === 1) {
                             const imageBase64 = images[0]
                             return (
-                              <div className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 w-full">
+                              <div className="relative rounded-lg overflow-hidden w-full">
                                 <img
                                   src={`data:image/jpeg;base64,${imageBase64}`}
                                   alt="Caw image"
@@ -1097,7 +1078,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                                   onClick={(e) => {
                                     e.preventDefault()
                                     e.stopPropagation()
-                                    // TODO: Open image in modal
+                                    openPostMedia(useItem.id, 0)
                                   }}
                                   onError={(e) => {
                                     console.error('Failed to load on-chain image')
@@ -1113,10 +1094,10 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
 
                           const gridClass =
                             count === 2
-                                ? 'grid grid-cols-2 gap-2 aspect-video rounded-lg overflow-hidden'
+                                ? 'grid grid-cols-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
                                 : count === 3
-                                  ? 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden'
-                                  : 'grid grid-cols-2 grid-rows-2 gap-2 aspect-video rounded-lg overflow-hidden'
+                                  ? 'grid grid-cols-2 grid-rows-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
+                                  : 'grid grid-cols-2 grid-rows-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
 
                           const cellClass = (i: number) =>
                             count === 3 && i === 0 ? 'row-span-2 w-full h-full' : 'w-full h-full'
@@ -1124,7 +1105,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                           return (
                             <div className={gridClass}>
                               {images.slice(0, 4).map((imageBase64, index) => (
-                                <div key={index} className={`relative w-full h-full overflow-hidden border border-gray-200 dark:border-gray-700 ${cellClass(index)}`}>
+                                <div key={index} className={`relative w-full h-full overflow-hidden ${cellClass(index)}`}>
                                   <img
                                     src={`data:image/jpeg;base64,${imageBase64}`}
                                     alt={`Caw image ${index + 1}`}
@@ -1132,7 +1113,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                                     onClick={(e) => {
                                       e.preventDefault()
                                       e.stopPropagation()
-                                      // TODO: Open image in modal
+                                      openPostMedia(useItem.id, index)
                                     }}
                                     onError={(e) => {
                                       console.error('Failed to load on-chain image')
@@ -1153,8 +1134,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                 } else if (useItem.imageUrl) {
                   // Legacy single image URL
                   return (
-                    <div className="relative w-full rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
-                      {collapseBtn}
+                    <div className="w-full rounded-lg overflow-hidden">
                       <img
                         src={useItem.imageUrl}
                         alt="Caw image"
@@ -1162,7 +1142,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                         onClick={(e) => {
                           e.preventDefault()
                           e.stopPropagation()
-                          // TODO: Open image in modal
+                          openPostMedia(useItem.id, 0)
                         }}
                         onError={(e) => {
                           console.error('Failed to load image')
@@ -1221,7 +1201,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
 
           {/* Post Actions */}
           <div className="flex items-center justify-between" onClick={(e) => e.stopPropagation()}>
-            <div className="flex items-center space-x-6">
+            <div className={`flex items-center ${uiDensity === 'compact' ? 'gap-4' : 'space-x-6'}`}>
               {/* Comments/Replies */}
               <Tooltip text={replyPending ? "Processing on-chain" : "Reply"} disabled={item.status === 'FAILED'}><button
                 className={`flex items-center space-x-2 transition-colors duration-300 ${
@@ -1236,8 +1216,8 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                 onClick={handleReply}
                 disabled={item.status === 'FAILED'}
               >
-                <HiOutlineChat className="w-5 h-5" />
-                <span className={`text-sm ${(useItem.hasReplied || replyPending) ? 'text-blue-500' : ''}`}>
+                <HiOutlineChat className={uiDensity === 'compact' ? 'w-4 h-4' : 'w-5 h-5'} />
+                <span className={`${uiDensity === 'compact' ? 'text-xs' : 'text-sm'} ${(useItem.hasReplied || replyPending) ? 'text-blue-500' : ''}`}>
                   {formatEngagementCount(useItem.commentCount + effectiveReplyAdj)}
                 </span>
               </button></Tooltip>
@@ -1273,11 +1253,11 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                       <HiOutlineCheck className="absolute inset-0 w-3 h-3 m-auto text-green-500" />
                     </div>
                   ) : (
-                    <Recaw className={`w-5 h-5 translate-y-1 transition-all duration-300 ${
+                    <Recaw className={`${uiDensity === 'compact' ? 'w-4 h-4 translate-y-[3px]' : 'w-5 h-5 translate-y-1'} transition-all duration-300 ${
                       (useItem.hasRecawed || isRecawByCurrentUser || recawPending) ? 'text-green-500' : ''
                     }`} />
                   )}
-                  <span className={`text-sm translate-y-1 transition-colors duration-300 ${
+                  <span className={`${uiDensity === 'compact' ? 'text-xs translate-y-0.5' : 'text-sm translate-y-1'} transition-colors duration-300 ${
                     (useItem.hasRecawed || isRecawByCurrentUser) ? 'text-green-500' : ''
                   }`}>{formatEngagementCount(useItem.recawCount + effectiveRecawAdj)}</span>
                 </button></Tooltip>
@@ -1375,9 +1355,9 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                     <HiOutlineCheck className="absolute inset-0 w-3 h-3 m-auto text-red-500" />
                   </div>
                 ) : (
-                  <HiOutlineHeart className={`w-5 h-5 ${(useItem.hasLiked || likePending || stateSource.likePending) ? 'fill-current' : ''}`} />
+                  <HiOutlineHeart className={`${uiDensity === 'compact' ? 'w-4 h-4' : 'w-5 h-5'} ${(useItem.hasLiked || likePending || stateSource.likePending) ? 'fill-current' : ''}`} />
                 )}
-                <span className="text-sm">{formatEngagementCount(useItem.likeCount + effectiveLikeAdj)}</span>
+                <span className={uiDensity === 'compact' ? 'text-xs' : 'text-sm'}>{formatEngagementCount(useItem.likeCount + effectiveLikeAdj)}</span>
               </button></Tooltip>
 
               {/* Views */}
@@ -1386,12 +1366,12 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                   isDark ? 'text-gray-400' : 'text-gray-600'
                 }`}
               >
-                <HiOutlineEye className="w-5 h-5" />
-                <span className="text-sm">{formatEngagementCount(useItem.viewCount || 0)}</span>
+                <HiOutlineEye className={uiDensity === 'compact' ? 'w-4 h-4' : 'w-5 h-5'} />
+                <span className={uiDensity === 'compact' ? 'text-xs' : 'text-sm'}>{formatEngagementCount(useItem.viewCount || 0)}</span>
               </button></Tooltip>
             </div>
 
-            <div className="flex items-center space-x-4">
+            <div className={`flex items-center ${uiDensity === 'compact' ? 'gap-3' : 'space-x-4'}`}>
               {/* Bookmark */}
               <Tooltip text={isBookmarked ? "Remove bookmark" : "Save"} disabled={item.status === 'FAILED'}><button
                 onClick={handleBookmark}
@@ -1406,13 +1386,13 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                     : isDark ? 'text-gray-400' : 'text-gray-600'
                 }`}
               >
-                <Bookmark className={`w-5 h-5 -translate-y-[3px] transition-all duration-300 ${
+                <Bookmark className={`${uiDensity === 'compact' ? 'w-4 h-4 -translate-y-[2px]' : 'w-5 h-5 -translate-y-[3px]'} transition-all duration-300 ${
                   isBookmarked
                     ? 'fill-yellow-500 stroke-yellow-500'
                     : isDark ? 'stroke-white stroke-[1.5]' : 'stroke-gray-600'
                 }`} />
                 {localBookmarkCount > 0 && (
-                  <span className="text-xs -translate-y-[3px]">{localBookmarkCount}</span>
+                  <span className={`${uiDensity === 'compact' ? 'text-[11px] -translate-y-[2px]' : 'text-xs -translate-y-[3px]'}`}>{localBookmarkCount}</span>
                 )}
               </button></Tooltip>
 
@@ -1434,9 +1414,9 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                     : isDark ? 'text-gray-400' : 'text-gray-600'
                 }`}
               >
-                <HiOutlineCurrencyDollar className="w-5 h-5 mb-[5px]" />
+                <HiOutlineCurrencyDollar className={`${uiDensity === 'compact' ? 'w-4 h-4 mb-[4px]' : 'w-5 h-5 mb-[5px]'}`} />
                 {(useItem.tipCount ?? 0) > 0 && (
-                  <span className="text-xs -translate-y-[3px]">{useItem.tipCount}</span>
+                  <span className={`${uiDensity === 'compact' ? 'text-[11px] -translate-y-[2px]' : 'text-xs -translate-y-[3px]'}`}>{useItem.tipCount}</span>
                 )}
               </button></Tooltip>
 
@@ -1456,7 +1436,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                   isDark ? 'text-gray-400' : 'text-gray-600'
                 }`}
               >
-                <Share className={`w-5 h-5 transition-all duration-300 ${
+                <Share className={`${uiDensity === 'compact' ? 'w-4 h-4' : 'w-5 h-5'} transition-all duration-300 ${
                   isDark ? 'stroke-white stroke-[1.5]' : 'stroke-gray-600'
                 }`} />
               </button></Tooltip>

--- a/client/src/services/FrontEnd/src/components/HighlightedTextarea.tsx
+++ b/client/src/services/FrontEnd/src/components/HighlightedTextarea.tsx
@@ -15,6 +15,10 @@ interface HighlightedTextareaProps {
   className?: string
   textareaRef?: React.RefObject<HTMLTextAreaElement | null>
   fontSize?: 'base' | 'xl'
+  /** Tighter vertical padding for compact composers (e.g. replies). */
+  compact?: boolean
+  /** When true, grows textarea height to fit content (no internal scroll). */
+  autoResize?: boolean
 }
 
 /**
@@ -33,13 +37,20 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
   rows = 3,
   className = '',
   textareaRef: externalRef,
-  fontSize = 'xl'
+  fontSize = 'xl',
+  compact = false,
+  autoResize = false
 }) => {
   const { isDark } = useTheme()
   const internalRef = useRef<HTMLTextAreaElement>(null)
   const textareaRef = externalRef || internalRef
   const highlightRef = useRef<HTMLDivElement>(null)
   const [scrollTop, setScrollTop] = useState(0)
+
+  const textSizeClass = fontSize === 'xl' ? 'text-xl' : 'text-base'
+  const lineHeight = fontSize === 'xl' ? '1.75rem' : '1.5rem'
+  const paddingBottom = compact ? '10px' : '26px'
+  const padding = `2px 8px ${paddingBottom} 8px`
 
   // Sync scroll between textarea and highlight div
   const handleScroll = (e: React.UIEvent<HTMLTextAreaElement>) => {
@@ -51,6 +62,20 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
       highlightRef.current.scrollTop = scrollTop
     }
   }, [scrollTop])
+
+  // Auto-grow to fit content (handles soft-wrapped long lines too).
+  useEffect(() => {
+    if (!autoResize) return
+    const el = (textareaRef as React.RefObject<HTMLTextAreaElement | null>)?.current
+    if (!el) return
+
+    // Use scrollHeight for BOTH empty and non-empty so the height is stable.
+    // The placeholder is NOT inside the <textarea>, so we keep a hidden dot
+    // in the mirror layer; here we just want consistent sizing.
+    el.style.height = '0px'
+    const next = el.scrollHeight + 2 // tiny buffer to avoid 1px flicker
+    el.style.height = `${next}px`
+  }, [autoResize, value, textareaRef, compact, lineHeight, fontSize])
 
   // Parse text and apply highlighting for @mentions, #hashtags, $cashtags, and URLs
   const getHighlightedText = (text: string) => {
@@ -80,9 +105,6 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
     })
   }
 
-  const textSizeClass = fontSize === 'xl' ? 'text-xl' : 'text-base'
-  const lineHeight = fontSize === 'xl' ? '1.75rem' : '1.5rem'
-
   return (
     <div className="relative w-full">
       {/* Highlight layer - renders behind textarea */}
@@ -92,7 +114,7 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
           isDark ? 'text-white' : 'text-black'
         }`}
         style={{
-          padding: '2px 8px 26px 8px',
+          padding,
           lineHeight,
           wordBreak: 'break-word',
           overflowWrap: 'break-word',
@@ -110,8 +132,9 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
         className={`w-full resize-none border-none outline-none bg-transparent ${textSizeClass} ${className}`}
         style={{
           boxShadow: 'none',
-          padding: '2px 8px 26px 8px',
+          padding,
           lineHeight,
+          overflow: autoResize ? 'hidden' : undefined,
           color: 'transparent',
           caretColor: isDark ? 'white' : 'black',
           WebkitTextFillColor: 'transparent',

--- a/client/src/services/FrontEnd/src/components/MediaUpload.tsx
+++ b/client/src/services/FrontEnd/src/components/MediaUpload.tsx
@@ -65,12 +65,12 @@ const MediaCell: React.FC<{
     onDragOver={(e) => onReorderDragOver(e, index)}
     onDragLeave={onReorderDragLeave}
     onDrop={(e) => onReorderDrop(e, index)}
-    className={`relative rounded-lg overflow-hidden border-2 transition-all ${
+    className={`relative rounded-lg overflow-hidden transition-all ${
       dragOverIndex === index
-        ? 'border-yellow-500 scale-[1.02]'
+        ? 'ring-2 ring-yellow-500 scale-[1.02]'
         : draggedIndex === index
-          ? 'border-yellow-500/50 opacity-50'
-          : isDark ? 'border-gray-600 bg-gray-800' : 'border-gray-200 bg-gray-50'
+          ? 'ring-2 ring-yellow-500/50 opacity-50'
+          : isDark ? 'bg-gray-800' : 'bg-gray-50'
     } ${draggable ? 'cursor-grab active:cursor-grabbing' : ''} ${className}`}
   >
     <div className="relative w-full h-full bg-black">
@@ -521,12 +521,12 @@ const MediaUpload: React.FC<MediaUploadProps> = ({
                       onDragOver={(e) => handleReorderDragOver(e, index)}
                       onDragLeave={handleReorderDragLeave}
                       onDrop={(e) => handleReorderDrop(e, index)}
-                      className={`relative rounded-lg overflow-hidden border-2 transition-all ${
+                      className={`relative rounded-lg overflow-hidden transition-all ${
                         dragOverIndex === index
-                          ? 'border-yellow-500 scale-105'
+                          ? 'ring-2 ring-yellow-500 scale-105'
                           : draggedIndex === index
-                            ? 'border-yellow-500/50 opacity-50'
-                            : isDark ? 'border-gray-600 bg-gray-800' : 'border-gray-200 bg-gray-50'
+                            ? 'ring-2 ring-yellow-500/50 opacity-50'
+                            : isDark ? 'bg-gray-800' : 'bg-gray-50'
                       } ${selectedMedia.length > 1 ? 'cursor-grab active:cursor-grabbing' : ''}`}
                     >
                       {/* Media Preview */}

--- a/client/src/services/FrontEnd/src/components/Notifications.tsx
+++ b/client/src/services/FrontEnd/src/components/Notifications.tsx
@@ -277,29 +277,29 @@ const Notifications: React.FC = () => {
   const getNotificationIcon = (type: Notification['type']) => {
     switch (type) {
       case 'FOLLOW':
-        return <HiUserAdd className="w-5 h-5 text-blue-500" />
+        return <HiUserAdd className="w-6 h-6 text-blue-500" />
       case 'LIKE':
-        return <HiHeart className="w-5 h-5 text-red-500" />
+        return <HiHeart className="w-6 h-6 text-red-500" />
       case 'REPLY':
-        return <HiReply className="w-5 h-5 text-green-500" />
+        return <HiReply className="w-6 h-6 text-green-500" />
       case 'REPOST':
-        return <HiRefresh className="w-5 h-5 text-purple-500" />
+        return <HiRefresh className="w-6 h-6 text-purple-500" />
       case 'QUOTE':
-        return <HiReply className="w-5 h-5 text-indigo-500" />
+        return <HiReply className="w-6 h-6 text-indigo-500" />
       case 'MENTION':
-        return <HiAtSymbol className="w-5 h-5 text-orange-500" />
+        return <HiAtSymbol className="w-6 h-6 text-orange-500" />
       case 'TIP':
-        return <HiCurrencyDollar className="w-5 h-5 text-yellow-500" />
+        return <HiCurrencyDollar className="w-6 h-6 text-yellow-500" />
       case 'OFFER':
-        return <HiTag className="w-5 h-5 text-yellow-500" />
+        return <HiTag className="w-6 h-6 text-yellow-500" />
       case 'OUTBID':
-        return <HiTag className="w-5 h-5 text-orange-500" />
+        return <HiTag className="w-6 h-6 text-orange-500" />
       case 'AUCTION_WON':
-        return <HiTag className="w-5 h-5 text-green-500" />
+        return <HiTag className="w-6 h-6 text-green-500" />
       case 'ACTION_FAILED':
-        return <HiBell className="w-5 h-5 text-red-400" />
+        return <HiBell className="w-6 h-6 text-red-400" />
       default:
-        return <HiBell className="w-5 h-5 text-gray-500" />
+        return <HiBell className="w-6 h-6 text-gray-500" />
     }
   }
 
@@ -417,12 +417,24 @@ const Notifications: React.FC = () => {
   const getNotificationText = (notification: Notification): React.ReactNode => {
     const { type, actor, additionalActors, count = 1 } = notification
 
+    // Style: actor is the visual anchor; action should be readable (less gray).
+    const actionClass = isDark ? 'text-white/85 font-normal' : 'text-gray-800 font-normal'
+    const Actor = (node: React.ReactNode) => <span className="font-bold">{node}</span>
+    const Action = (node: React.ReactNode) => <span className={actionClass}>{node}</span>
+
     const actorLabel = actor.displayName || actor.username
     const actorLink = (
       <span
         onClick={e => {
+          // Actor name sits inside an <a> notification row for most types.
+          // stopPropagation prevents the row's SPA handler, so we MUST also
+          // preventDefault or the browser will follow the row href.
+          e.preventDefault()
           e.stopPropagation()
-          navigate(`/users/${actor.username}`)
+          const uname = actor.username && actor.username !== `#${actor.tokenId}`
+            ? actor.username
+            : (actor.displayName || actor.username)
+          navigate(`/users/${uname}`)
         }}
         className="hover:underline cursor-pointer"
       >
@@ -459,17 +471,17 @@ const Notifications: React.FC = () => {
         )
       }
       case 'FOLLOW':
-        return <>{actorNode} followed you</>
+        return <>{Actor(actorNode)} {Action('followed you')}</>
       case 'LIKE':
-        return <>{actorNode} liked your caw</>
+        return <>{Actor(actorNode)} {Action('liked your caw')}</>
       case 'REPLY':
-        return <>{actorNode} replied to your caw</>
+        return <>{Actor(actorNode)} {Action('replied to your caw')}</>
       case 'REPOST':
-        return <>{actorNode} recawed your caw</>
+        return <>{Actor(actorNode)} {Action('recawed your caw')}</>
       case 'QUOTE':
-        return <>{actorNode} quoted your caw</>
+        return <>{Actor(actorNode)} {Action('quoted your caw')}</>
       case 'MENTION':
-        return <>{actorNode} mentioned you</>
+        return <>{Actor(actorNode)} {Action('mentioned you')}</>
       case 'TIP': {
         const tipAmt = notification.actionPayload?.tipAmount
         let tipLabel = ''
@@ -482,8 +494,8 @@ const Notifications: React.FC = () => {
           tipLabel = ` ${formatted} CAW${usd}`
         }
         return notification.caw
-          ? <>{actorNode} tipped your caw{tipLabel}</>
-          : <>{actorNode} tipped you{tipLabel}</>
+          ? <>{Actor(actorNode)} {Action(<>tipped your caw{tipLabel}</>)}</>
+          : <>{Actor(actorNode)} {Action(<>tipped you{tipLabel}</>)}</>
       }
       case 'OFFER': {
         // Build USD display
@@ -504,7 +516,7 @@ const Notifications: React.FC = () => {
         // Show actor username if they have one, otherwise fall back to address with etherscan link
         const addr = notification.offer?.offerer
         if (actor.username && actor.username !== `#${actor.tokenId}`) {
-          return <>{actorNode} made an offer on your profile{offerUsd}</>
+          return <>{Actor(actorNode)} {Action(<>made an offer on your profile{offerUsd}</>)}</>
         }
         if (addr) {
           const addrDisplay = `${addr.slice(0, 6)}...${addr.slice(-4)}`
@@ -517,24 +529,24 @@ const Notifications: React.FC = () => {
               >
                 {addrDisplay}
               </Link>
-              {` made an offer on your profile${offerUsd}`}
+              {Action(` made an offer on your profile${offerUsd}`)}
             </>
           )
         }
-        return <>{actorNode} made an offer on your profile{offerUsd}</>
+        return <>{Actor(actorNode)} {Action(<>made an offer on your profile{offerUsd}</>)}</>
       }
       case 'OUTBID': {
         const payload = notification.actionPayload
         const username = payload?.username ?? 'a profile'
-        return `You've been outbid on @${username}`
+        return Action(`You've been outbid on @${username}`)
       }
       case 'AUCTION_WON': {
         const payload = notification.actionPayload
         const username = payload?.username ?? 'a profile'
-        return `You won the auction for @${username}! Settle it to claim the username.`
+        return Action(`You won the auction for @${username}! Settle it to claim the username.`)
       }
       default:
-        return actorNode
+        return Actor(actorNode)
     }
   }
 
@@ -810,23 +822,21 @@ const Notifications: React.FC = () => {
           </p>
         </div>
       ) : (
-        <div className="space-y-2">
-          {notifications.map(notification => {
+        <div className="w-full">
+          {notifications.map((notification, idx) => {
             // Render as <a href> when the notification has a real
             // destination so cmd/ctrl/middle-click open it in a new tab
             // the way the browser already does for links. Plain left-
             // click is intercepted for SPA navigation. Non-navigating
             // types (OFFER opens a modal) fall back to a plain div.
             const href = getNotificationHref(notification)
-            const rowClass = `block p-4 rounded-lg transition cursor-pointer no-underline ${
-              !notification.isRead
-                ? isDark
-                  ? 'bg-blue-500/10 hover:bg-blue-500/20'
-                  : 'bg-blue-50 hover:bg-blue-100'
-                : isDark
-                  ? 'bg-white/5 hover:bg-white/10'
-                  : 'bg-gray-50 hover:bg-gray-100'
-            }`
+            // Flat rows (no cards). Only a horizontal divider between rows.
+            const divider = idx < notifications.length - 1
+              ? (isDark ? 'border-b border-white/15' : 'border-b border-gray-200')
+              : ''
+            const rowClass = `block px-4 py-4 transition cursor-pointer no-underline ${
+              isDark ? 'hover:bg-white/5' : 'hover:bg-gray-50'
+            } ${divider}`
             const RowTag: any = href ? 'a' : 'div'
             const rowProps: any = href
               ? {
@@ -849,18 +859,23 @@ const Notifications: React.FC = () => {
                   {getNotificationIcon(notification.type)}
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className={`text-sm flex items-center gap-1.5 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                  <div className={`min-w-0 text-sm md:text-base leading-snug ${isDark ? 'text-white' : 'text-gray-900'}`}>
                     {notification.actor && notification.type !== 'ACTION_FAILED' && (
                       <Avatar
                         src={getUserAvatar(notification.actor)}
-                        className="w-[18px] h-[18px] rounded-full flex-shrink-0"
+                        className="w-7 h-7 rounded-full flex-shrink-0 inline-block align-middle mr-1.5"
                         size="small"
                       />
                     )}
-                    <span className="font-semibold">
-                      {getNotificationText(notification)}
-                    </span>
-                  </p>
+                    {getNotificationText(notification)}
+                    <Tooltip text={formatFullDateTime(notification.createdAt)} className="inline-block">
+                      <span
+                        className={`ml-2 whitespace-nowrap text-sm ${isDark ? 'text-white/55' : 'text-gray-500'}`}
+                      >
+                        · {formatRelativeTime(notification.createdAt)}
+                      </span>
+                    </Tooltip>
+                  </div>
                   {notification.caw && (
                     <p className={`text-sm mt-1 truncate ${
                       isDark ? 'text-white/60' : 'text-gray-600'
@@ -868,15 +883,6 @@ const Notifications: React.FC = () => {
                       {notification.caw.content}
                     </p>
                   )}
-                  <Tooltip text={formatFullDateTime(notification.createdAt)} className="inline-block">
-                    <p
-                      className={`text-xs mt-1 ${
-                        isDark ? 'text-white/40' : 'text-gray-500'
-                      }`}
-                    >
-                      {formatRelativeTime(notification.createdAt)}
-                    </p>
-                  </Tooltip>
                 </div>
                 {notification.type === 'ACTION_FAILED' && notification.actionPayload && (() => {
                   // Manual retry in progress (user tapped the button on this
@@ -923,10 +929,10 @@ const Notifications: React.FC = () => {
           {hasMore && (
             <button
               onClick={() => fetchNotifications()}
-              className={`w-full py-3 text-center rounded-lg transition ${
+              className={`w-full py-4 text-center transition ${
                 isDark
-                  ? 'bg-white/10 hover:bg-white/20 text-white'
-                  : 'bg-gray-100 hover:bg-gray-200 text-gray-900'
+                  ? 'hover:bg-white/5 text-white/80'
+                  : 'hover:bg-gray-50 text-gray-800'
               }`}
               disabled={loading}
             >

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -14,6 +14,7 @@ import { useConnectModal } from "@rainbow-me/rainbowkit";
 import type { ActionParams } from '~/api/actions'
 import type { CawItem } from '~/types'
 import { useTheme } from '~/hooks/useTheme'
+import { DesktopDatePicker, DesktopTimePicker } from '~/components/forms/DesktopDateTimePicker'
 import { getUserAvatar } from '~/utils/defaultAvatar'
 import { BsWallet } from 'react-icons/bs'
 import MediaUpload from './MediaUpload'
@@ -383,6 +384,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
   const [showScheduler, setShowScheduler] = useState(false)
   const [scheduledDate, setScheduledDate] = useState('')
   const [scheduledTime, setScheduledTime] = useState('')
+  const [schedulePicker, setSchedulePicker] = useState<null | 'date' | 'time'>(null)
   const [isScheduling, setIsScheduling] = useState(false)
   const [scheduleError, setScheduleError] = useState<string | null>(null)
   const [showMediaUpload, setShowMediaUpload] = useState(false)
@@ -663,11 +665,46 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
         // Build the post content
         let finalText = text
 
-        // Handle GIFs (already have URLs from Giphy)
-        const gifs = selectedMedia.filter(m => m.type === 'gif')
-        if (gifs.length > 0) {
-          const gifUrls = gifs.map(gif => `\n${gif.url}`).join('')
-          finalText = finalText + gifUrls
+        // Persist attached media for scheduled posts. We upload images now and
+        // append media URLs into the scheduled text (same as immediate posts).
+        // NOTE: scheduled posts do not support video yet.
+        if (selectedMedia.some(m => m.type === 'video')) {
+          setScheduleError('Scheduled posts do not support video yet.')
+          return
+        }
+
+        const uploadedUrls: Map<number, string> = new Map()
+        const offChainImages = selectedMedia
+          .map((m, i) => ({ media: m, index: i }))
+          .filter(({ media }) => media.type === 'image')
+
+        if (offChainImages.length > 0) {
+          const imageFiles = offChainImages.map(({ media }: any) => media.file as File)
+          const uploadResult = await uploadMedia(imageFiles, 'image', effectiveTokenId)
+          if (!uploadResult.success || !uploadResult.urls) {
+            setScheduleError('Failed to upload images for scheduled post.')
+            return
+          }
+          offChainImages.forEach(({ index }, i) => {
+            uploadedUrls.set(index, uploadResult.urls![i])
+          })
+        }
+
+        const mediaUrls: string[] = []
+        selectedMedia.forEach((media: any, index: number) => {
+          let url: string | undefined
+          if (media.type === 'image') url = uploadedUrls.get(index)
+          if (media.type === 'gif') url = media.shortUrl || media.url
+          if (url) mediaUrls.push(url)
+        })
+
+        const mediaBlock = mediaUrls.length > 0 ? '\n' + mediaUrls.join('\n') : ''
+        if (mediaBlock) {
+          if (isThreadMode && mediaPosition === 'end') {
+            // Media appended after splitting.
+          } else {
+            finalText = finalText + mediaBlock
+          }
         }
 
         // Replace original URLs with short URLs for on-chain submission
@@ -676,6 +713,49 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
         // Split into thread chunks if needed — mirrors the immediate-post path.
         const chunks = splitTextIntoChunks(finalText, includePageIndicators)
+
+        // If media goes at end of thread, check if it fits in the last chunk or needs its own.
+        if (isThreadMode && mediaPosition === 'end' && mediaBlock) {
+          const lastChunk = chunks[chunks.length - 1]
+          if (byteLen(lastChunk) + byteLen(mediaBlock) <= POST_CHAR_LIMIT) {
+            chunks[chunks.length - 1] = lastChunk + mediaBlock
+          } else {
+            const mediaContent = mediaBlock.replace(/^\n/, '')
+            const totalWithMedia = chunks.length + 1
+            if (includePageIndicators) {
+              const oldDigits = String(chunks.length).length
+              const newDigits = String(totalWithMedia).length
+              if (newDigits > oldDigits) {
+                chunks.length = 0
+                let remaining = finalText
+                let idx = 0
+                while (remaining.length > 0) {
+                  const indicator = `(${idx + 1}/${totalWithMedia}) `
+                  const available = POST_CHAR_LIMIT - indicator.length
+                  if (byteLen(remaining) <= available) {
+                    chunks.push(indicator + remaining)
+                    break
+                  }
+                  const splitAt = findSplitPoint(remaining, available)
+                  chunks.push(indicator + remaining.slice(0, splitAt))
+                  remaining = remaining.slice(splitAt).trimStart()
+                  idx++
+                }
+              } else {
+                for (let i = 0; i < chunks.length; i++) {
+                  const oldIndicator = `(${i + 1}/${chunks.length}) `
+                  const newIndicator = `(${i + 1}/${totalWithMedia}) `
+                  if (chunks[i].startsWith(oldIndicator)) {
+                    chunks[i] = newIndicator + chunks[i].slice(oldIndicator.length)
+                  }
+                }
+              }
+              chunks.push(`(${totalWithMedia}/${totalWithMedia}) ${mediaContent}`)
+            } else {
+              chunks.push(mediaContent)
+            }
+          }
+        }
 
         // Same MAX_THREAD_LENGTH guard as the immediate-post path. Catch this
         // before reserving cawonces so a bounced submit doesn't leave a gap
@@ -885,7 +965,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
     if (chunks.length > 1) setSigningProgress({ current: 1, total: chunks.length })
 
     // If media goes at end of thread, check if it fits in the last chunk or needs its own
-    if (isThreadMode && mediaPosition === 'end' && mediaBlock && chunks.length > 1) {
+    if (isThreadMode && mediaPosition === 'end' && mediaBlock) {
       const lastChunk = chunks[chunks.length - 1]
       if (byteLen(lastChunk) + byteLen(mediaBlock) <= POST_CHAR_LIMIT) {
         // Media fits in the last text chunk
@@ -1205,6 +1285,10 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
     }
   }
 
+  useEffect(() => {
+    if (!showScheduler) setSchedulePicker(null)
+  }, [showScheduler])
+
   // Calculate total media URL character cost
   const getMediaCharCost = () => {
     let mediaCost = 0
@@ -1268,11 +1352,19 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
   // Dynamic textarea rows — grow after 4 lines, max 12
   const lineCount = text.split('\n').length
-  const desktopRows = Math.max(3, Math.min(lineCount, 12))
+  // Replies should feel tighter (closer to X/Threads).
+  // For regular posts, keep it roomy when it's text-only, but when media is
+  // attached the big empty textarea looks ridiculous.
+  const hasMedia = selectedMedia.length > 0
+  const desktopRows = replyTo
+    ? Math.max(2, Math.min(lineCount, 10))
+    : hasMedia
+      ? Math.max(1, Math.min(lineCount, 5))
+      : Math.max(3, Math.min(lineCount, 12))
   const isOverLimit = false // Thread mode handles overflow by splitting
 
   return (
-    <div className={`p-4 transition-all duration-300 ${isDark ? 'bg-black' : 'bg-white'}`}>
+      <div className={`${replyTo ? 'p-2' : 'p-4'} transition-all duration-300 ${isDark ? 'bg-black' : 'bg-white'}`}>
       {/* Hidden file input for media selection */}
       <input
         ref={fileInputRef}
@@ -1284,16 +1376,16 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
       />
 
       {/* Mobile Layout - Input + Button */}
-      <div className="md:hidden flex flex-col space-y-2">
+      <div className={`md:hidden flex flex-col ${replyTo ? 'space-y-1' : 'space-y-2'}`}>
           {/* Input and Reply Button Row */}
           <div className="flex items-center space-x-3">
             {/* Input */}
             <div className="flex-1 relative">
               <HighlightedTextarea
-                value={text}
-                onChange={handleTextChange}
-                onClick={handleTextClick}
-                onKeyUp={handleTextKeyUp}
+                 value={text}
+                 onChange={handleTextChange}
+                 onClick={handleTextClick}
+                 onKeyUp={handleTextKeyUp}
                 onDragOver={handleTextareaDragOver}
                 onDragLeave={handleTextareaDragLeave}
                 onDrop={handleTextareaDrop}
@@ -1305,9 +1397,11 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                       placeholder ?? (quote ? "Add a comment" : "What's happening?")
                     )
                 }
-                textareaRef={textareaRef}
-                fontSize="base"
-              />
+                 textareaRef={textareaRef}
+                 fontSize="base"
+                 compact={!!replyTo || hasMedia}
+                 autoResize
+               />
               <MentionAutocomplete
                 text={text}
                 cursorPosition={cursorPosition}
@@ -1355,7 +1449,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
           </div>
 
           {/* Mobile Icons Row */}
-          <div className="flex items-center justify-between">
+          <div className={`flex items-center justify-between ${replyTo ? 'pt-0.5' : ''}`}>
             {/* Left side - media icons */}
             <div className="flex items-center space-x-4">
               {/* Media Upload */}
@@ -1563,7 +1657,9 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                 )
             }
             textareaRef={textareaRef}
-            fontSize="xl"
+            fontSize={replyTo ? 'base' : 'xl'}
+            compact={!!replyTo || hasMedia}
+            autoResize
           />
           <MentionAutocomplete
             text={text}
@@ -1640,7 +1736,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
         )}
 
         {/* Scheduler */}
-        {showScheduler && (
+        {!replyTo && !quote && showScheduler && (
           <div className={`mt-4 p-4 border rounded-lg ${
             isDark ? 'border-white/20 bg-black' : 'border-gray-200 bg-gray-50'
           }`}>
@@ -1655,31 +1751,30 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                 <label className={`block text-sm mb-1 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                   Date
                 </label>
-                <input
-                  type="date"
+                <DesktopDatePicker
+                  isDark={isDark}
                   value={scheduledDate}
-                  onChange={(e) => { setScheduledDate(e.target.value); setScheduleError(null) }}
-                  min={new Date().toISOString().split('T')[0]}
-                  className={`w-full px-3 py-2 rounded-lg border transition-colors ${
-                    isDark
-                      ? 'bg-gray-700 border-gray-600 text-white focus:border-yellow-400'
-                      : 'bg-white border-gray-300 text-gray-900 focus:border-yellow-500'
-                  } focus:outline-none`}
+                  open={schedulePicker === 'date'}
+                  onOpenChange={(o) => setSchedulePicker(o ? 'date' : null)}
+                  onChange={(v) => {
+                    setScheduledDate(v)
+                    setScheduleError(null)
+                  }}
                 />
               </div>
               <div>
                 <label className={`block text-sm mb-1 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
                   Time
                 </label>
-                <input
-                  type="time"
+                <DesktopTimePicker
+                  isDark={isDark}
                   value={scheduledTime}
-                  onChange={(e) => { setScheduledTime(e.target.value); setScheduleError(null) }}
-                  className={`w-full px-3 py-2 rounded-lg border transition-colors ${
-                    isDark
-                      ? 'bg-gray-700 border-gray-600 text-white focus:border-yellow-400'
-                      : 'bg-white border-gray-300 text-gray-900 focus:border-yellow-500'
-                  } focus:outline-none`}
+                  open={schedulePicker === 'time'}
+                  onOpenChange={(o) => setSchedulePicker(o ? 'time' : null)}
+                  onChange={(v) => {
+                    setScheduledTime(v)
+                    setScheduleError(null)
+                  }}
                 />
               </div>
             </div>
@@ -1698,7 +1793,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
         )}
 
         {/* Functionality Icons */}
-        <div className="flex items-center justify-between mt-4">
+        <div className={`flex items-center justify-between ${replyTo ? 'mt-1.5' : 'mt-4'}`}>
           <div className="flex items-center space-x-3">
             {/* Media Upload */}
             <button
@@ -1754,22 +1849,24 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
               </svg>
             </button>
 
-            {/* Schedule Post */}
-            <button
-              onClick={() => setShowScheduler(!showScheduler)}
-              className={`p-2 rounded-full transition-all duration-200 cursor-pointer ${
-              text.trim()
-                ? (isDark
-                    ? 'text-yellow-400 hover:text-yellow-300 hover:bg-yellow-400/10'
-                    : 'text-yellow-600 hover:text-yellow-500 hover:bg-yellow-200/50')
-                : (isDark
-                    ? 'text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-400/10'
-                    : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50')
-            }`}>
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </button>
+            {/* Schedule Post (not for replies/quotes) */}
+            {!replyTo && !quote && (
+              <button
+                onClick={() => setShowScheduler(!showScheduler)}
+                className={`p-2 rounded-full transition-all duration-200 cursor-pointer ${
+                text.trim()
+                  ? (isDark
+                      ? 'text-yellow-400 hover:text-yellow-300 hover:bg-yellow-400/10'
+                      : 'text-yellow-600 hover:text-yellow-500 hover:bg-yellow-200/50')
+                  : (isDark
+                      ? 'text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-400/10'
+                      : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50')
+              }`}>
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </button>
+            )}
 
           </div>
 
@@ -1903,11 +2000,11 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
       {showScheduledSuccessModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div
-            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            className="absolute inset-0 bg-black/60"
             onClick={() => setShowScheduledSuccessModal(false)}
           />
           <div className={`relative z-10 w-full max-w-sm mx-4 p-6 rounded-2xl shadow-xl ${
-            isDark ? 'bg-gray-900 border border-white/10' : 'bg-white border border-gray-200'
+            isDark ? 'bg-black border border-white/10' : 'bg-white border border-gray-200'
           }`}>
             <div className="text-center">
               <div className={`w-16 h-16 mx-auto mb-4 rounded-full flex items-center justify-center ${
@@ -1939,4 +2036,3 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 }
 
 export default PostForm
-

--- a/client/src/services/FrontEnd/src/components/SuggestedUsers.tsx
+++ b/client/src/services/FrontEnd/src/components/SuggestedUsers.tsx
@@ -122,7 +122,8 @@ const SuggestedUsers: React.FC<SuggestedUsersProps> = ({ onFollowChange }) => {
 
   return (
     <div className={`pt-4 mb-3 rounded-xl ${
-      isDark ? 'bg-black' : 'bg-gray-100 border border-gray-200 shadow-inner'
+      // Light theme: keep it flat (no gray panel behind cards).
+      isDark ? 'bg-black' : 'bg-transparent'
     }`}>
       <h2 className={`text-lg font-semibold mb-4 ml-4 ${isDark ? 'text-white' : 'text-gray-900'}`}>
         Suggested users to follow

--- a/client/src/services/FrontEnd/src/components/UserCard.tsx
+++ b/client/src/services/FrontEnd/src/components/UserCard.tsx
@@ -70,7 +70,7 @@ const UserCard: React.FC<UserCardProps> = ({
       className={`relative rounded-xl p-4 transition-all duration-700 ease-in-out ${containerClass} ${
         isDark
           ? 'bg-white/5 hover:bg-white/10'
-          : 'bg-white hover:bg-gray-50 shadow-lg border border-gray-200'
+          : `bg-gray-50 hover:bg-gray-100 border ${layout === 'carousel' ? 'border-gray-200' : 'border-gray-200'} ${layout === 'carousel' ? '' : 'shadow-lg'}`
       }`}
       style={carouselStyle}
     >

--- a/client/src/services/FrontEnd/src/components/dm/MessageReactions.tsx
+++ b/client/src/services/FrontEnd/src/components/dm/MessageReactions.tsx
@@ -34,6 +34,18 @@ interface ReactionStripProps {
   /** Pass true on the bubble's "isFromCurrentUser" branch so we anchor
    *  the strip to the right edge instead of the left. */
   alignRight?: boolean
+
+  /** Controlled open state (optional). */
+  open?: boolean
+  /** Controlled open setter (optional). */
+  onOpenChange?: (open: boolean) => void
+
+  /**
+   * Anchor strategy for the portal strip positioning.
+   * - 'bubble': anchor to the message bubble element (recommended)
+   * - 'trigger': anchor to the smiley trigger element
+   */
+  anchor?: 'bubble' | 'trigger'
 }
 
 /**
@@ -53,9 +65,22 @@ export const MessageReactionStrip: React.FC<ReactionStripProps> = ({
   onOpenPicker,
   onOpenCustomize,
   alignRight,
+  open: controlledOpen,
+  onOpenChange,
+  anchor = 'bubble',
 }) => {
   const { isDark } = useTheme()
-  const [open, setOpen] = useState(false)
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
+  const open = controlledOpen ?? uncontrolledOpen
+  const setOpen = (next: boolean | ((prev: boolean) => boolean)) => {
+    const resolved = typeof next === 'function' ? (next as any)(open) : next
+    if (controlledOpen !== undefined) {
+      onOpenChange?.(resolved)
+      return
+    }
+    setUncontrolledOpen(resolved)
+    onOpenChange?.(resolved)
+  }
   const wrapperRef = useRef<HTMLDivElement>(null)
   const stripRef = useRef<HTMLDivElement>(null)
   const [coords, setCoords] = useState({ top: 0, left: 0 })
@@ -88,7 +113,11 @@ export const MessageReactionStrip: React.FC<ReactionStripProps> = ({
     const trigger = wrapperRef.current
     const strip = stripRef.current
     if (!trigger || !strip) return
-    const tRect = trigger.getBoundingClientRect()
+    const anchorEl = anchor === 'bubble'
+      ? (trigger.previousElementSibling as HTMLElement | null)
+      : trigger
+
+    const tRect = (anchorEl ?? trigger).getBoundingClientRect()
     const sRect = strip.getBoundingClientRect()
     const margin = 8
 
@@ -143,7 +172,9 @@ export const MessageReactionStrip: React.FC<ReactionStripProps> = ({
         type="button"
         onClick={() => setOpen(o => !o)}
         className={`p-1.5 rounded-full transition-opacity cursor-pointer ${
-          open ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+          open
+            ? 'opacity-100 pointer-events-auto'
+            : 'opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto'
         } ${isDark ? 'hover:bg-white/10 text-white/40 hover:text-white/80' : 'hover:bg-gray-200 text-gray-400 hover:text-gray-700'}`}
         title="Add reaction"
       >

--- a/client/src/services/FrontEnd/src/components/forms/DesktopDateTimePicker.tsx
+++ b/client/src/services/FrontEnd/src/components/forms/DesktopDateTimePicker.tsx
@@ -1,0 +1,317 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { HiChevronLeft, HiChevronRight } from 'react-icons/hi'
+import ThemedListbox from '~/components/forms/ThemedListbox'
+
+const pad2 = (n: number) => String(n).padStart(2, '0')
+const isValidDate = (d: Date) => !Number.isNaN(d.getTime())
+
+const panelClass = (isDark: boolean) =>
+  `absolute mt-2 rounded-xl border shadow-lg z-[70] overflow-visible ${
+    isDark ? 'bg-neutral-900 border-white/10' : 'bg-white border-gray-200'
+  }`
+
+const fieldClass = (isDark: boolean) =>
+  `w-full px-3 py-2 rounded-lg border transition-colors outline-none flex items-center justify-between gap-3 ${
+    isDark
+      ? 'bg-black border-white/20 text-white'
+      : 'bg-white border-gray-300 text-gray-900'
+  }`
+
+const subtleText = (isDark: boolean) => (isDark ? 'text-white/50' : 'text-gray-400')
+const hoverBg = (isDark: boolean) => (isDark ? 'hover:bg-white/10' : 'hover:bg-gray-100')
+
+export function DesktopDatePicker({
+  isDark,
+  value,
+  open,
+  onOpenChange,
+  onChange,
+}: {
+  isDark: boolean
+  value: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onChange: (next: string) => void
+}) {
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  const selected = useMemo(() => {
+    if (!value) return null
+    const d = new Date(`${value}T00:00:00`)
+    return isValidDate(d) ? d : null
+  }, [value])
+
+  const [cursor, setCursor] = useState<Date>(() => selected ?? new Date())
+
+  useEffect(() => {
+    if (selected) setCursor(new Date(selected.getFullYear(), selected.getMonth(), 1))
+  }, [selected])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      const t = e.target as Node | null
+      if (!t || !rootRef.current?.contains(t)) onOpenChange(false)
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onOpenChange(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open, onOpenChange])
+
+  const display = selected
+    ? selected.toLocaleDateString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit' })
+    : ''
+
+  const year = cursor.getFullYear()
+  const month = cursor.getMonth()
+  const first = new Date(year, month, 1)
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+  // Monday-first index.
+  const startIndex = (first.getDay() + 6) % 7
+  const prevMonthDays = new Date(year, month, 0).getDate()
+
+  const cells = Array.from({ length: 42 }, (_, i) => {
+    const dayNum = i - startIndex + 1
+    if (dayNum < 1) {
+      const d = prevMonthDays + dayNum
+      const dt = new Date(year, month - 1, d)
+      return { dt, inMonth: false }
+    }
+    if (dayNum > daysInMonth) {
+      const d = dayNum - daysInMonth
+      const dt = new Date(year, month + 1, d)
+      return { dt, inMonth: false }
+    }
+    return { dt: new Date(year, month, dayNum), inMonth: true }
+  })
+
+  const isSameDay = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
+
+  const today = useMemo(() => {
+    const t = new Date()
+    t.setHours(0, 0, 0, 0)
+    return t
+  }, [])
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        className={`${fieldClass(isDark)} ${hoverBg(isDark)} cursor-pointer`}
+        onClick={() => onOpenChange(!open)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        <span className={display ? '' : subtleText(isDark)}>{display || 'dd/mm/aaaa'}</span>
+        <span className={subtleText(isDark)}>
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+        </span>
+      </button>
+
+      {open && (
+        <div className={`${panelClass(isDark)} left-0 w-[280px] p-3`} role="dialog">
+          <div className="flex items-center justify-between mb-2">
+            <button
+              type="button"
+              className={`p-1 rounded-md ${hoverBg(isDark)} ${subtleText(isDark)}`}
+              onClick={() => setCursor(new Date(year, month - 1, 1))}
+              aria-label="Previous month"
+            >
+              <HiChevronLeft className="w-5 h-5" />
+            </button>
+            <div className={`text-sm font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {cursor.toLocaleString(undefined, { month: 'long', year: 'numeric' })}
+            </div>
+            <button
+              type="button"
+              className={`p-1 rounded-md ${hoverBg(isDark)} ${subtleText(isDark)}`}
+              onClick={() => setCursor(new Date(year, month + 1, 1))}
+              aria-label="Next month"
+            >
+              <HiChevronRight className="w-5 h-5" />
+            </button>
+          </div>
+
+          <div className={`grid grid-cols-7 gap-1 text-[11px] mb-1 ${subtleText(isDark)}`}>
+            {['LU', 'MA', 'MI', 'JU', 'VI', 'SA', 'DO'].map(d => (
+              <div key={d} className="text-center py-1">{d}</div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7 gap-1">
+            {cells.map(({ dt, inMonth }, idx) => {
+              const selectedDay = selected ? isSameDay(dt, selected) : false
+              const disabled = dt.getTime() < today.getTime()
+              const cls = selectedDay
+                ? (isDark ? 'bg-yellow-500/20 text-yellow-200' : 'bg-yellow-100 text-yellow-800')
+                : inMonth
+                  ? (isDark ? 'text-white hover:bg-white/10' : 'text-gray-900 hover:bg-gray-100')
+                  : (isDark ? 'text-white/35 hover:bg-white/5' : 'text-gray-400 hover:bg-gray-50')
+              return (
+                <button
+                  key={idx}
+                  type="button"
+                  disabled={disabled}
+                  className={`h-9 rounded-md text-sm transition-colors ${cls} ${disabled ? 'opacity-30 cursor-not-allowed hover:bg-transparent' : ''}`}
+                  onClick={() => {
+                    if (disabled) return
+                    const next = `${dt.getFullYear()}-${pad2(dt.getMonth() + 1)}-${pad2(dt.getDate())}`
+                    onChange(next)
+                    onOpenChange(false)
+                  }}
+                >
+                  {dt.getDate()}
+                </button>
+              )
+            })}
+          </div>
+
+          <div className="flex items-center justify-between mt-3">
+            <button
+              type="button"
+              className={`text-xs font-medium px-2 py-1 rounded-md ${hoverBg(isDark)} ${isDark ? 'text-white/70' : 'text-gray-600'}`}
+              onClick={() => {
+                onChange('')
+                onOpenChange(false)
+              }}
+            >
+              Borrar
+            </button>
+            <button
+              type="button"
+              className={`text-xs font-medium px-2 py-1 rounded-md ${hoverBg(isDark)} ${isDark ? 'text-yellow-200' : 'text-yellow-800'}`}
+              onClick={() => {
+                const now = new Date()
+                const next = `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())}`
+                onChange(next)
+                onOpenChange(false)
+              }}
+            >
+              Hoy
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function DesktopTimePicker({
+  isDark,
+  value,
+  open,
+  onOpenChange,
+  onChange,
+}: {
+  isDark: boolean
+  value: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onChange: (next: string) => void
+}) {
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      const t = e.target as Node | null
+      if (!t || !rootRef.current?.contains(t)) onOpenChange(false)
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onOpenChange(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open, onOpenChange])
+
+  const [h, m] = (value || '').split(':')
+  const selH = h && h.length === 2 ? h : ''
+  const selM = m && m.length === 2 ? m : ''
+
+  const hours = useMemo(() => Array.from({ length: 24 }, (_, i) => pad2(i)), [])
+  const minutes = useMemo(() => Array.from({ length: 60 }, (_, i) => pad2(i)), [])
+
+  const display = value || ''
+
+  const setPart = (nextH: string, nextM: string) => {
+    if (!nextH || !nextM) return
+    onChange(`${nextH}:${nextM}`)
+  }
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        className={`${fieldClass(isDark)} ${hoverBg(isDark)} cursor-pointer`}
+        onClick={() => onOpenChange(!open)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        <span className={display ? '' : subtleText(isDark)}>{display || '--:--'}</span>
+        <span className={subtleText(isDark)}>
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        </span>
+      </button>
+
+      {open && (
+        <div className={`${panelClass(isDark)} right-0 w-[320px] p-3`} role="dialog">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <div className={`text-xs mb-1 ${subtleText(isDark)}`}>Hour</div>
+              <ThemedListbox
+                isDark={isDark}
+                value={(selH || '00')}
+                onChange={(hr) => setPart(String(hr), selM || '00')}
+                options={hours.map(v => ({ value: v, label: v }))}
+              />
+            </div>
+            <div>
+              <div className={`text-xs mb-1 ${subtleText(isDark)}`}>Minute</div>
+              <ThemedListbox
+                isDark={isDark}
+                value={(selM || '00')}
+                onChange={(mi) => setPart(selH || '00', String(mi))}
+                options={minutes.map(v => ({ value: v, label: v }))}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between mt-3 px-1">
+            <button
+              type="button"
+              className={`text-xs font-medium px-2 py-1 rounded-md ${hoverBg(isDark)} ${isDark ? 'text-white/70' : 'text-gray-600'}`}
+              onClick={() => {
+                onChange('')
+                onOpenChange(false)
+              }}
+            >
+              Borrar
+            </button>
+            <button
+              type="button"
+              className={`text-xs font-medium px-2 py-1 rounded-md ${hoverBg(isDark)} ${isDark ? 'text-yellow-200' : 'text-yellow-800'}`}
+              onClick={() => onOpenChange(false)}
+            >
+              OK
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/client/src/services/FrontEnd/src/components/modals/CawMediaModal.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/CawMediaModal.tsx
@@ -1,0 +1,557 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { HiArrowLeft, HiArrowRight, HiOutlineX } from 'react-icons/hi'
+
+import FeedItem from '~/components/FeedItem'
+import PostForm from '~/components/PostForm'
+import SignInModal from '~/components/modals/SignInModal'
+import { apiFetch } from '~/api/client'
+import type { CawItem } from '~/types'
+import { useTheme } from '~/hooks/useTheme'
+import { useTokenDataStore, useActiveToken } from '~/store/tokenDataStore'
+import { usePendingPostsStore } from '~/store/pendingPostsStore'
+
+type MediaItem =
+  | { kind: 'url'; src: string }
+  | { kind: 'base64'; data: string }
+  | { kind: 'shortImage'; code: string; originHost?: string }
+
+// Local short-url resolver cache. (Same idea as ContentWithHashtags.)
+const shortUrlCache = new Map<string, string | null>()
+
+const cacheKey = (host: string | undefined, code: string) => (host ? `${host}|${code}` : code)
+const resolverEndpoint = (host: string | undefined, code: string) => (host ? `${host}/api/shorturl/${code}` : `/api/shorturl/${code}`)
+const extractShortUrlHost = (shortUrlText: string): string | undefined => {
+  const m = shortUrlText.match(/^(https?:\/\/[^\/]+)\/s\//)
+  return m ? m[1] : undefined
+}
+
+const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n))
+
+export default function CawMediaModal() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { isDark } = useTheme()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const source = searchParams.get('source') || 'content'
+
+  const activeTokenId = useTokenDataStore(s => s.activeTokenId)
+  const activeToken = useActiveToken()
+  const isAuthenticated = !!activeToken?.username
+
+  const [caw, setCaw] = useState<CawItem | null>(null)
+  const [comments, setComments] = useState<CawItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showSignInModal, setShowSignInModal] = useState(false)
+  // Mobile-only: bottom sheet (post + replies) over the image.
+  const [mobileSheetOpen, setMobileSheetOpen] = useState(false)
+  const allPendingPosts = usePendingPostsStore(s => s.pendingPosts)
+
+  // Lock scroll while modal is open.
+  useEffect(() => {
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [])
+
+  // ESC closes modal (standard lightbox behavior).
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        navigate(-1)
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [navigate])
+
+  useEffect(() => {
+    if (!id) return
+    let cancelled = false
+    const run = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const data = await apiFetch<{ caw: CawItem; comments: CawItem[] }>(`/api/caws/${id}`)
+        if (cancelled) return
+        setCaw(data.caw)
+        setComments(data.comments)
+      } catch (e) {
+        console.error('Failed to load caw for media modal:', e)
+        if (cancelled) return
+        setError('Could not load post')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [id, activeTokenId])
+
+  const pendingReplies = useMemo(
+    () => allPendingPosts.filter(p => p.replyToId === id),
+    [allPendingPosts, id]
+  )
+
+  // Avoid rendering the same pending reply twice: PostForm adds an
+  // optimistic pending reply to the store, and the API may also return a
+  // mirrored PENDING reply object for the same content.
+  const dedupedComments = useMemo(() => {
+    if (!comments.length) return comments
+    if (!pendingReplies.length) return comments
+    const sigs = new Set(
+      pendingReplies.map((p: any) => `${p?.user?.tokenId}:${String(p?.content ?? '').trim()}`)
+    )
+    return comments.filter((c) => {
+      if (c.status !== 'PENDING') return true
+      const sig = `${c?.user?.tokenId}:${String(c?.content ?? '').trim()}`
+      return !sigs.has(sig)
+    })
+  }, [comments, pendingReplies])
+
+  const mediaItems = useMemo<MediaItem[]>(() => {
+    if (!caw) return []
+    const out: MediaItem[] = []
+    const seen = new Set<string>()
+
+    const pushUrl = (src: string) => {
+      const key = `url:${src}`
+      if (!src || seen.has(key)) return
+      seen.add(key)
+      out.push({ kind: 'url', src })
+    }
+
+    const addContentMedia = () => {
+      // Mirrors ContentWithHashtags extraction.
+      const text = caw.content || ''
+      const mediaMatches: { type: 'shortImage' | 'image'; data: string; code?: string; originHost?: string; position: number }[] = []
+      const shortUrlWithExtPattern = /(?:https?:\/\/[^\s]+)?\/s\/([a-zA-Z0-9]+\.(gif|jpg|jpeg|png|webp))/g
+      const imageUrlPattern = /https?:\/\/[^\s<>"{}|\\^`[\]]+\.(?:gif|jpg|jpeg|png|webp)(?:\?[^\s]*)?/g
+
+      let match: RegExpExecArray | null
+      while ((match = shortUrlWithExtPattern.exec(text)) !== null) {
+        const code = match[1]
+        const full = match[0]
+        mediaMatches.push({
+          type: 'shortImage',
+          data: full,
+          code,
+          originHost: extractShortUrlHost(full),
+          position: match.index,
+        })
+      }
+
+      while ((match = imageUrlPattern.exec(text)) !== null) {
+        mediaMatches.push({
+          type: 'image',
+          data: match[0],
+          position: match.index,
+        })
+      }
+
+      mediaMatches.sort((a, b) => a.position - b.position)
+
+      mediaMatches.forEach(m => {
+        if (m.type === 'shortImage' && m.code) {
+          const key = `short:${m.originHost ?? ''}:${m.code}`
+          if (seen.has(key)) return
+          seen.add(key)
+          out.push({ kind: 'shortImage', code: m.code, originHost: m.originHost })
+          return
+        }
+        if (m.type === 'image') pushUrl(m.data)
+      })
+    }
+
+    const addImageDataMedia = () => {
+      if (caw.imageData) {
+        if (caw.imageData.startsWith('urls:')) {
+          caw.imageData.replace('urls:', '').split('|||').forEach(u => pushUrl(u))
+        } else {
+          caw.imageData.split('|||').filter(Boolean).forEach(b64 => {
+            const key = `b64:${b64}`
+            if (seen.has(key)) return
+            seen.add(key)
+            out.push({ kind: 'base64', data: b64 })
+          })
+        }
+      } else if (caw.imageUrl) {
+        pushUrl(caw.imageUrl)
+      }
+    }
+
+    // IMPORTANT: Keep indices stable.
+    // - source=imageData: only show attached media (imageData/imageUrl)
+    // - source=content: only show media extracted from content
+    // Fallback: if the chosen source produced nothing, try the other one.
+    if (source === 'imageData') {
+      addImageDataMedia()
+      if (!out.length) addContentMedia()
+    } else if (source === 'content') {
+      addContentMedia()
+      if (!out.length) addImageDataMedia()
+    } else {
+      addContentMedia()
+      addImageDataMedia()
+    }
+
+    return out
+  }, [caw, source])
+
+  const requestedIndex = Number(searchParams.get('media') || '0')
+  const activeIndex = clamp(Number.isFinite(requestedIndex) ? requestedIndex : 0, 0, Math.max(0, mediaItems.length - 1))
+
+  // Keep URL param normalized when out of range.
+  useEffect(() => {
+    if (!mediaItems.length) return
+    if (requestedIndex === activeIndex) return
+    const next = new URLSearchParams(searchParams)
+    next.set('media', String(activeIndex))
+    setSearchParams(next, { replace: true })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeIndex, mediaItems.length])
+
+  const setIndex = (nextIndex: number) => {
+    const next = clamp(nextIndex, 0, Math.max(0, mediaItems.length - 1))
+    const sp = new URLSearchParams(searchParams)
+    sp.set('media', String(next))
+    // IMPORTANT: preserve location.state.backgroundLocation.
+    // If we drop state here, AppRoutes loses `backgroundLocation` and the modal unmounts.
+    navigate(
+      { search: `?${sp.toString()}` },
+      { replace: true, state: location.state }
+    )
+  }
+
+  const close = () => {
+    navigate(-1)
+  }
+
+  const current = mediaItems[activeIndex]
+
+  const postPanelInner = loading
+    ? <div className={`${isDark ? 'text-white/70' : 'text-gray-700'}`}>Loading…</div>
+    : error || !caw
+      ? <div className={`${isDark ? 'text-white/70' : 'text-gray-700'}`}>{error || 'Could not load post'}</div>
+      : (
+        <>
+          <FeedItem
+            item={caw}
+            isMainPost={true}
+            hideMedia={true}
+            uiDensity="compact"
+            contentClassName="text-base md:text-lg leading-relaxed"
+          />
+
+          {/* Keep separators minimal in modal: FeedItem already includes its own divider. */}
+
+          {isAuthenticated && (
+            <PostForm
+              replyTo={caw}
+              onSuccess={() => {
+                // Refresh replies after posting
+                apiFetch<{ caw: CawItem; comments: CawItem[] }>(`/api/caws/${id}`)
+                  .then(d => {
+                    setCaw(d.caw)
+                    setComments(d.comments)
+                  })
+                  .catch(() => {})
+              }}
+            />
+          )}
+
+          {/* Replies */}
+          {isAuthenticated ? (
+            <div className="space-y-0 mt-3">
+              {pendingReplies.map((post: any) => (
+                <div key={post.tempId} className="relative">
+                  <FeedItem item={post as CawItem} isReply={true} hideParentPreview={true} hideMedia={true} uiDensity="compact" />
+                </div>
+              ))}
+
+              {dedupedComments.map((comm) => (
+                <div key={comm.id} className="relative">
+                  <FeedItem item={comm} isReply={true} hideParentPreview={true} hideMedia={true} uiDensity="compact" />
+                </div>
+              ))}
+            </div>
+          ) : (
+            (caw?.commentCount ?? 0) > 0 ? (
+              <button
+                onClick={() => setShowSignInModal(true)}
+                className={`w-full py-6 text-center rounded-lg border transition-colors cursor-pointer mt-3 ${
+                  isDark
+                    ? 'border-white/10 hover:border-yellow-500/40 hover:bg-yellow-500/5'
+                    : 'border-gray-200 hover:border-yellow-500/40 hover:bg-yellow-50'
+                }`}
+              >
+                <span className={`text-sm font-medium ${isDark ? 'text-white/70' : 'text-gray-600'}`}>
+                  {caw.commentCount} {caw.commentCount === 1 ? 'reply' : 'replies'}
+                </span>
+                <span className={`block text-xs mt-1 ${isDark ? 'text-white/40' : 'text-gray-400'}`}>
+                  Sign in to view and reply
+                </span>
+              </button>
+            ) : (
+              <div className={`py-6 text-center text-sm mt-3 ${isDark ? 'text-white/30' : 'text-gray-400'}`}>
+                Sign in to be the first to reply
+              </div>
+            )
+          )}
+        </>
+      )
+
+  return (
+      <div
+        className="fixed inset-0 z-[9999] bg-black/90"
+        onClick={(e) => {
+          // Close on backdrop tap/click, WITHOUT click-through to the feed.
+          if (e.target !== e.currentTarget) return
+          e.preventDefault()
+          e.stopPropagation()
+          close()
+        }}
+      >
+      {/* Close button (top-right) */}
+      <button
+        onClick={close}
+        className="absolute top-4 right-4 z-10 p-2 rounded-full bg-black/60 text-white/80 hover:text-white hover:bg-black/80 transition-colors cursor-pointer"
+        aria-label="Close"
+      >
+        <HiOutlineX className="w-6 h-6" />
+      </button>
+
+      <div className="absolute inset-0 flex flex-col md:flex-row">
+        {/* LEFT PANEL: post + actions + comments */}
+        <div className={`hidden md:block md:w-[300px] lg:w-[340px] xl:w-[380px] h-full overflow-hidden border-r ${isDark ? 'border-white/10 bg-black' : 'border-gray-200 bg-white'}`}>
+          <div className="h-full overflow-y-auto">
+            <div className="px-4 py-4">
+              {postPanelInner}
+            </div>
+          </div>
+        </div>
+
+        {/* RIGHT PANEL: image viewer */}
+        <div
+          className="flex-1 h-full bg-transparent flex items-center justify-center relative overflow-hidden pb-16 md:pb-0"
+          onPointerDown={(e) => {
+            // Never let interactions inside the viewer close the modal.
+            e.stopPropagation()
+
+            // If the bottom sheet is open, a tap on the image area
+            // (outside the sheet) should minimize it.
+            if (e.pointerType === 'touch' && mobileSheetOpen) setMobileSheetOpen(false)
+          }}
+          onClick={(e) => {
+            // Tap/click the empty area around the image closes the modal.
+            // Use click (not pointerdown) to avoid click-through after unmount.
+            if (e.target !== e.currentTarget) return
+            e.preventDefault()
+            e.stopPropagation()
+            close()
+          }}
+        >
+          {/* Nav arrows */}
+          {mediaItems.length > 1 && (
+            <>
+              <button
+                onClick={(e) => {
+                  // Never let nav buttons click-through to the backdrop.
+                  e.preventDefault()
+                  e.stopPropagation()
+                  if (activeIndex <= 0) return
+                  setIndex(activeIndex - 1)
+                }}
+                aria-disabled={activeIndex <= 0}
+                tabIndex={activeIndex <= 0 ? -1 : 0}
+                className={`flex items-center justify-center absolute left-3 md:left-4 top-1/2 -translate-y-1/2 p-3 md:p-2 rounded-full bg-black/50 text-white/80 transition-colors cursor-pointer select-none ${
+                  activeIndex <= 0
+                    ? 'opacity-30 cursor-not-allowed'
+                    : 'hover:text-white hover:bg-black/70'
+                }`}
+                aria-label="Previous"
+              >
+                <HiArrowLeft className="w-6 h-6" />
+              </button>
+              <button
+                onClick={(e) => {
+                  // Never let nav buttons click-through to the backdrop.
+                  e.preventDefault()
+                  e.stopPropagation()
+                  if (activeIndex >= mediaItems.length - 1) return
+                  setIndex(activeIndex + 1)
+                }}
+                aria-disabled={activeIndex >= mediaItems.length - 1}
+                tabIndex={activeIndex >= mediaItems.length - 1 ? -1 : 0}
+                className={`flex items-center justify-center absolute right-3 md:right-4 top-1/2 -translate-y-1/2 p-3 md:p-2 rounded-full bg-black/50 text-white/80 transition-colors cursor-pointer select-none ${
+                  activeIndex >= mediaItems.length - 1
+                    ? 'opacity-30 cursor-not-allowed'
+                    : 'hover:text-white hover:bg-black/70'
+                }`}
+                aria-label="Next"
+              >
+                <HiArrowRight className="w-6 h-6" />
+              </button>
+            </>
+          )}
+
+          {/* Counter */}
+          {mediaItems.length > 1 && (
+            <div className="absolute bottom-4 right-4 text-xs text-white/70 bg-black/50 px-2 py-1 rounded-full">
+              {activeIndex + 1}/{mediaItems.length}
+            </div>
+          )}
+
+          <MediaViewerImage item={current} />
+        </div>
+
+        {/* MOBILE: bottom sheet for post + replies (mobile only) */}
+        <div className="md:hidden fixed inset-x-0 bottom-0 z-[10000] pointer-events-none">
+          <div
+            className={`pointer-events-auto w-full rounded-t-2xl border-t ${
+              isDark ? 'bg-black/95 border-white/10' : 'bg-white/95 border-gray-200'
+            }`}
+            style={{
+              height: '75vh',
+              transform: mobileSheetOpen
+                ? 'translateY(0)'
+                : 'translateY(calc(75vh - 64px))',
+              transition: 'transform 220ms ease',
+              backdropFilter: 'blur(10px)',
+              WebkitBackdropFilter: 'blur(10px)'
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            {/* Handle / header */}
+            <button
+              type="button"
+              onClick={() => setMobileSheetOpen(v => !v)}
+              className={`w-full px-4 pt-2 pb-3 flex flex-col items-center gap-2 cursor-pointer ${
+                isDark ? 'text-white/70' : 'text-gray-700'
+              }`}
+              aria-expanded={mobileSheetOpen}
+            >
+              <span className={`h-1.5 w-12 rounded-full ${isDark ? 'bg-white/15' : 'bg-black/10'}`} />
+              <div className="w-full flex items-center justify-between text-xs">
+                <span className="font-medium">Post</span>
+                <span className="opacity-70">
+                  {caw?.commentCount ?? 0} {(caw?.commentCount ?? 0) === 1 ? 'reply' : 'replies'}
+                </span>
+              </div>
+            </button>
+
+            {/* Sheet content */}
+            <div className="h-[calc(75vh-64px)] overflow-y-auto px-4 pb-6">
+              <div className="pt-1">
+                {postPanelInner}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <SignInModal
+        isOpen={showSignInModal}
+        onClose={() => setShowSignInModal(false)}
+        message="Connect your wallet and create a username to view replies and join the conversation."
+      />
+    </div>
+  )
+}
+
+function MediaViewerImage({ item }: { item?: MediaItem }) {
+  const { isDark } = useTheme()
+  // Resolve short URLs on demand for the currently active item.
+  const resolved = useShortImageResolver(item)
+
+  if (!item) {
+    return <div className="text-white/60">No media</div>
+  }
+
+  if (item.kind === 'shortImage') {
+    if (resolved.loading) {
+      return <div className="w-[60vw] h-[60vh] max-w-[1100px] bg-white/10 rounded animate-pulse" />
+    }
+    if (!resolved.url) {
+      return <div className={`${isDark ? 'text-white/60' : 'text-gray-700'}`}>Failed to load image</div>
+    }
+    return (
+      <img
+        src={resolved.url}
+        alt="Post media"
+        className="max-w-[95vw] md:max-w-full max-h-[70vh] md:max-h-[95vh] object-contain"
+        onMouseDown={e => e.stopPropagation()}
+      />
+    )
+  }
+
+  const src = item.kind === 'base64'
+    ? `data:image/jpeg;base64,${item.data}`
+    : item.src
+
+  return (
+    <img
+      src={src}
+      alt="Post media"
+      className="max-w-[95vw] md:max-w-full max-h-[70vh] md:max-h-[95vh] object-contain"
+      onMouseDown={e => e.stopPropagation()}
+    />
+  )
+}
+
+function useShortImageResolver(item?: MediaItem): { url: string | null; loading: boolean } {
+  const [state, setState] = useState<{ url: string | null; loading: boolean }>({ url: null, loading: false })
+
+  useEffect(() => {
+    if (!item || item.kind !== 'shortImage') {
+      setState({ url: null, loading: false })
+      return
+    }
+
+    const key = cacheKey(item.originHost, item.code)
+    const cached = shortUrlCache.get(key)
+    if (shortUrlCache.has(key)) {
+      setState({ url: cached ?? null, loading: false })
+      return
+    }
+
+    let cancelled = false
+    setState({ url: null, loading: true })
+    const endpoint = resolverEndpoint(item.originHost, item.code)
+
+    const run = async () => {
+      try {
+        let data: any
+        if (/^https?:\/\//.test(endpoint)) {
+          const res = await fetch(endpoint)
+          if (!res.ok) throw new Error(`HTTP ${res.status}`)
+          data = await res.json()
+        } else {
+          data = await apiFetch<any>(endpoint)
+        }
+        const url = data?.originalUrl ? String(data.originalUrl) : null
+        shortUrlCache.set(key, url)
+        if (!cancelled) setState({ url, loading: false })
+      } catch (e) {
+        console.error('Failed to resolve short image url:', e)
+        shortUrlCache.set(key, null)
+        if (!cancelled) setState({ url: null, loading: false })
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [item])
+
+  return state
+}

--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -46,7 +46,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
         <div className={`w-full max-w-[1050px] ${themeLayoutShell(isDark)}`} />
       </div>
     )}
-    <div className={`min-h-screen w-full flex transition-colors duration-300 relative z-[1] ${
+    <div className={`min-h-screen w-full flex [--app-mobile-header-h:4rem] transition-colors duration-300 relative z-[1] ${
       hideSidebars
         ? (isDark ? 'bg-black' : 'bg-gray-100')
         : `max-w-[1050px] m-auto ${themeLayoutShell(isDark)}`

--- a/client/src/services/FrontEnd/src/pages/Messages.tsx
+++ b/client/src/services/FrontEnd/src/pages/Messages.tsx
@@ -74,6 +74,20 @@ const MessagesPage: React.FC = () => {
   const [defaultReactions, setDefaultReactions] = useState<string[]>([])
   // Modals invoked from the reaction strip.
   const [emojiPickerForMessage, setEmojiPickerForMessage] = useState<string | null>(null)
+  // Which message currently has its quick-reaction strip open.
+  // On desktop this is toggled by the smiley trigger; on mobile we open
+  // it via long-press on the bubble.
+  const [reactionStripForMessage, setReactionStripForMessage] = useState<string | null>(null)
+
+  // Long-press state for opening reactions on touch devices.
+  const longPressRef = useRef<{ timer: number | null; messageId: string | null; pointerId: number | null; startX: number; startY: number; fired: boolean }>({
+    timer: null,
+    messageId: null,
+    pointerId: null,
+    startX: 0,
+    startY: 0,
+    fired: false,
+  })
   // Toggles the full emoji picker for the *composer* (vs. reactions).
   // Picking from it inserts the emoji into the textarea, mirroring the
   // small inline strip's behavior.
@@ -863,6 +877,18 @@ const MessagesPage: React.FC = () => {
     }
   }
 
+  // Compact clock time for bubble footer (X-style).
+  const formatBubbleTime = (dateStr: string | number | Date | undefined) => {
+    if (!dateStr) return ''
+    try {
+      const date = new Date(dateStr)
+      if (isNaN(date.getTime())) return ''
+      return date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+    } catch {
+      return ''
+    }
+  }
+
   // Close chat options menu when clicking outside
   useEffect(() => {
     if (!showChatOptionsMenu) return
@@ -880,7 +906,9 @@ const MessagesPage: React.FC = () => {
   return (
     <MainLayout>
       <div
-        className={`max-w-2xl mx-auto pt-4 pb-0 flex flex-col relative h-full ${isDark ? 'bg-black' : 'bg-white'}`}
+        className={`max-w-2xl mx-auto pt-4 pb-0 flex flex-col relative flex-1 min-h-0 ${
+          currentView === 'chat' ? 'h-[calc(100dvh-var(--app-mobile-header-h))] md:h-screen' : ''
+        } ${isDark ? 'bg-black' : 'bg-white'}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
@@ -894,7 +922,11 @@ const MessagesPage: React.FC = () => {
           </div>
         )}
         {/* Messages Header */}
-        <div className={`mb-6 flex-shrink-0 mx-3 sm:mx-6 ${currentView === 'chat' ? `fixed md:sticky top-0 left-0 right-0 z-30 p-4 md:p-0 ${isDark ? 'bg-black' : 'bg-white'}` : ''}`}>
+        <div
+          className={`${currentView === 'chat'
+            ? `flex-shrink-0 w-full px-4 py-3 ${isDark ? 'bg-black' : 'bg-white'}`
+            : `mb-6 flex-shrink-0 mx-3 sm:mx-6`}`}
+        >
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
               {currentView === 'chat' && (
@@ -1320,9 +1352,9 @@ const MessagesPage: React.FC = () => {
 
         {/* Chat View */}
         {currentView === 'chat' && selectedConversationId && (
-          <div className="flex flex-col flex-1 md:flex-1 h-screen md:h-auto">
+          <div className="flex flex-col flex-1 min-h-0">
             {/* Encryption Status Banner */}
-            <div className={`flex items-center justify-center py-4 px-6 mx-3 sm:mx-6 ${
+            <div className={`flex-shrink-0 w-full flex items-center justify-center py-4 px-6 ${
               isDark ? 'bg-green-900/20 border-b border-green-800/30' : 'bg-green-50 border-b border-green-200'
             }`}>
               <div className="flex items-center space-x-2">
@@ -1340,8 +1372,8 @@ const MessagesPage: React.FC = () => {
             {/* Chat Messages — fixed height so overflow scrolling works, fade in when ready */}
             <div
               ref={messagesContainerRef}
-              className="overflow-y-auto custom-scrollbar-alt space-y-4 p-4 md:p-4 pt-32 md:pt-4 pb-20 md:pb-4 transition-opacity duration-300"
-              style={{ height: '100%', opacity: chatReady ? 1 : 0 }}
+              className="flex-1 min-h-0 overflow-y-auto overscroll-contain custom-scrollbar-alt p-4 md:p-4 pt-4 pb-20 md:pb-4 transition-opacity duration-300"
+              style={{ opacity: chatReady ? 1 : 0 }}
               onScroll={(e) => {
                 const el = e.currentTarget
                 // Load older messages when scrolled near the top
@@ -1392,7 +1424,7 @@ const MessagesPage: React.FC = () => {
 
                 let lastDateLabel = ''
 
-                return messages.map((message) => {
+                return messages.map((message, msgIdx) => {
                   // Handle different content types
                   let messageContent = '';
                   let attachments: any[] = [];
@@ -1432,11 +1464,18 @@ const MessagesPage: React.FC = () => {
                     ? messages.find(m => m.id === message.replyToMessageId)
                     : undefined
 
+                  const nextMsg = messages[msgIdx + 1]
+                  const compactWithNext = !!nextMsg
+                    && nextMsg.isFromCurrentUser === message.isFromCurrentUser
+                    && new Date(nextMsg.createdAt).toDateString() === msgDate.toDateString()
+                    && (new Date(nextMsg.createdAt).getTime() - msgDate.getTime()) <= 5 * 60 * 1000
+                  const blockSpacing = compactWithNext && message.isFromCurrentUser ? 'mb-2' : 'mb-4'
+
                   return (
                     <div
                       key={message.id}
                       data-message-id={message.id}
-                      className={`${isNew ? (message.isFromCurrentUser ? 'dm-animate-in-right' : 'dm-animate-in-left') : ''} ${
+                      className={`${blockSpacing} ${isNew ? (message.isFromCurrentUser ? 'dm-animate-in-right' : 'dm-animate-in-left') : ''} ${
                         highlightMessageId === message.id ? 'dm-highlight-flash' : ''
                       }`}
                     >
@@ -1521,6 +1560,52 @@ const MessagesPage: React.FC = () => {
                                 ? 'bg-gray-700 text-white'
                                 : 'bg-gray-200 text-black'
                             }`}
+                            onPointerDown={(e) => {
+                              // Mobile UX: reactions open on long-press, not on random taps.
+                              if (e.pointerType !== 'touch') return
+                              // Only one long-press tracker at a time.
+                              if (longPressRef.current.timer) window.clearTimeout(longPressRef.current.timer)
+                              longPressRef.current = {
+                                timer: window.setTimeout(() => {
+                                  longPressRef.current.fired = true
+                                  setReactionStripForMessage(message.id)
+                                }, 420),
+                                messageId: message.id,
+                                pointerId: e.pointerId,
+                                startX: e.clientX,
+                                startY: e.clientY,
+                                fired: false,
+                              }
+                            }}
+                            onPointerMove={(e) => {
+                              if (e.pointerType !== 'touch') return
+                              if (longPressRef.current.pointerId !== e.pointerId) return
+                              const dx = Math.abs(e.clientX - longPressRef.current.startX)
+                              const dy = Math.abs(e.clientY - longPressRef.current.startY)
+                              // If the user is scrolling, bail.
+                              if (dx + dy > 12 && longPressRef.current.timer) {
+                                window.clearTimeout(longPressRef.current.timer)
+                                longPressRef.current.timer = null
+                              }
+                            }}
+                            onPointerUp={(e) => {
+                              if (e.pointerType !== 'touch') return
+                              if (longPressRef.current.pointerId !== e.pointerId) return
+                              if (longPressRef.current.timer) window.clearTimeout(longPressRef.current.timer)
+                              longPressRef.current.timer = null
+                              longPressRef.current.pointerId = null
+                              longPressRef.current.messageId = null
+                              longPressRef.current.fired = false
+                            }}
+                            onPointerCancel={(e) => {
+                              if (e.pointerType !== 'touch') return
+                              if (longPressRef.current.pointerId !== e.pointerId) return
+                              if (longPressRef.current.timer) window.clearTimeout(longPressRef.current.timer)
+                              longPressRef.current.timer = null
+                              longPressRef.current.pointerId = null
+                              longPressRef.current.messageId = null
+                              longPressRef.current.fired = false
+                            }}
                           >
 
                           {/* Inline editing mode */}
@@ -1556,6 +1641,18 @@ const MessagesPage: React.FC = () => {
                           <>
                           {/* Message content — handle text, images, GIFs, encrypted attachments */}
                           {messageContent && (() => {
+                            const bubbleTime = formatBubbleTime(message.createdAt)
+                            const bubbleTimeTextClass = message.isFromCurrentUser
+                              ? 'text-white/70'
+                              : isDark
+                                ? 'text-white/60'
+                                : 'text-black/60'
+                            const bubbleTimePillClass = message.isFromCurrentUser
+                              ? 'bg-black/40 text-white/80'
+                              : isDark
+                                ? 'bg-black/40 text-white/75'
+                                : 'bg-white/80 text-black/70'
+
                             // Check for encrypted attachment JSON
                             try {
                               const parsed = JSON.parse(messageContent)
@@ -1569,23 +1666,41 @@ const MessagesPage: React.FC = () => {
                                 const mt = String(parsed.mimeType || '')
                                 if (mt.startsWith('image/') || mt.startsWith('video/') || parsed.type === 'image') {
                                   return (
-                                    <EncryptedImage
-                                      url={parsed.url}
-                                      sharedSecret={chatSharedSecret}
-                                      mimeType={parsed.mimeType}
-                                      alt={parsed.name}
-                                      className={mt.startsWith('video/')
-                                        ? 'max-w-[320px] max-h-[320px] rounded-lg'
-                                        : 'max-w-[240px] max-h-[240px] rounded-lg object-contain'}
-                                    />
+                                    <div className="relative">
+                                      <EncryptedImage
+                                        url={parsed.url}
+                                        sharedSecret={chatSharedSecret}
+                                        mimeType={parsed.mimeType}
+                                        alt={parsed.name}
+                                        className={mt.startsWith('video/')
+                                          ? 'max-w-[320px] max-h-[320px] rounded-lg'
+                                          : 'max-w-[240px] max-h-[240px] rounded-lg object-contain'}
+                                      />
+                                      {bubbleTime && (
+                                        <span className={`absolute bottom-1 right-1 px-1.5 py-0.5 rounded text-[11px] font-medium whitespace-nowrap ${bubbleTimePillClass}`}>
+                                          <span className="inline-flex items-center gap-1">
+                                            {bubbleTime}
+                                            <HiOutlineLockClosed className="w-3 h-3 text-green-400" />
+                                          </span>
+                                        </span>
+                                      )}
+                                    </div>
                                   )
                                 }
                                 // Generic file
                                 return (
-                                  <div className="flex items-center gap-2 p-2 rounded bg-black/20">
-                                    <HiOutlinePaperClip className="w-4 h-4 flex-shrink-0" />
-                                    <span className="text-xs truncate">{parsed.name}</span>
-                                    <span className="text-xs text-white/30">{(parsed.size / 1024).toFixed(0)}KB</span>
+                                  <div className="grid grid-cols-[1fr_auto] items-end gap-2 min-w-0">
+                                    <div className="flex items-center gap-2 p-2 rounded bg-black/20 min-w-0">
+                                      <HiOutlinePaperClip className="w-4 h-4 flex-shrink-0" />
+                                      <span className="text-xs truncate">{parsed.name}</span>
+                                      <span className="text-xs text-white/30 flex-shrink-0">{(parsed.size / 1024).toFixed(0)}KB</span>
+                                    </div>
+                                    {bubbleTime && (
+                                      <span className={`text-[11px] font-medium whitespace-nowrap inline-flex items-center gap-1 ${bubbleTimeTextClass}`}>
+                                        {bubbleTime}
+                                        <HiOutlineLockClosed className="w-3 h-3 text-green-400" />
+                                      </span>
+                                    )}
                                   </div>
                                 )
                               }
@@ -1597,15 +1712,38 @@ const MessagesPage: React.FC = () => {
                             const trimmed = messageContent.trim()
                             if (imageUrlPattern.test(trimmed) || giphyPattern.test(trimmed)) {
                               return (
-                                <img
-                                  src={trimmed}
-                                  alt="Shared image"
-                                  className="max-w-[240px] max-h-[240px] rounded-lg object-contain"
-                                  loading="lazy"
-                                />
+                                <div className="relative">
+                                  <img
+                                    src={trimmed}
+                                    alt="Shared image"
+                                    className="max-w-[240px] max-h-[240px] rounded-lg object-contain"
+                                    loading="lazy"
+                                  />
+                                  {bubbleTime && (
+                                    <span className={`absolute bottom-1 right-1 px-1.5 py-0.5 rounded text-[11px] font-medium whitespace-nowrap ${bubbleTimePillClass}`}>
+                                      <span className="inline-flex items-center gap-1">
+                                        {bubbleTime}
+                                        <HiOutlineLockClosed className="w-3 h-3 text-green-400" />
+                                      </span>
+                                    </span>
+                                  )}
+                                </div>
                               )
                             }
-                            return <p className={`${emojiOnlyTextClass(messageContent)} whitespace-pre-wrap`}>{messageContent}</p>
+
+                            return (
+                              <div className="grid grid-cols-[1fr_auto] items-end gap-2 min-w-0">
+                                <p className={`${emojiOnlyTextClass(messageContent)} whitespace-pre-wrap break-words min-w-0`}>
+                                  {messageContent}
+                                </p>
+                                {bubbleTime && (
+                                  <span className={`text-[11px] font-medium whitespace-nowrap inline-flex items-center gap-1 ${bubbleTimeTextClass}`}>
+                                    {bubbleTime}
+                                    <HiOutlineLockClosed className="w-3 h-3 text-green-400" />
+                                  </span>
+                                )}
+                              </div>
+                            )
                           })()}
 
                           {/* Edited indicator */}
@@ -1629,6 +1767,7 @@ const MessagesPage: React.FC = () => {
                               ))}
                             </div>
                           )}
+
                           </>
                           )}
                           </div>
@@ -1648,6 +1787,9 @@ const MessagesPage: React.FC = () => {
                               onOpenPicker={() => setEmojiPickerForMessage(message.id)}
                               onOpenCustomize={() => setShowCustomizeReactions(true)}
                               alignRight={message.isFromCurrentUser}
+                              anchor="bubble"
+                              open={reactionStripForMessage === message.id}
+                              onOpenChange={(nextOpen) => setReactionStripForMessage(nextOpen ? message.id : null)}
                             />
                           )}
 
@@ -1699,30 +1841,6 @@ const MessagesPage: React.FC = () => {
                         )}
                         </>
                         )}
-
-                        {/* Message metadata with encryption indicator */}
-                        <div className={`mt-1 px-2 flex items-center space-x-2 ${
-                          message.isFromCurrentUser ? 'flex-row-reverse space-x-reverse' : 'flex-row'
-                        }`}>
-                          <div className="flex items-center space-x-1">
-                            {/* Encryption indicator */}
-                            <Tooltip text="End-to-end encrypted" position={message.isFromCurrentUser ? 'left' : 'right'} forceBlack compact>
-                              <HiOutlineLockClosed className="w-3 h-3 text-green-400" />
-                            </Tooltip>
-
-                          </div>
-
-                          <Tooltip
-                            text={new Date(message.createdAt).toLocaleString()}
-                            position="bottom"
-                            forceBlack
-                            compact
-                          >
-                            <p className="text-xs text-white/50 font-medium">
-                              {formatMessageTime(message.createdAt)}
-                            </p>
-                          </Tooltip>
-                        </div>
 
                         {/* Seen indicator — shown below the last message the peer has read */}
                         {message.id === lastSeenMsgId && (

--- a/client/src/services/FrontEnd/src/pages/MutedContent.tsx
+++ b/client/src/services/FrontEnd/src/pages/MutedContent.tsx
@@ -467,7 +467,7 @@ const MutedContentPage: React.FC = () => {
                       }`}>
                         <div className={`text-sm pt-3 ${isDark ? 'text-white/80' : 'text-gray-700'}`}>
                           {post.content ? (
-                            <ContentWithHashtags content={post.content} />
+                            <ContentWithHashtags content={post.content} postId={post.id} />
                           ) : (
                             <span className="italic opacity-50">No content</span>
                           )}

--- a/client/src/services/FrontEnd/src/pages/Profile/New.tsx
+++ b/client/src/services/FrontEnd/src/pages/Profile/New.tsx
@@ -627,6 +627,20 @@ console.log("BALANCE:", balance)
                 >
                   Need more CAW? Click here.
                 </a>
+
+                <div className="mt-3">
+                  <Link
+                    to="/faucet"
+                    className={`inline-flex items-center justify-center px-4 py-2 rounded-full text-sm font-semibold transition-colors cursor-pointer ${
+                      isDark
+                        ? 'bg-yellow-500/15 text-yellow-400 hover:bg-yellow-500/25'
+                        : 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200'
+                    }`}
+                  >
+                    Claim more mCAW
+                  </Link>
+                </div>
+
                 <Link to="/usernames" className="block mt-2 text-sm text-gray-400 hover:text-gray-300 transition-colors">
                   Username Marketplace &rarr;
                 </Link>

--- a/client/src/services/FrontEnd/src/pages/Scheduled.tsx
+++ b/client/src/services/FrontEnd/src/pages/Scheduled.tsx
@@ -4,7 +4,7 @@ import MainLayout from '~/layouts/MainLayout'
 import { useTheme } from '~/hooks/useTheme'
 import { useAccount } from "wagmi"
 import { useConnectModal } from "@rainbow-me/rainbowkit"
-import { HiOutlineClock, HiOutlineTrash, HiOutlineCheck, HiOutlineXCircle, HiChevronDown, HiChevronRight, HiOutlineInformationCircle } from "react-icons/hi"
+import { HiOutlineClock, HiOutlineTrash, HiOutlineCheck, HiOutlineXCircle, HiChevronDown, HiChevronRight, HiOutlineInformationCircle, HiOutlineEye, HiOutlinePhotograph, HiOutlineX } from "react-icons/hi"
 import { useActiveToken } from '~/store/tokenDataStore'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '~/api/client'
@@ -20,6 +20,7 @@ interface ScheduledCaw {
   scheduledAt: string
   status: 'pending' | 'published' | 'failed' | 'cancelled'
   publishedId: number | null
+  imageData?: string | null
   hasImage: boolean
   createdAt: string
   threadId: string | null
@@ -38,6 +39,82 @@ interface ScheduledCaw {
 type Row =
   | { kind: 'single'; item: ScheduledCaw }
   | { kind: 'thread'; threadId: string; items: ScheduledCaw[] }
+
+// Minimal media URL detection (mirrors ContentWithHashtags patterns) so the
+// Scheduled list can stay compact even when content includes media URLs.
+const SHORT_URL_WITH_MEDIA_EXT = /(?:https?:\/\/[^\s]+)?\/s\/[a-zA-Z0-9]+\.(?:gif|jpg|jpeg|png|webp|mp4|webm|mov)\b/gi
+const SHORT_URL_WITH_MEDIA_EXT_TEST = /(?:https?:\/\/[^\s]+)?\/s\/[a-zA-Z0-9]+\.(?:gif|jpg|jpeg|png|webp|mp4|webm|mov)\b/i
+const DIRECT_IMAGE_URL = /https?:\/\/[^\s<>"{}|\\^`\[\]]+\.(?:gif|jpg|jpeg|png|webp)(?:\?[^\s<>"{}|\\^`\[\]]*)?/gi
+const DIRECT_IMAGE_URL_TEST = /https?:\/\/[^\s<>"{}|\\^`\[\]]+\.(?:gif|jpg|jpeg|png|webp)(?:\?[^\s<>"{}|\\^`\[\]]*)?/i
+
+function hasMediaInContent(content: string): boolean {
+  return SHORT_URL_WITH_MEDIA_EXT_TEST.test(content) || DIRECT_IMAGE_URL_TEST.test(content)
+}
+
+function stripMediaFromContent(content: string): string {
+  // Remove media URLs (keep other links as-is).
+  const withoutMedia = content
+    .replace(SHORT_URL_WITH_MEDIA_EXT, '')
+    .replace(DIRECT_IMAGE_URL, (m) => (m.includes('/s/') ? m : ''))
+  return withoutMedia
+    .replace(/[ \t]+/g, ' ')
+    .replace(/^ +/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+function ScheduledMedia({ imageData }: { imageData?: string | null }) {
+  if (!imageData) return null
+
+  const renderGrid = (urls: string[], kind: 'url' | 'base64') => {
+    const count = urls.length
+    if (count <= 0) return null
+
+    const gridClass =
+      count === 1
+        ? 'w-full'
+        : count === 2
+          ? 'grid grid-cols-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
+          : 'grid grid-cols-2 grid-rows-2 gap-1.5 aspect-video rounded-lg overflow-hidden'
+
+    const cellClass = (i: number) => (count === 3 && i === 0 ? 'row-span-2 w-full h-full' : 'w-full h-full')
+
+    if (count === 1) {
+      const src = kind === 'base64' ? `data:image/jpeg;base64,${urls[0]}` : urls[0]
+      return (
+        <div className="w-full rounded-lg overflow-hidden">
+          <img src={src} alt="Scheduled media" className="block w-full max-h-96 h-auto object-contain" />
+        </div>
+      )
+    }
+
+    return (
+      <div className={gridClass}>
+        {urls.slice(0, 4).map((u, idx) => {
+          const src = kind === 'base64' ? `data:image/jpeg;base64,${u}` : u
+          return (
+            <div key={idx} className={`relative w-full h-full overflow-hidden ${cellClass(idx)}`}>
+              <img src={src} alt={`Scheduled media ${idx + 1}`} className="block w-full h-full object-cover" />
+              {urls.length > 4 && idx === 3 && (
+                <div className="absolute inset-0 bg-black/50 flex items-center justify-center text-white text-xl font-semibold pointer-events-none">
+                  +{urls.length - 4}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+
+  if (imageData.startsWith('urls:')) {
+    const urls = imageData.replace('urls:', '').split('|||').filter(Boolean)
+    return <div className="mb-3">{renderGrid(urls, 'url')}</div>
+  }
+
+  const images = imageData.split('|||').filter(Boolean)
+  return <div className="mb-3">{renderGrid(images, 'base64')}</div>
+}
 
 // Bucket the API response into rows: single posts stay as-is; chunks sharing a
 // threadId collapse into one thread row anchored on chunk 0's scheduled time.
@@ -70,6 +147,7 @@ const ScheduledPage: React.FC = () => {
   const { isDark } = useTheme()
   const [activeTab, setActiveTab] = useState<'pending' | 'published' | 'failed'>('pending')
   const [expandedThreads, setExpandedThreads] = useState<Set<string>>(new Set())
+  const [previewRow, setPreviewRow] = useState<Row | null>(null)
   const toggleThread = (threadId: string) => {
     setExpandedThreads(prev => {
       const next = new Set(prev)
@@ -281,10 +359,19 @@ const ScheduledPage: React.FC = () => {
               }`
               if (row.kind === 'single') {
                 const item = row.item
+                const hasMedia = item.hasImage || !!item.imageData || hasMediaInContent(item.content)
+                const displayText = stripMediaFromContent(item.content)
                 return (
                   <div key={item.id} className={cardClass}>
-                    <div className={`mb-3 ${isDark ? 'text-white' : 'text-black'}`}>
-                      <ContentWithHashtags content={item.content} />
+                    <div className="flex items-start justify-between gap-3 mb-3">
+                      <div className={`min-w-0 flex-1 text-sm leading-snug whitespace-pre-wrap break-words line-clamp-3 ${isDark ? 'text-white' : 'text-black'}`}>
+                        {displayText || <span className={isDark ? 'text-white/50' : 'text-black/50'}>(no text)</span>}
+                      </div>
+                      {hasMedia && (
+                        <div className={`mt-0.5 flex-shrink-0 ${isDark ? 'text-white/50' : 'text-black/40'}`} title="Has media">
+                          <HiOutlinePhotograph className="w-5 h-5" />
+                        </div>
+                      )}
                     </div>
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
@@ -293,28 +380,43 @@ const ScheduledPage: React.FC = () => {
                           {getStatusText(item)}
                         </span>
                       </div>
-                      {item.status === 'pending' && (
-                        <button
-                          onClick={() => cancelMutation.mutate(item.id)}
-                          disabled={cancelMutation.isPending}
-                          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors ${
-                            isDark ? 'text-red-400 hover:bg-red-500/20' : 'text-red-600 hover:bg-red-50'
-                          } ${cancelMutation.isPending ? 'opacity-50 cursor-not-allowed' : ''}`}
-                        >
-                          <HiOutlineTrash className="w-4 h-4" />
-                          Cancel
-                        </button>
-                      )}
-                      {item.status === 'published' && item.publishedId && (
-                        <Link
-                          to={`/caws/${item.publishedId}`}
-                          className={`text-sm px-3 py-1.5 rounded-full transition-colors ${
-                            isDark ? 'text-yellow-400 hover:bg-yellow-500/20' : 'text-yellow-600 hover:bg-yellow-50'
-                          }`}
-                        >
-                          View Post
-                        </Link>
-                      )}
+                      <div className="flex items-center gap-2">
+                        {(item.status === 'pending' || item.status === 'failed') && (
+                          <button
+                            type="button"
+                            onClick={() => setPreviewRow({ kind: 'single', item })}
+                            className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors cursor-pointer ${
+                              isDark ? 'text-gray-200 hover:bg-white/10' : 'text-gray-700 hover:bg-gray-100'
+                            }`}
+                          >
+                            <HiOutlineEye className="w-4 h-4" />
+                            View
+                          </button>
+                        )}
+                        {item.status === 'pending' && (
+                          <button
+                            type="button"
+                            onClick={() => cancelMutation.mutate(item.id)}
+                            disabled={cancelMutation.isPending}
+                            className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors ${
+                              isDark ? 'text-red-400 hover:bg-red-500/20' : 'text-red-600 hover:bg-red-50'
+                            } ${cancelMutation.isPending ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                          >
+                            <HiOutlineTrash className="w-4 h-4" />
+                            Cancel
+                          </button>
+                        )}
+                        {item.status === 'published' && item.publishedId && (
+                          <Link
+                            to={`/caws/${item.publishedId}`}
+                            className={`text-sm px-3 py-1.5 rounded-full transition-colors ${
+                              isDark ? 'text-yellow-400 hover:bg-yellow-500/20' : 'text-yellow-600 hover:bg-yellow-50'
+                            }`}
+                          >
+                            View Post
+                          </Link>
+                        )}
+                      </div>
                     </div>
                   </div>
                 )
@@ -325,6 +427,8 @@ const ScheduledPage: React.FC = () => {
               // (the API cascade-cancels every still-pending chunk by threadId).
               const expanded = expandedThreads.has(row.threadId)
               const head = row.items[0]
+              const threadHasMedia = row.items.some(it => it.hasImage || !!it.imageData || hasMediaInContent(it.content))
+              const headDisplayText = stripMediaFromContent(head.content)
               const total = head.threadTotal ?? row.items.length
               // Status to display for the thread as a whole: any failed → failed,
               // else any pending → pending, else any cancelled → cancelled, else published.
@@ -348,10 +452,21 @@ const ScheduledPage: React.FC = () => {
                   </button>
 
                   <div className={`mb-3 ${isDark ? 'text-white' : 'text-black'}`}>
-                    <ContentWithHashtags content={head.content} />
+                    <div className="flex items-start justify-between gap-3">
+                      <div className={`min-w-0 flex-1 text-sm leading-snug whitespace-pre-wrap break-words line-clamp-3 ${isDark ? 'text-white' : 'text-black'}`}>
+                        {headDisplayText || <span className={isDark ? 'text-white/50' : 'text-black/50'}>(no text)</span>}
+                      </div>
+                      {threadHasMedia && (
+                        <div className={`mt-0.5 flex-shrink-0 ${isDark ? 'text-white/50' : 'text-black/40'}`} title="Has media">
+                          <HiOutlinePhotograph className="w-5 h-5" />
+                        </div>
+                      )}
+                    </div>
                   </div>
 
-                  {expanded && row.items.slice(1).map((chunk, idx) => (
+                  {expanded && row.items.slice(1).map((chunk, idx) => {
+                    const chunkDisplayText = stripMediaFromContent(chunk.content)
+                    return (
                     <div
                       key={chunk.id}
                       className={`mt-3 pt-3 border-t ${isDark ? 'border-white/10 text-white' : 'border-gray-200 text-black'}`}
@@ -359,9 +474,11 @@ const ScheduledPage: React.FC = () => {
                       <div className={`text-[11px] mb-1 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
                         {idx + 2} / {total}
                       </div>
-                      <ContentWithHashtags content={chunk.content} />
+                      <div className={`text-sm leading-snug whitespace-pre-wrap break-words line-clamp-3 ${isDark ? 'text-white' : 'text-black'}`}>
+                        {chunkDisplayText || <span className={isDark ? 'text-white/50' : 'text-black/50'}>(no text)</span>}
+                      </div>
                     </div>
-                  ))}
+                  )})}
 
                   <div className="flex items-center justify-between mt-3">
                     <div className="flex items-center gap-2">
@@ -370,32 +487,132 @@ const ScheduledPage: React.FC = () => {
                         {getStatusText(headForStatus)}
                       </span>
                     </div>
-                    {aggregateStatus === 'pending' && (
-                      <button
-                        onClick={() => cancelMutation.mutate(head.id)}
-                        disabled={cancelMutation.isPending}
-                        className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors ${
-                          isDark ? 'text-red-400 hover:bg-red-500/20' : 'text-red-600 hover:bg-red-50'
-                        } ${cancelMutation.isPending ? 'opacity-50 cursor-not-allowed' : ''}`}
-                      >
-                        <HiOutlineTrash className="w-4 h-4" />
-                        Cancel thread
-                      </button>
-                    )}
-                    {aggregateStatus === 'published' && head.publishedId && (
-                      <Link
-                        to={`/caws/${head.publishedId}`}
-                        className={`text-sm px-3 py-1.5 rounded-full transition-colors ${
-                          isDark ? 'text-yellow-400 hover:bg-yellow-500/20' : 'text-yellow-600 hover:bg-yellow-50'
-                        }`}
-                      >
-                        View Thread
-                      </Link>
-                    )}
+                    <div className="flex items-center gap-2">
+                      {(aggregateStatus === 'pending' || aggregateStatus === 'failed') && (
+                        <button
+                          type="button"
+                          onClick={() => setPreviewRow({ kind: 'thread', threadId: row.threadId, items: row.items })}
+                          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors cursor-pointer ${
+                            isDark ? 'text-gray-200 hover:bg-white/10' : 'text-gray-700 hover:bg-gray-100'
+                          }`}
+                        >
+                          <HiOutlineEye className="w-4 h-4" />
+                          View
+                        </button>
+                      )}
+                      {aggregateStatus === 'pending' && (
+                        <button
+                          type="button"
+                          onClick={() => cancelMutation.mutate(head.id)}
+                          disabled={cancelMutation.isPending}
+                          className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-colors ${
+                            isDark ? 'text-red-400 hover:bg-red-500/20' : 'text-red-600 hover:bg-red-50'
+                          } ${cancelMutation.isPending ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                        >
+                          <HiOutlineTrash className="w-4 h-4" />
+                          Cancel thread
+                        </button>
+                      )}
+                      {aggregateStatus === 'published' && head.publishedId && (
+                        <Link
+                          to={`/caws/${head.publishedId}`}
+                          className={`text-sm px-3 py-1.5 rounded-full transition-colors ${
+                            isDark ? 'text-yellow-400 hover:bg-yellow-500/20' : 'text-yellow-600 hover:bg-yellow-50'
+                          }`}
+                        >
+                          View Thread
+                        </Link>
+                      )}
+                    </div>
                   </div>
                 </div>
               )
             })}
+          </div>
+        )}
+
+        {previewRow && (
+          <div className="fixed inset-0 z-[80]">
+            <div className="absolute inset-0 bg-black/60" />
+
+            {/* Align to the app's 3-column shell (sidebar/main/trending) so the modal
+                doesn't feel off-center on wide desktops. */}
+            <div
+              className="absolute inset-0 flex items-center justify-center"
+              onMouseDown={(e) => {
+                if (e.target === e.currentTarget) setPreviewRow(null)
+              }}
+              onTouchStart={(e) => {
+                if (e.target === e.currentTarget) setPreviewRow(null)
+              }}
+            >
+              <div className="w-full max-w-[1050px] mx-auto px-6 flex">
+                <div className="hidden md:block w-[200px]" />
+                <div className="flex-1 flex justify-center">
+                  <div
+                    className={`relative z-10 w-full max-w-lg rounded-2xl border shadow-xl ${
+                      isDark ? 'bg-black border-white/10' : 'bg-white border-gray-200'
+                    }`}
+                  >
+                    <div className={`p-4 border-b ${isDark ? 'border-white/10' : 'border-gray-200'} flex items-center justify-between`}>
+                <div>
+                  <div className={`text-sm font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    Preview
+                  </div>
+                  <div className={`text-xs mt-0.5 ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                    {previewRow.kind === 'single'
+                      ? getStatusText(previewRow.item)
+                      : `Thread (${previewRow.items[0].threadTotal ?? previewRow.items.length} posts) • ${getStatusText({ ...previewRow.items[0], status: previewRow.items.find(i => i.status === 'failed')?.status ?? previewRow.items.find(i => i.status === 'pending')?.status ?? previewRow.items.find(i => i.status === 'cancelled')?.status ?? 'published' })}`}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setPreviewRow(null)}
+                  aria-label="Close preview"
+                  className={`p-2 rounded-full transition-colors cursor-pointer ${
+                    isDark ? 'text-white/70 hover:bg-white/10' : 'text-gray-700 hover:bg-gray-100'
+                  }`}
+                >
+                  <HiOutlineX className="w-5 h-5" />
+                </button>
+                    </div>
+
+                    <div className="p-4 max-h-[70vh] overflow-y-auto">
+                      {previewRow.kind === 'single' ? (
+                        <div className={isDark ? 'text-white' : 'text-black'}>
+                          <ScheduledMedia imageData={previewRow.item.imageData} />
+                          <ContentWithHashtags
+                            content={previewRow.item.content}
+                            renderMedia={!previewRow.item.imageData}
+                          />
+                        </div>
+                      ) : (
+                        <div className="space-y-4">
+                          {previewRow.items.map((chunk, idx) => (
+                            <div key={chunk.id}>
+                              <div className={`text-[11px] mb-1 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}>
+                                {idx + 1} / {previewRow.items[0].threadTotal ?? previewRow.items.length}
+                              </div>
+                              <div className={isDark ? 'text-white' : 'text-black'}>
+                                <ScheduledMedia imageData={chunk.imageData} />
+                                <ContentWithHashtags
+                                  content={chunk.content}
+                                  renderMedia={!chunk.imageData}
+                                />
+                              </div>
+                              {idx !== previewRow.items.length - 1 && (
+                                <div className={`mt-4 border-t ${isDark ? 'border-white/10' : 'border-gray-200'}`} />
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="hidden lg:block w-[280px]" />
+              </div>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Scheduled posts
- Upload images at schedule time and persist resulting URLs in `content` (matches immediate-post behavior).
- Prefer GIF `shortUrl` when available.
- Block scheduled video uploads with a clear error message.
- Respect `mediaPosition === 'end'` for threads, including chunk handling and indicators.

Scheduled list + preview
- Make scheduled list cards compact (no inline media); show a media icon when media is detected.
- Strip media URLs from list snippets to avoid leaking raw links.
- Preview modal: replace “Close” with an X and allow backdrop click/tap to close.

Media modal (CawMediaModal)
- Show navigation arrows on mobile.
- Allow backdrop click/tap to close without click-through to the feed.

Notifications UI
- Improve readability: bolder actor, better dark-mode contrast, inline timestamp, slightly larger avatars.

DMs (Messages)
- Remove redundant “about X ago” lines; move to compact, X-style timestamps inside bubbles.
- Restore the green lock icon next to the timestamp (text + media bubbles).
- Reduce spacing between consecutive own messages (same sender within 5 minutes).
- Fix chat header/encryption banner scrolling by correcting flex/overflow layout so only the message list scrolls.
- Centralize mobile header height via `--app-mobile-header-h` in `MainLayout` and consume it in `Messages`; add overscroll containment to reduce scroll chaining.