### PR TITLE
Frontend UX Polish: Profile Chooser, Usernames “My Profiles”, Menus, and Mobile Pickers

### DIFF
--- a/client/src/services/FrontEnd/src/components/FeedItem.tsx
+++ b/client/src/services/FrontEnd/src/components/FeedItem.tsx
@@ -552,10 +552,18 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
       return
     }
 
-    // Open modal with onSuccess callback to set pending state.
     // For plain recaws, reply to the original post (useItem), not the recaw wrapper.
     // Quotes act as their own posts, so reply to the quote itself (item).
     const replyTarget = (isRecaw && !isQuote) ? useItem : item
+
+    // Desktop UX: navigate to the post page to reply inline.
+    // Mobile UX stays modal for now.
+    if (typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches) {
+      navigate(`/caws/${replyTarget.id}?reply=1`)
+      return
+    }
+
+    // Mobile: open modal with onSuccess callback to set pending state.
     openModal('comment', replyTarget, () => {
       setReplyPending(true)
       setReplyCountAdj(1)

--- a/client/src/services/FrontEnd/src/components/PollComposer.tsx
+++ b/client/src/services/FrontEnd/src/components/PollComposer.tsx
@@ -175,7 +175,7 @@ const PollComposer: React.FC<Props> = ({
           return (
             <div
               key={i}
-              className={`flex items-center gap-2 rounded-lg transition-colors ${
+              className={`flex items-center gap-2 rounded-lg transition-colors min-w-0 ${
                 isDragging
                   ? (isDark ? 'ring-2 ring-yellow-400/60 bg-yellow-400/5' : 'ring-2 ring-yellow-500 bg-yellow-50')
                   : ''
@@ -259,7 +259,7 @@ const PollComposer: React.FC<Props> = ({
                 placeholder={`Option ${i + 1}`}
                 maxLength={optionByteCap * 2 /* generous: real check is byteLen */}
                 style={{ height: 50 }}
-                className={`flex-1 px-3 rounded-lg text-base outline-none border ${
+                className={`flex-1 min-w-0 w-full px-3 rounded-lg text-base outline-none border ${
                   overByte
                     ? 'border-red-500'
                     : isDark
@@ -267,14 +267,14 @@ const PollComposer: React.FC<Props> = ({
                       : 'bg-white border-gray-200 focus:border-yellow-500 text-gray-900'
                 }`}
               />
-              <span className={`text-[10px] tabular-nums w-8 text-right ${
+              <span className={`flex-shrink-0 text-[10px] tabular-nums w-8 text-right ${
                 overByte ? 'text-red-500' : isDark ? 'text-white/30' : 'text-gray-400'
               }`}>
                 {remaining}
               </span>
               <button
                 onClick={() => removeOption(i)}
-                className={`p-1 rounded transition-colors ${
+                className={`p-1 rounded transition-colors flex-shrink-0 ${
                   isDark ? 'text-white/30 hover:text-white/60' : 'text-gray-400 hover:text-gray-600'
                 }`}
                 aria-label="Remove option"

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef, useEffect, useLayoutEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { useSignAndSubmitAction, buildTypedData, TYPES, setLocalCawonceFloor } from '../api/actions'
 
@@ -384,6 +384,13 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
   const [isDragOverTextarea, setIsDragOverTextarea] = useState(false)
   const [showGifPicker, setShowGifPicker] = useState(false)
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
+  type AnchorRect = { left: number; right: number; top: number; bottom: number }
+  const [emojiPopover, setEmojiPopover] = useState<null | {
+    x: number
+    y: number
+    anchor: AnchorRect
+  }>(null)
+  const emojiPopoverRef = useRef<HTMLDivElement>(null)
   const [showScheduler, setShowScheduler] = useState(false)
   const [scheduledDate, setScheduledDate] = useState('')
   const [scheduledTime, setScheduledTime] = useState('')
@@ -416,6 +423,44 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
   // signing is main-thread heavy, and React reconciliation would starve it.
   const signingCountRef1 = useRef<HTMLSpanElement | null>(null)
   const signingCountRef2 = useRef<HTMLSpanElement | null>(null)
+
+  // Mobile emoji picker should open near the emoji button, not glued to the bottom.
+  // We compute an initial position on click, then measure the panel and clamp
+  // before paint to avoid the "jump" glitch.
+  useLayoutEffect(() => {
+    if (!showEmojiPicker || !emojiPopover) return
+    const el = emojiPopoverRef.current
+    if (!el) return
+
+    const { width: panelW, height: panelH } = el.getBoundingClientRect()
+    const pad = 8
+    const gap = 8
+    const bounds = {
+      left: pad,
+      right: window.innerWidth - pad,
+      top: pad,
+      bottom: window.innerHeight - pad,
+    }
+
+    const a = emojiPopover.anchor
+    const anchorCx = (a.left + a.right) / 2
+    const xRaw = anchorCx - panelW / 2
+
+    const yBelow = a.bottom + gap
+    const yAbove = a.top - panelH - gap
+    const hasRoomBelow = yBelow + panelH <= bounds.bottom
+    const hasRoomAbove = yAbove >= bounds.top
+    const yRaw = hasRoomBelow
+      ? yBelow
+      : (hasRoomAbove ? yAbove : (a.top - panelH / 2))
+
+    const x = Math.min(Math.max(bounds.left, xRaw), bounds.right - panelW)
+    const y = Math.min(Math.max(bounds.top, yRaw), bounds.bottom - panelH)
+
+    if (Math.abs(x - emojiPopover.x) > 0.5 || Math.abs(y - emojiPopover.y) > 0.5) {
+      setEmojiPopover(prev => prev ? { ...prev, x, y } : prev)
+    }
+  }, [showEmojiPicker, emojiPopover])
   useEffect(() => {
     if (!signingTotal) return
     // Pace the full count-up to roughly 2s regardless of thread length; floor
@@ -1566,6 +1611,20 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
           </div>
 
+          {/* Poll composer (mobile) */}
+          {pollEnabled && (
+            <PollComposer
+              options={pollOptions}
+              onChange={setPollOptions}
+              optionImages={pollOptionImages}
+              onChangeImages={setPollOptionImages}
+              onClose={() => { setPollEnabled(false); setPollOptions([]); setPollOptionImages([]) }}
+              position={pollPosition}
+              onChangePosition={setPollPosition}
+              showPositionPicker={isThreadMode}
+            />
+          )}
+
           {/* Mobile Icons Row */}
           <div className={`flex items-center justify-between ${replyTo ? 'pt-0.5' : ''}`}>
             {/* Left side - media icons */}
@@ -1595,6 +1654,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                   if (gifDisabled) return
                   setShowGifPicker(!showGifPicker)
                   setShowEmojiPicker(false)
+                  setEmojiPopover(null)
                 }}
                 disabled={gifDisabled}
                 className={`px-3 py-1 rounded-full text-base font-medium transition-all duration-200 ${
@@ -1613,9 +1673,24 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
               {/* Emoji Picker */}
               <button
-                onClick={() => {
-                  setShowEmojiPicker(!showEmojiPicker)
+                onClick={(e) => {
+                  const willOpen = !showEmojiPicker
                   setShowGifPicker(false)
+                  setShowEmojiPicker(willOpen)
+                  if (willOpen) {
+                    const r = (e.currentTarget as HTMLElement).getBoundingClientRect()
+                    // First-pass position (centered under the button). We'll
+                    // measure + clamp in layoutEffect.
+                    const anchorCx = (r.left + r.right) / 2
+                    setEmojiPopover({
+                      anchor: { left: r.left, right: r.right, top: r.top, bottom: r.bottom },
+                      // left coordinate guess; refined after measuring.
+                      x: anchorCx - 180,
+                      y: r.bottom + 8,
+                    })
+                  } else {
+                    setEmojiPopover(null)
+                  }
                 }}
                 className={`p-1 rounded-full transition-all duration-200 cursor-pointer ${
                 text.trim()
@@ -1629,6 +1704,31 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
+              </button>
+
+              {/* Poll */}
+              <button
+                onClick={() => {
+                  if (pollEnabled) {
+                    setPollEnabled(false)
+                    setPollOptions([])
+                    setPollOptionImages([])
+                  } else {
+                    setPollEnabled(true)
+                    setPollOptions(['', ''])
+                    setPollOptionImages(['', ''])
+                  }
+                }}
+                aria-label={pollEnabled ? 'Remove poll' : 'Add poll'}
+                className={`p-1 rounded-full transition-all duration-200 cursor-pointer ${
+                  pollEnabled
+                    ? 'text-yellow-500 bg-yellow-400/10'
+                    : (isDark
+                      ? 'text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-400/10'
+                      : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50')
+                }`}
+              >
+                <HiOutlineChartBar className="w-5 h-5" />
               </button>
             </div>
 
@@ -1756,12 +1856,27 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
             {/* Backdrop */}
             <div
               className="fixed inset-0 z-40"
-              onClick={() => setShowEmojiPicker(false)}
+              onClick={() => {
+                setShowEmojiPicker(false)
+                setEmojiPopover(null)
+              }}
             />
-            {/* Floating panel — anchored above the composer so it doesn't push layout */}
+            {/* Floating panel — opens near the emoji button in mobile feed */}
             <div
-              className={`fixed left-1/2 -translate-x-1/2 w-[calc(100%-2rem)] z-50 rounded-xl shadow-2xl max-h-[40vh] overflow-auto ${isDark ? 'border border-white/10 bg-black' : 'border border-gray-200 bg-white'}`}
-              style={{ bottom: 'calc(var(--app-mobile-header-h, 4rem) + env(safe-area-inset-bottom))' }}
+              ref={emojiPopoverRef}
+              className={`fixed z-50 rounded-xl shadow-2xl max-h-[40vh] overflow-auto ${isDark ? 'border border-white/10 bg-black' : 'border border-gray-200 bg-white'}`}
+              style={emojiPopover
+                ? {
+                    left: emojiPopover.x,
+                    top: emojiPopover.y,
+                    width: 'min(360px, calc(100vw - 2rem))',
+                  }
+                : {
+                    left: '50%',
+                    transform: 'translateX(-50%)',
+                    width: 'calc(100% - 2rem)',
+                    bottom: 'calc(env(safe-area-inset-bottom) + 0.75rem)',
+                  }}
             >
               <div className="p-3">
                 <div className="grid grid-cols-6 gap-2">
@@ -1771,6 +1886,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                       onClick={() => {
                         setText(prev => prev + emoji)
                         setShowEmojiPicker(false)
+                        setEmojiPopover(null)
                       }}
                       className="p-1 text-2xl hover:bg-gray-200 dark:hover:bg-white/10 rounded transition-colors"
                     >
@@ -1983,9 +2099,9 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                     onClick={() => setShowGifPicker(false)}
                   />
 
-                  {/* Popover: opens upward on desktop */}
+                  {/* Popover: in feed composer open downward; in reply composer open upward */}
                   <div
-                    className="absolute z-50 bottom-full mb-2 left-1/2"
+                    className={`absolute z-50 left-1/2 ${replyTo ? 'bottom-full mb-2' : 'top-full mt-2'}`}
                     style={{
                       width: 'min(520px, calc(100vw - 2rem))',
                       transform: 'translateX(calc(-50% + 170px))',
@@ -2034,9 +2150,11 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                     onClick={() => setShowEmojiPicker(false)}
                   />
 
-                  {/* Popover: opens upward on desktop */}
+                  {/* Popover: in feed composer open downward; in reply composer open upward */}
                   <div
-                    className={`absolute z-50 bottom-full mb-2 left-1/2 p-3 border rounded-xl shadow-2xl ${
+                    className={`absolute z-50 left-1/2 p-3 border rounded-xl shadow-2xl ${
+                      replyTo ? 'bottom-full mb-2' : 'top-full mt-2'
+                    } ${
                       isDark ? 'border-white/10 bg-black' : 'border-gray-200 bg-white'
                     }`}
                     style={{ width: 'min(420px, calc(100vw - 2rem))', transform: 'translateX(calc(-50% + 140px))' }}

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -1591,7 +1591,11 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
               {/* GIF */}
               <button
-                onClick={() => !gifDisabled && setShowGifPicker(!showGifPicker)}
+                onClick={() => {
+                  if (gifDisabled) return
+                  setShowGifPicker(!showGifPicker)
+                  setShowEmojiPicker(false)
+                }}
                 disabled={gifDisabled}
                 className={`px-3 py-1 rounded-full text-base font-medium transition-all duration-200 ${
                 gifDisabled
@@ -1609,7 +1613,10 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
               {/* Emoji Picker */}
               <button
-                onClick={() => setShowEmojiPicker(!showEmojiPicker)}
+                onClick={() => {
+                  setShowEmojiPicker(!showEmojiPicker)
+                  setShowGifPicker(false)
+                }}
                 className={`p-1 rounded-full transition-all duration-200 cursor-pointer ${
                 text.trim()
                   ? (isDark
@@ -1723,35 +1730,57 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
         {/* Mobile GIF Picker */}
         {showGifPicker && (
-          <div className="mt-4">
-            <GifPicker
-              initialQuery={gifSearchQuery(text)}
-              onSelect={handleGifSelected}
-              onClose={() => setShowGifPicker(false)}
+          <>
+            {/* Backdrop */}
+            <div
+              className="fixed inset-0 z-40"
+              onClick={() => setShowGifPicker(false)}
             />
-          </div>
+            {/* Floating panel — anchored above the composer so it covers the post */}
+            <div
+              className={`fixed left-1/2 -translate-x-1/2 w-[calc(100%-2rem)] z-50 rounded-xl shadow-2xl max-h-[60vh] overflow-auto ${isDark ? 'border border-white/10 bg-black' : 'border border-gray-200 bg-white'}`}
+              style={{ bottom: 'calc(var(--app-mobile-header-h, 4rem) + env(safe-area-inset-bottom))' }}
+            >
+              <GifPicker
+                initialQuery={gifSearchQuery(text)}
+                onSelect={handleGifSelected}
+                onClose={() => setShowGifPicker(false)}
+              />
+            </div>
+          </>
         )}
 
         {/* Mobile Emoji Picker */}
         {showEmojiPicker && (
-          <div className={`mt-4 p-4 border rounded-lg ${
-            isDark ? 'border-white/20 bg-black' : 'border-gray-200 bg-gray-50'
-          }`}>
-            <div className="grid grid-cols-6 gap-2 max-h-32 overflow-y-auto">
-              {['😀', '😂', '🤣', '😊', '😍', '🤔', '😎', '🔥', '💯', '❤️', '👍', '👎'].map(emoji => (
-                <button
-                  key={emoji}
-                  onClick={() => {
-                    setText(prev => prev + emoji)
-                    setShowEmojiPicker(false)
-                  }}
-                  className="p-1 text-xl hover:bg-gray-200 dark:hover:bg-white/10 rounded transition-colors"
-                >
-                  {emoji}
-                </button>
-              ))}
+          <>
+            {/* Backdrop */}
+            <div
+              className="fixed inset-0 z-40"
+              onClick={() => setShowEmojiPicker(false)}
+            />
+            {/* Floating panel — anchored above the composer so it doesn't push layout */}
+            <div
+              className={`fixed left-1/2 -translate-x-1/2 w-[calc(100%-2rem)] z-50 rounded-xl shadow-2xl max-h-[40vh] overflow-auto ${isDark ? 'border border-white/10 bg-black' : 'border border-gray-200 bg-white'}`}
+              style={{ bottom: 'calc(var(--app-mobile-header-h, 4rem) + env(safe-area-inset-bottom))' }}
+            >
+              <div className="p-3">
+                <div className="grid grid-cols-6 gap-2">
+                  {['😀', '😂', '🤣', '😊', '😍', '🤔', '😎', '🔥', '💯', '❤️', '👍', '👎'].map(emoji => (
+                    <button
+                      key={emoji}
+                      onClick={() => {
+                        setText(prev => prev + emoji)
+                        setShowEmojiPicker(false)
+                      }}
+                      className="p-1 text-2xl hover:bg-gray-200 dark:hover:bg-white/10 rounded transition-colors"
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
+              </div>
             </div>
-          </div>
+          </>
         )}
       </div>
 
@@ -1820,38 +1849,11 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
           </div>
         )}
 
-        {/* GIF Picker */}
-        {showGifPicker && (
-          <div className="mt-4">
-            <GifPicker
-              initialQuery={gifSearchQuery(text)}
-              onSelect={handleGifSelected}
-              onClose={() => setShowGifPicker(false)}
-            />
-          </div>
-        )}
+        {/* GIF Picker (desktop) is rendered as a popover above the GIF button.
+            Keeping it inline pushes the whole page down, which feels broken on desktop. */}
 
-        {/* Emoji Picker */}
-        {showEmojiPicker && (
-          <div className={`mt-4 p-4 border rounded-lg ${
-            isDark ? 'border-white/20 bg-black' : 'border-gray-200 bg-gray-50'
-          }`}>
-            <div className="grid grid-cols-8 gap-2 max-h-48 overflow-y-auto">
-              {['😀', '😂', '🤣', '😊', '😍', '🤔', '😎', '🔥', '💯', '❤️', '👍', '👎', '👏', '🙏', '💪', '🚀'].map(emoji => (
-                <button
-                  key={emoji}
-                  onClick={() => {
-                    setText(prev => prev + emoji)
-                    setShowEmojiPicker(false)
-                  }}
-                  className="p-2 text-2xl hover:bg-gray-200 dark:hover:bg-white/10 rounded transition-colors"
-                >
-                  {emoji}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
+        {/* Emoji Picker (desktop) is rendered as a popover above the emoji button.
+            Keeping it inline pushes the whole page down, which feels broken on desktop. */}
 
         {/* Poll composer */}
         {pollEnabled && (
@@ -1947,39 +1949,116 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
             </button>
 
             {/* GIF */}
-            <button
-              onClick={() => !gifDisabled && setShowGifPicker(!showGifPicker)}
-              disabled={gifDisabled}
-              className={`p-2 rounded-full transition-all duration-200 ${
-              gifDisabled
-                ? 'opacity-30 cursor-not-allowed'
-                : `cursor-pointer ${text.trim()
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => {
+                  if (gifDisabled) return
+                  setShowGifPicker((v) => !v)
+                  setShowEmojiPicker(false)
+                }}
+                disabled={gifDisabled}
+                className={`p-2 rounded-full transition-all duration-200 ${
+                gifDisabled
+                  ? 'opacity-30 cursor-not-allowed'
+                  : `cursor-pointer ${text.trim()
+                    ? (isDark
+                        ? 'text-yellow-400 hover:text-yellow-300 hover:bg-yellow-400/10'
+                        : 'text-yellow-600 hover:text-yellow-500 hover:bg-yellow-200/50')
+                    : (isDark
+                        ? 'text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-400/10'
+                        : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50')}`
+              }`}
+                aria-haspopup="dialog"
+                aria-expanded={showGifPicker}
+              >
+                <span className="text-base font-medium">GIF</span>
+              </button>
+
+              {showGifPicker && (
+                <>
+                  {/* Backdrop: click outside closes */}
+                  <div
+                    className="fixed inset-0 z-40"
+                    onClick={() => setShowGifPicker(false)}
+                  />
+
+                  {/* Popover: opens upward on desktop */}
+                  <div
+                    className="absolute z-50 bottom-full mb-2 left-1/2"
+                    style={{
+                      width: 'min(520px, calc(100vw - 2rem))',
+                      transform: 'translateX(calc(-50% + 170px))',
+                    }}
+                  >
+                    <GifPicker
+                      initialQuery={gifSearchQuery(text)}
+                      onSelect={handleGifSelected}
+                      onClose={() => setShowGifPicker(false)}
+                    />
+                  </div>
+                </>
+              )}
+            </div>
+
+            {/* Emoji Picker */}
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowEmojiPicker(!showEmojiPicker)
+                  setShowGifPicker(false)
+                }}
+                className={`p-2 rounded-full transition-all duration-200 cursor-pointer ${
+                text.trim()
                   ? (isDark
                       ? 'text-yellow-400 hover:text-yellow-300 hover:bg-yellow-400/10'
                       : 'text-yellow-600 hover:text-yellow-500 hover:bg-yellow-200/50')
                   : (isDark
                       ? 'text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-400/10'
-                      : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50')}`
-            }`}>
-              <span className="text-base font-medium">GIF</span>
-            </button>
+                      : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50')
+              }`}
+                aria-haspopup="dialog"
+                aria-expanded={showEmojiPicker}
+              >
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </button>
 
-            {/* Emoji Picker */}
-            <button
-              onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-              className={`p-2 rounded-full transition-all duration-200 cursor-pointer ${
-              text.trim()
-                ? (isDark
-                    ? 'text-yellow-400 hover:text-yellow-300 hover:bg-yellow-400/10'
-                    : 'text-yellow-600 hover:text-yellow-500 hover:bg-yellow-200/50')
-                : (isDark
-                    ? 'text-yellow-400/70 hover:text-yellow-400 hover:bg-yellow-400/10'
-                    : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50')
-            }`}>
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </button>
+              {showEmojiPicker && (
+                <>
+                  {/* Backdrop: click outside closes */}
+                  <div
+                    className="fixed inset-0 z-40"
+                    onClick={() => setShowEmojiPicker(false)}
+                  />
+
+                  {/* Popover: opens upward on desktop */}
+                  <div
+                    className={`absolute z-50 bottom-full mb-2 left-1/2 p-3 border rounded-xl shadow-2xl ${
+                      isDark ? 'border-white/10 bg-black' : 'border-gray-200 bg-white'
+                    }`}
+                    style={{ width: 'min(420px, calc(100vw - 2rem))', transform: 'translateX(calc(-50% + 140px))' }}
+                  >
+                    <div className="grid grid-cols-8 gap-2 max-h-48 overflow-y-auto">
+                      {['😀', '😂', '🤣', '😊', '😍', '🤔', '😎', '🔥', '💯', '❤️', '👍', '👎', '👏', '🙏', '💪', '🚀'].map(emoji => (
+                        <button
+                          key={emoji}
+                          onClick={() => {
+                            setText(prev => prev + emoji)
+                            setShowEmojiPicker(false)
+                          }}
+                          className="p-2 text-2xl hover:bg-gray-200 dark:hover:bg-white/10 rounded transition-colors"
+                        >
+                          {emoji}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
 
             {/* Schedule Post (not for replies/quotes) */}
             {!replyTo && !quote && (

--- a/client/src/services/FrontEnd/src/components/ProfileChooser.tsx
+++ b/client/src/services/FrontEnd/src/components/ProfileChooser.tsx
@@ -16,6 +16,7 @@ import { useUserByUsername, useUserByToken } from '~/hooks/useUserData';
 import { getUserAvatar } from '~/utils/defaultAvatar';
 import Avatar from '~/components/Avatar';
 import { useQuickSignPromptStore } from '~/components/modals/QuickSignModal';
+import { HiOutlinePlus, HiUsers } from 'react-icons/hi'
 
 const ProfileChooser: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
   const { isConnected, address } = useAccount();
@@ -315,6 +316,23 @@ const ProfileChooser: React.FC<{ compact?: boolean }> = ({ compact = false }) =>
   if (normalizedAddress && (!visibleTokensByAddress[normalizedAddress] || visibleTokensByAddress[normalizedAddress].length == 0))
       visibleTokensByAddress[normalizedAddress] = [];
 
+  // Dropdown UX: show only the first 3 profiles, with a "See more" CTA when
+  // there are more. Keep it surgical: no new components, no refactors.
+  const MAX_DROPDOWN_PROFILES = 3
+  const totalDropdownProfiles = Object.values(visibleTokensByAddress).reduce((acc, list) => acc + (list?.length ?? 0), 0)
+  let remainingDropdownSlots = MAX_DROPDOWN_PROFILES
+  const limitedTokensByAddress: Record<string, TokenData[]> = {}
+  for (const [addrKey, list] of Object.entries(visibleTokensByAddress)) {
+    if (remainingDropdownSlots <= 0) break
+    const slice = (list || []).slice(0, remainingDropdownSlots)
+    if (slice.length > 0 || (list || []).length === 0) {
+      // Preserve empty connected-wallet group header if present (so the user
+      // still sees the address row + mismatch indicator).
+      limitedTokensByAddress[addrKey] = slice
+    }
+    remainingDropdownSlots -= slice.length
+  }
+
   // --- main render when tokens exist ---
   return (
     <div ref={dropdownRef} className="relative flex flex-col text-left left-[0%]">
@@ -429,7 +447,7 @@ const ProfileChooser: React.FC<{ compact?: boolean }> = ({ compact = false }) =>
                 }),
           }}
         >
-          {Object.entries(visibleTokensByAddress).map(([ownerAddress, tokenList]) => (
+          {Object.entries(limitedTokensByAddress).map(([ownerAddress, tokenList]) => (
             <li key={ownerAddress} className={`border-b transition-all duration-300 ${
               isDark ? 'border-gray-700' : 'border-gray-200'
             }`}>
@@ -480,14 +498,41 @@ const ProfileChooser: React.FC<{ compact?: boolean }> = ({ compact = false }) =>
               </ul>
             </li>
           ))}
+
+          {/* Manage profiles (only when we truncated the list) */}
+          {totalDropdownProfiles > MAX_DROPDOWN_PROFILES && (
+            <li className={`border-t ${isDark ? 'border-white/20' : 'border-gray-200'}`}>
+              <Link
+                to="/usernames?tab=mine"
+                state={{ scrollTo: 'my-profiles' }}
+                className={`cursor-pointer flex items-center gap-2 px-4 py-2 w-full text-left text-sm font-medium transition-all duration-200 ${
+                  isDark
+                    ? 'hover:bg-gray-800 text-yellow-400 hover:text-yellow-300'
+                    : 'hover:bg-gray-100 text-yellow-700 hover:text-yellow-800'
+                }`}
+              >
+                <HiUsers className="w-4 h-4 flex-shrink-0" />
+                <span>Manage my profiles</span>
+              </Link>
+            </li>
+          )}
+
           {/* Sticky footer: create new profile */}
           <li
-            className={`sticky bottom-0 z-10 text-xs text-center py-2 border-t ${
+            className={`sticky bottom-0 z-10 border-t ${
               isDark ? 'bg-black border-white/20' : 'bg-white border-gray-200'
             }`}
           >
-            <Link to={`/usernames/new`} className="block">
-              +Create new profile
+            <Link
+              to={`/usernames/new`}
+              className={`cursor-pointer flex items-center gap-2 px-4 py-2 w-full text-left text-sm font-medium transition-all duration-200 ${
+                isDark
+                  ? 'hover:bg-gray-800 text-white'
+                  : 'hover:bg-gray-100 text-black'
+              }`}
+            >
+              <HiOutlinePlus className={`w-4 h-4 flex-shrink-0 ${isDark ? 'text-white/70' : 'text-black/60'}`} />
+              <span>Create new profile</span>
             </Link>
           </li>
         </ul>

--- a/client/src/services/FrontEnd/src/components/ProfileChooser.tsx
+++ b/client/src/services/FrontEnd/src/components/ProfileChooser.tsx
@@ -411,7 +411,10 @@ const ProfileChooser: React.FC<{ compact?: boolean }> = ({ compact = false }) =>
 
       {isDropdownOpen && (
         <ul
-          className={`${compact ? 'absolute left-0 right-0 bottom-full mb-2 w-full max-w-full' : (window.innerWidth < 1350 ? 'fixed mt-2' : 'absolute mt-2')} rounded-md overflow-y-auto z-[9999] transition-all duration-300 max-h-[95vh] ${
+          className={`${compact
+            ? 'absolute left-0 right-0 bottom-full mb-2 w-full max-w-full sm:w-[340px] sm:max-w-[340px] sm:right-auto'
+            : (window.innerWidth < 1350 ? 'fixed mt-2' : 'absolute mt-2')
+          } rounded-md overflow-y-auto z-[9999] transition-all duration-300 max-h-[95vh] ${
             compact ? '' : 'max-w-[calc(100vw-20px)] w-[min(420px,calc(100vw-20px))]'
           } ${
             isDark ? 'bg-black border border-white/20' : 'bg-white border border-gray-200'

--- a/client/src/services/FrontEnd/src/components/marketplace/ProfileCard.tsx
+++ b/client/src/services/FrontEnd/src/components/marketplace/ProfileCard.tsx
@@ -5,7 +5,8 @@ import { themeTextMuted, themeBorder } from '~/utils/theme'
 import { convertToNumber, formatNumberCompact } from '~/utils'
 import { apiFetch } from '~/api/client'
 import UsernameSvg from '~/components/UsernameSvg'
-import { useTokenDataStore } from '~/store/tokenDataStore'
+import { useActiveToken, useTokenDataStore } from '~/store/tokenDataStore'
+import { HiOutlineEye, HiOutlineSwitchHorizontal } from 'react-icons/hi'
 
 type UserStats = { followerCount: number; cawCount: number; likeCount: number }
 
@@ -21,6 +22,13 @@ const ProfileCard: React.FC<Props> = ({ username, stats: externalStats, children
   const { isDark } = useTheme()
   const [stats, setStats] = useState<UserStats | null>(externalStats ?? null)
   const tokensByAddress = useTokenDataStore(s => s.tokensByAddress)
+  const setActiveTokenId = useTokenDataStore(s => s.setActiveTokenId)
+  const activeToken = useActiveToken()
+  const ownedToken = useMemo(
+    () => Object.values(tokensByAddress).flat().find(t => t.username === username),
+    [tokensByAddress, username]
+  )
+  const isActive = !!ownedToken?.tokenId && ownedToken.tokenId === activeToken?.tokenId
   const staked = useMemo(() => {
     const token = Object.values(tokensByAddress).flat().find(t => t.username === username)
     return token ? convertToNumber(token.stakedAmount, 18) : 0
@@ -44,13 +52,48 @@ const ProfileCard: React.FC<Props> = ({ username, stats: externalStats, children
         <div className="w-full max-w-[200px]">
           <UsernameSvg username={username} />
         </div>
-        <Link
-          to={`/users/${username}`}
-          onClick={e => e.stopPropagation()}
-          className={`text-xs mt-2 transition ${isDark ? 'text-gray-500 hover:text-gray-300' : 'text-gray-400 hover:text-gray-600'}`}
-        >
-          visit profile &rarr;
-        </Link>
+        {/* Action pills — centered as a group (mobile looks weird when
+            they hug the card edges). */}
+        <div className="mt-2 w-full flex items-center justify-center gap-2 flex-wrap">
+          {ownedToken && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                if (!ownedToken?.tokenId) return
+                setActiveTokenId(ownedToken.tokenId)
+              }}
+              disabled={isActive}
+              className={`text-xs px-2.5 py-1 rounded-full border border-yellow-500 transition cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
+                isDark
+                  ? 'bg-white/10 hover:bg-white/20 text-white'
+                  : 'bg-gray-100 hover:bg-gray-200 text-gray-900'
+              }`}
+              aria-label={isActive ? 'Active profile' : 'Switch to this profile'}
+              title={isActive ? 'Active' : 'Switch to this profile'}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <HiOutlineSwitchHorizontal className="w-4 h-4" />
+                {isActive ? 'Active' : 'Switch'}
+              </span>
+            </button>
+          )}
+
+          <Link
+            to={`/users/${username}`}
+            onClick={e => e.stopPropagation()}
+            className={`text-xs px-2.5 py-1 rounded-full transition cursor-pointer ${
+              isDark
+                ? 'bg-white/5 hover:bg-white/10 text-white/60 hover:text-white/80'
+                : 'bg-gray-100 hover:bg-gray-200 text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            <span className="inline-flex items-center gap-1.5">
+              <HiOutlineEye className="w-4 h-4" />
+              Visit profile
+            </span>
+          </Link>
+        </div>
       </div>
       <div className={`grid grid-cols-2 min-[370px]:max-[520px]:grid-cols-4 gap-3 px-5 py-4 border-t ${themeBorder(isDark)}`}>
         <div className="text-center">

--- a/client/src/services/FrontEnd/src/pages/CawPage.tsx
+++ b/client/src/services/FrontEnd/src/pages/CawPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { useParams, Link } from 'react-router-dom'
+import { useParams, Link, useSearchParams } from 'react-router-dom'
 import PostForm from "~/components/PostForm";
 import MainLayout from '~/layouts/MainLayout'
 import FeedItem from '~/components/FeedItem'
@@ -38,6 +38,7 @@ type TipIndicator = {
 
 export const CawPage: React.FC = () => {
   const { id } = useParams<{ id: string }>()
+  const [searchParams] = useSearchParams()
   const [caw, setCaw]           = useState<CawItem | null>(null)
   const [comments, setComments] = useState<CawItem[]>([])
   const [recaws, setRecaws]     = useState<RecawIndicator[]>([])
@@ -99,6 +100,23 @@ export const CawPage: React.FC = () => {
   const quotes = useMemo(() => comments.filter(isQuoteItem), [comments])
   const [showSignInModal, setShowSignInModal] = useState(false)
   const [pollingReplies, setPollingReplies] = useState(false)
+
+  // If we arrived from a desktop Reply click, scroll/focus the reply form.
+  useEffect(() => {
+    if (searchParams.get('reply') !== '1') return
+    if (!isAuthenticated) return
+    // Wait for PostForm to render.
+    requestAnimationFrame(() => {
+      const el = document.getElementById('caw-reply-form')
+      if (!el) return
+      el.scrollIntoView({ block: 'start', behavior: 'smooth' })
+      // Focus the first textarea inside the reply form.
+      setTimeout(() => {
+        const ta = el.querySelector('textarea') as HTMLTextAreaElement | null
+        ta?.focus()
+      }, 60)
+    })
+  }, [searchParams, isAuthenticated])
 
   // Function to refresh comments after posting a reply
   const refreshComments = async () => {
@@ -278,7 +296,7 @@ export const CawPage: React.FC = () => {
 
         {/* Reply Form — only for authenticated users */}
         {isAuthenticated && (
-          <div className="border-b border-white/20 mb-2">
+          <div id="caw-reply-form" className="border-b border-white/20 mb-2">
             <PostForm
               replyTo={caw}
               onSuccess={() => {

--- a/client/src/services/FrontEnd/src/pages/Marketplace.tsx
+++ b/client/src/services/FrontEnd/src/pages/Marketplace.tsx
@@ -10,7 +10,7 @@ import { useMarketplaceStore, MarketplaceListing, MarketplaceOffer } from '~/sto
 import ListingCard from '~/components/marketplace/ListingCard'
 import ListingFilters from '~/components/marketplace/ListingFilters'
 import SaleCard from '~/components/marketplace/SaleCard'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams, useLocation } from 'react-router-dom'
 import { formatAddress } from '~/utils'
 import ProfileCard from '~/components/marketplace/ProfileCard'
 import RefundsBanner from '~/components/marketplace/RefundsBanner'
@@ -41,6 +41,7 @@ const VALID_TABS: Tab[] = ['listings', 'sales', 'mine', 'offers']
 const Marketplace: React.FC = () => {
   const { isDark } = useTheme()
   const [searchParams, setSearchParams] = useSearchParams()
+  const location = useLocation() as any
   const tabParam = searchParams.get('tab') as Tab | null
   const [activeTab, setActiveTab] = useState<Tab>(
     tabParam && VALID_TABS.includes(tabParam) ? tabParam : 'listings'
@@ -62,6 +63,20 @@ const Marketplace: React.FC = () => {
       setSearchParams(searchParams, { replace: true })
     }
   }, [activeTab])
+
+  // If we navigated here from ProfileChooser "Manage my profiles",
+  // scroll the user down to the tabs (otherwise leave scroll untouched).
+  useEffect(() => {
+    const shouldScroll = location?.state?.scrollTo === 'my-profiles'
+    if (!shouldScroll) return
+    if (activeTab !== 'mine') return
+
+    // Wait a frame so layout is ready.
+    requestAnimationFrame(() => {
+      const el = document.getElementById('usernames-tabs')
+      el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    })
+  }, [activeTab, location?.state])
 
   // The offers badge intentionally does NOT clear on view — it tracks the
   // count of ACTIVE offers received and only drops when each offer is
@@ -131,7 +146,7 @@ const Marketplace: React.FC = () => {
           <RefundsBanner />
 
           {/* Tabs */}
-          <div className={`flex gap-1 mb-6 border-b ${themeBorder(isDark)}`}>
+          <div id="usernames-tabs" className={`flex gap-1 mb-6 border-b ${themeBorder(isDark)}`}>
             <TabButton active={activeTab === 'listings'} onClick={() => setActiveTab('listings')} isDark={isDark}>
               For Sale
             </TabButton>

--- a/client/src/services/FrontEnd/src/pages/Messages.tsx
+++ b/client/src/services/FrontEnd/src/pages/Messages.tsx
@@ -1,6 +1,6 @@
 import MainLayout from '~/layouts/MainLayout'
 import { useTheme } from '~/hooks/useTheme'
-import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback } from 'react'
 import { useAccount } from 'wagmi'
 import { useConnectModal } from '@rainbow-me/rainbowkit'
 import { useEnsureWallet } from '~/hooks/useEnsureWallet'
@@ -115,7 +115,19 @@ const MessagesPage: React.FC = () => {
   const [filePreview, setFilePreview] = useState<{ file: File; previewUrl: string; isImage: boolean } | null>(null)
   const [chatSharedSecret, setChatSharedSecret] = useState<CryptoKey | null>(null)
   const [chatReady, setChatReady] = useState(false)
-  const [contextMenu, setContextMenu] = useState<{ messageId: string; x: number; y: number; isOwn: boolean; createdAt: string } | null>(null)
+  type ContextMenuState = {
+    messageId: string
+    x: number
+    y: number
+    isOwn: boolean
+    createdAt: string
+    // Viewport-space rect of the bubble (numbers only so it's safe in state).
+    bubble: { left: number; right: number; top: number; bottom: number; height: number }
+    // Bounds we clamp within (center column), in viewport-space.
+    bounds: { left: number; right: number; top: number; bottom: number }
+  }
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
+  const contextMenuRef = useRef<HTMLDivElement>(null)
   // ID of the message we're replying to. Cleared on send, on Escape, or
   // when the user X's the chip. Sent as plaintext to the server alongside
   // the encrypted body — the server already knows the conversation graph,
@@ -139,6 +151,7 @@ const MessagesPage: React.FC = () => {
   const [targetUser, setTargetUser] = useState<{ tokenId: number, username: string } | null>(null)
   const [attemptedConversations, setAttemptedConversations] = useState<Set<string>>(new Set())
   const messagesContainerRef = useRef<HTMLDivElement>(null)
+  const composerTextareaRef = useRef<HTMLTextAreaElement>(null)
 
   // Auth state
   const { verify, isVerifying, error: verifyError } = useVerifyWallet()
@@ -476,6 +489,9 @@ const MessagesPage: React.FC = () => {
     const content = newMessageContent.trim()
     setNewMessageContent('')
     setShowEmojiPicker(false)
+    // Reset composer height after clearing content (mobile multiline can
+    // leave the inline style stuck at the previous scrollHeight).
+    if (composerTextareaRef.current) composerTextareaRef.current.style.height = 'auto'
     const replyTo = replyingToId
     setReplyingToId(null)
 
@@ -903,9 +919,41 @@ const MessagesPage: React.FC = () => {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [showChatOptionsMenu])
 
+  // After the context menu mounts, measure its real size and re-clamp.
+  // LayoutEffect => no visible "jump" (the glitch you saw on desktop).
+  // UX RULE: menu must be on the SAME ROW as the bubble, right next to it.
+  useLayoutEffect(() => {
+    if (!contextMenu) return
+    const el = contextMenuRef.current
+    if (!el) return
+
+    const { width: menuW, height: menuH } = el.getBoundingClientRect()
+    const pad = 8
+    const gap = 8
+    const { bubble, bounds } = contextMenu
+
+    // Own bubble is on the right => put menu to the left of bubble.
+    // Other bubble is on the left => put menu to the right of bubble.
+    const xRaw = contextMenu.isOwn
+      ? (bubble.left - gap - menuW)
+      : (bubble.right + gap)
+
+    // Same "row" as the bubble: vertically center with bubble.
+    const yRaw = bubble.top + (bubble.height - menuH) / 2
+
+    const x = Math.min(Math.max(bounds.left + pad, xRaw), bounds.right - pad - menuW)
+    const y = Math.min(Math.max(bounds.top + pad, yRaw), bounds.bottom - pad - menuH)
+
+    // Avoid an infinite loop: only update if it actually changed.
+    if (Math.abs(x - contextMenu.x) > 0.5 || Math.abs(y - contextMenu.y) > 0.5) {
+      setContextMenu(prev => prev ? { ...prev, x, y } : prev)
+    }
+  }, [contextMenu])
+
   return (
     <MainLayout>
       <div
+        data-messages-root
         className={`max-w-2xl mx-auto pt-4 pb-0 flex flex-col relative flex-1 min-h-0 ${
           currentView === 'chat' ? 'h-[calc(100dvh-var(--app-mobile-header-h))] md:h-screen' : ''
         } ${isDark ? 'bg-black' : 'bg-white'}`}
@@ -1553,7 +1601,8 @@ const MessagesPage: React.FC = () => {
                               itself isn't a tooltip trigger and doesn't
                               fight the reaction strip's hover area. */}
                           <div
-                            className={`max-w-md lg:max-w-xl px-6 py-4 rounded-2xl relative ${
+                            data-dm-bubble
+                            className={`max-w-[85%] md:max-w-md lg:max-w-xl px-5 py-3.5 rounded-2xl relative ${
                               message.isFromCurrentUser
                                 ? 'bg-gray-600 text-white'
                                 : isDark
@@ -1732,16 +1781,16 @@ const MessagesPage: React.FC = () => {
                             }
 
                             return (
-                              <div className="grid grid-cols-[1fr_auto] items-end gap-2 min-w-0">
-                                <p className={`${emojiOnlyTextClass(messageContent)} whitespace-pre-wrap break-words min-w-0`}>
-                                  {messageContent}
-                                </p>
+                              <div className={`${emojiOnlyTextClass(messageContent)} whitespace-pre-wrap break-words min-w-0`}>
+                                {messageContent}
                                 {bubbleTime && (
-                                  <span className={`text-[11px] font-medium whitespace-nowrap inline-flex items-center gap-1 ${bubbleTimeTextClass}`}>
+                                  <span className={`float-right ml-2 mt-1 text-[11px] font-medium whitespace-nowrap inline-flex items-center gap-1 ${bubbleTimeTextClass}`}>
                                     {bubbleTime}
                                     <HiOutlineLockClosed className="w-3 h-3 text-green-400" />
                                   </span>
                                 )}
+                                {/* Clear the float so the bubble wraps correctly */}
+                                {bubbleTime && <span className="block clear-both" />}
                               </div>
                             )
                           })()}
@@ -1815,12 +1864,56 @@ const MessagesPage: React.FC = () => {
                           <button
                             onClick={(e) => {
                               const rect = e.currentTarget.getBoundingClientRect()
+                              const bubbleRect = e.currentTarget
+                                .parentElement
+                                ?.querySelector<HTMLElement>('[data-dm-bubble]')
+                                ?.getBoundingClientRect()
+                              const rootRect = messagesContainerRef.current
+                                ?.closest<HTMLElement>('[data-messages-root]')
+                                ?.getBoundingClientRect()
+                              const pad = 8
+                              const bounds = rootRect
+                                ? {
+                                    left: rootRect.left,
+                                    right: rootRect.right,
+                                    top: rootRect.top,
+                                    bottom: rootRect.bottom,
+                                  }
+                                : {
+                                    left: 0,
+                                    right: window.innerWidth,
+                                    top: 0,
+                                    bottom: window.innerHeight,
+                                  }
+
+                              // First-pass placement (no flicker): use a size guess,
+                              // then useLayoutEffect measures real size and snaps BEFORE paint.
+                              const guessW = 240
+                              const guessH = 56
+                              const gap = 8
+                              const b = bubbleRect ?? rect
+                              const bubble = {
+                                left: b.left,
+                                right: b.right,
+                                top: b.top,
+                                bottom: b.bottom,
+                                height: b.height,
+                              }
+                              const xRaw = message.isFromCurrentUser
+                                ? (bubble.left - gap - guessW)
+                                : (bubble.right + gap)
+                              const yRaw = bubble.top + (bubble.height - guessH) / 2
+
+                              const x = Math.min(Math.max(bounds.left + pad, xRaw), bounds.right - pad - guessW)
+                              const y = Math.min(Math.max(bounds.top + pad, yRaw), bounds.bottom - pad - guessH)
                               setContextMenu({
                                 messageId: message.id,
-                                x: message.isFromCurrentUser ? rect.left - 180 : rect.right,
-                                y: rect.top,
+                                x,
+                                y,
                                 isOwn: message.isFromCurrentUser,
                                 createdAt: message.createdAt,
+                                bubble,
+                                bounds,
                               })
                             }}
                             className="p-1.5 rounded-full opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer hover:bg-white/10 self-center flex-shrink-0"
@@ -1863,7 +1956,8 @@ const MessagesPage: React.FC = () => {
               <>
                 <div className="fixed inset-0 z-40" onClick={() => setContextMenu(null)} />
                 <div
-                  className="fixed z-50 bg-gray-800 border border-white/20 rounded-lg shadow-xl py-1 min-w-[180px]"
+                  ref={contextMenuRef}
+                  className="fixed z-50 bg-gray-800 border border-white/20 rounded-lg shadow-xl py-1 min-w-[180px] max-w-[calc(100vw-1rem)]"
                   style={{ top: contextMenu.y, left: contextMenu.x }}
                 >
                   {/* Edit — only own messages within 15 min */}
@@ -2158,14 +2252,16 @@ const MessagesPage: React.FC = () => {
 
                 {/* Input area - where user can type */}
                 <textarea
+                  ref={composerTextareaRef}
                   data-dm-composer
                   placeholder="Start a new message"
                   value={newMessageContent}
                   onChange={(e) => {
                     handleInputChange(e.target.value)
                     // Auto-resize
-                    e.target.style.height = 'auto'
-                    e.target.style.height = Math.min(e.target.scrollHeight, 128) + 'px'
+                    const el = e.currentTarget
+                    el.style.height = 'auto'
+                    el.style.height = Math.min(el.scrollHeight, 128) + 'px'
                   }}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && !e.shiftKey) {
@@ -2182,7 +2278,7 @@ const MessagesPage: React.FC = () => {
                     }
                   }}
                   rows={1}
-                  className={`flex-1 py-3 pr-12 bg-transparent border-none outline-none resize-none ${
+                  className={`flex-1 min-w-0 py-3 px-3 bg-transparent border-none outline-none resize-none text-left ${
                     isDark
                       ? 'text-white placeholder-gray-500'
                       : 'text-black placeholder-gray-500'

--- a/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
+++ b/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
@@ -1403,11 +1403,11 @@ export const Profile: React.FC = () => {
       {/* Edit Profile Modal */}
       {isEditModalOpen && (
         <div
-          className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4"
+          className="fixed inset-0 bg-black/70 flex items-start justify-center z-50 p-4 pt-[calc(var(--app-mobile-header-h)+env(safe-area-inset-top)+0.75rem)] sm:pt-4"
           onClick={() => { setIsEditModalOpen(false); setProfileError(null) }}
         >
           <div
-            className={`w-full max-w-2xl max-h-[90vh] overflow-y-auto thin-scrollbar rounded-2xl transition-all duration-300 ${
+            className={`w-full max-w-2xl max-h-[calc(100dvh-var(--app-mobile-header-h)-env(safe-area-inset-top)-1.5rem)] sm:max-h-[90vh] overflow-y-auto thin-scrollbar rounded-2xl transition-all duration-300 ${
               isDark ? 'bg-black border border-yellow-500/30' : 'bg-white border border-gray-200'
             }`}
             onClick={(e) => e.stopPropagation()}

--- a/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
+++ b/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
@@ -894,28 +894,28 @@ export const Profile: React.FC = () => {
         </div>
       </div>
 
-      <div className={`max-w-2xl mx-auto min-h-screen transition-all duration-300 ${
-        isDark ? 'bg-black text-white' : 'bg-white text-black'
-      }`}>
+        <div className={`max-w-2xl mx-auto min-h-screen overflow-x-hidden transition-all duration-300 ${
+          isDark ? 'bg-black text-white' : 'bg-white text-black'
+        }`}>
 
         {/* Profile Info - Layout de 2 columnas */}
         <div className={`pt-24 pb-6 px-6 transition-all duration-300 ${
           isDark ? 'bg-black text-white' : 'bg-white text-black'
         }`}>
           {/* Layout principal: 2 columnas */}
-          <div className="flex justify-between items-start">
+          <div className="flex justify-between items-start gap-4">
             {/* Columna izquierda: Username, Joined, Stats */}
-            <div className="flex-1">
+            <div className="flex-1 min-w-0">
               {/* Display Name, Username, and Joined */}
-              <div className="mb-4">
+              <div className="mb-4 min-w-0 pl-4 sm:pl-0">
                 <h1 className={`text-2xl font-bold transition-all duration-300 ${
                   isDark ? 'text-white' : 'text-black'
-                }`}>
+                } truncate`}>
                   {profileData?.displayName || profileData?.username || displayUsername}
                 </h1>
                 <p className={`text-base mt-0.5 transition-all duration-300 ${
                   isDark ? 'text-gray-400' : 'text-gray-600'
-                }`}>
+                } truncate`}>
                   @{profileData?.username || displayUsername}
                 </p>
                 {profileData?.address && (
@@ -1007,7 +1007,8 @@ export const Profile: React.FC = () => {
               </div>
 
               {/* Stats - Alineadas horizontalmente */}
-              <div className="flex space-x-8 mb-6">
+              {/* Mobile alignment: keep in sync with the name block (pl-4). */}
+              <div className="flex gap-5 sm:gap-8 mb-6 pl-4 sm:pl-0">
                 <div className="text-center">
                   <div className={`text-lg font-bold transition-all duration-300 ${
                     isDark ? 'text-white' : 'text-black'
@@ -1022,7 +1023,7 @@ export const Profile: React.FC = () => {
                 </div>
                 <button
                   onClick={() => openModal('followingList', { username: profileData?.username || displayUsername })}
-                  className="cursor-pointer hover:opacity-80 transition-opacity"
+                  className="cursor-pointer hover:opacity-80 transition-opacity text-center"
                 >
                   <div className={`text-lg font-bold transition-all duration-300 ${
                     isDark ? 'text-white' : 'text-black'
@@ -1037,7 +1038,7 @@ export const Profile: React.FC = () => {
                 </button>
                 <button
                   onClick={() => openModal('followersList', { username: profileData?.username || displayUsername })}
-                  className="cursor-pointer hover:opacity-80 transition-opacity"
+                  className="cursor-pointer hover:opacity-80 transition-opacity text-center"
                 >
                   <div className={`text-lg font-bold transition-all duration-300 ${
                     isDark ? 'text-white' : 'text-black'
@@ -1111,7 +1112,7 @@ export const Profile: React.FC = () => {
             </div>
 
             {/* Columna derecha: Solo Edit Button */}
-            <div className="ml-6 flex flex-col items-end">
+            <div className="ml-4 flex flex-col items-end flex-shrink-0">
               {/* Edit Button */}
               <div>
                 {isOwnProfile ? (
@@ -1218,7 +1219,7 @@ export const Profile: React.FC = () => {
                         disabled={followPending || followWrongWallet}
                         onMouseEnter={() => setFollowButtonHovered(true)}
                         onMouseLeave={() => setFollowButtonHovered(false)}
-                        className={`px-8 py-2 rounded-full font-semibold border transition-all duration-200 ${
+                        className={`px-6 sm:px-8 py-2 rounded-full font-semibold border transition-all duration-200 ${
                           followWrongWallet ? 'opacity-50 cursor-not-allowed' :
                           followPending ? 'opacity-90 cursor-not-allowed' : 'cursor-pointer'
                         } ${
@@ -1320,7 +1321,7 @@ export const Profile: React.FC = () => {
                               onClick={() => setShowOptionsMenu(false)}
                             />
                             <div className={`absolute right-0 top-full mt-2 w-48 rounded-lg shadow-lg z-50 overflow-hidden ${
-                              isDark ? 'bg-gray-900 border border-white/20' : 'bg-white border border-gray-200'
+                              isDark ? 'bg-black border border-white/20' : 'bg-white border border-gray-200'
                             }`}>
                               <button
                                 onClick={handleToggleMute}


### PR DESCRIPTION
Polished several mobile UI and desktop interaction details across Profile, DMs, the post composer, and Usernames.

Profile (mobile stats)
- Tweaked spacing/alignment so “Posts / Following / Followers” line up cleanly on mobile.

Messages (DMs)
- Improved message bubble text rendering for readability (better text layout/visual presentation).
- Repositioned the “…” context menu to anchor to the message bubble (not the button).
- Added measurement/clamping to prevent the menu from jumping/glitching near viewport edges.

Post Composer (mobile)
- Added Poll support in mobile PostForm (button + composer render when enabled).
- Fixed the emoji picker to open near the emoji button (instead of bottom-stuck), using measurement/clamping to avoid jumps.

PollComposer (mobile overflow)
- Fixed layout overflow so controls like the remove “X” don’t spill/crush the row (min-w-0, flex-shrink-0).

Usernames (Marketplace) → My Profiles cards
- Added a “Switch / Active” pill to change the active profile (only for owned profiles).
- Centered action pills as a group for better card balance.
- Added a yellow capsule border (border only) to the Switch pill to make it stand out.

ProfileChooser dropdown
- Limited the dropdown to show at most 3 profiles.
- Replaced “See more” with “Manage my profiles”, made it yellow, and added a two-users icon (HiUsers).
- Fixed the CTA route to the correct page: /usernames?tab=mine.
- Added contextual auto-scroll: only when navigating via “Manage my profiles”, Usernames scrolls down to the tabs area so you land near “My Profiles” instead of the top hero.

Profile options dropdown (dark theme)
- Changed the options menu background from gray to black in dark mode for consistency.