### PR TITLE
feat(ui): mobile UX overhaul + draft-aware composer

### DIFF
--- a/client/src/services/FrontEnd/src/components/FeedItem.tsx
+++ b/client/src/services/FrontEnd/src/components/FeedItem.tsx
@@ -26,6 +26,7 @@ import {
   HiOutlineX
 } from 'react-icons/hi'
 import Recaw from '~/assets/images/recaw.svg?react';
+import UserHoverCard from './UserHoverCard';
 import Pencil from '~/assets/images/pencil.svg?react';
 import Bookmark from '~/assets/images/bookmark.svg?react';
 import Share from '~/assets/images/share.svg?react';
@@ -1194,14 +1195,16 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
 
                   {/* First line: Display name, username, time, and status badges */}
                   <div className="flex items-center space-x-2 mb-0.5">
-                    <Link
-                      to={`/users/${useItem.user.username}`}
-                      className={`font-semibold transition-colors duration-300 cursor-pointer hover:underline ${
-                        isDark ? 'text-white' : 'text-black'
-                      }`}
-                    >
-                      {useItem.user.displayName || useItem.user.username}
-                    </Link>
+                    <UserHoverCard username={useItem.user.username}>
+                      <Link
+                        to={`/users/${useItem.user.username}`}
+                        className={`font-semibold transition-colors duration-300 cursor-pointer hover:underline ${
+                          isDark ? 'text-white' : 'text-black'
+                        }`}
+                      >
+                        {useItem.user.displayName || useItem.user.username}
+                      </Link>
+                    </UserHoverCard>
                     <XBadge xHandle={useItem.user.xHandle} xFollowerBucket={useItem.user.xFollowerBucket} />
 
                     <span className={`text-sm transition-colors duration-300 ${

--- a/client/src/services/FrontEnd/src/components/Notifications.tsx
+++ b/client/src/services/FrontEnd/src/components/Notifications.tsx
@@ -27,6 +27,7 @@ import { useT } from '~/i18n/I18nProvider'
 import { getUserAvatar } from '~/utils/defaultAvatar'
 import Avatar from '~/components/Avatar'
 import { LoadingSpinner } from '~/components/Skeleton'
+import UserHoverCard from '~/components/UserHoverCard'
 
 interface Actor {
   tokenId: number
@@ -459,7 +460,8 @@ const Notifications: React.FC = () => {
     const Action = (node: React.ReactNode) => <span className={actionClass}>{node}</span>
 
     const actorLabel = actor.displayName || actor.username
-    const actorLink = (
+    const hasRealUsername = !!actor.username && actor.username !== `#${actor.tokenId}`
+    const actorSpan = (
       <span
         onClick={e => {
           // Actor name sits inside an <a> notification row for most types.
@@ -467,9 +469,7 @@ const Notifications: React.FC = () => {
           // preventDefault or the browser will follow the row href.
           e.preventDefault()
           e.stopPropagation()
-          const uname = actor.username && actor.username !== `#${actor.tokenId}`
-            ? actor.username
-            : (actor.displayName || actor.username)
+          const uname = hasRealUsername ? actor.username : (actor.displayName || actor.username)
           navigate(`/users/${uname}`)
         }}
         className="hover:underline cursor-pointer"
@@ -477,6 +477,9 @@ const Notifications: React.FC = () => {
         {actorLabel}
       </span>
     )
+    const actorLink = hasRealUsername
+      ? <UserHoverCard username={actor.username!}>{actorSpan}</UserHoverCard>
+      : actorSpan
     const grouped = count > 1 && additionalActors && additionalActors.length > 0
     const othersCount = grouped ? count - 1 : 0
     // Use a sentinel marker so we can splice the React <Link> back in after

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -305,9 +305,11 @@ interface PostFormProps {
   /** called after a successful sign+submit */
   onSuccess?: () => void;
   placeholder?: string;
+  /** force the spacious compose layout (used by the mobile compose sheet) */
+  composeMode?: boolean;
 }
 
-const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placeholder }) => {
+const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placeholder, composeMode = false }) => {
   const { isConnected } = useAccount();
   const { openConnectModal } = useConnectModal();
   const hasActiveSession = useHasActiveSession();
@@ -1556,7 +1558,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
       />
 
       {/* Mobile Layout - Input + Button */}
-      <div className={`md:hidden flex flex-col ${replyTo ? 'space-y-1' : 'space-y-2'}`}>
+      <div className={`${composeMode ? 'hidden' : 'md:hidden'} flex flex-col ${replyTo ? 'space-y-1' : 'space-y-2'}`}>
           {/* Input and Reply Button Row */}
           <div className="flex items-center space-x-3">
             {/* Input */}
@@ -1643,7 +1645,9 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
           )}
 
           {/* Mobile Icons Row */}
-          <div className={`flex items-center justify-between ${replyTo ? 'pt-0.5' : ''}`}>
+          <div className={`flex items-center justify-between mt-4 pb-3 border-b ${
+            isDark ? 'border-white/10' : 'border-gray-200'
+          } ${replyTo ? 'pt-0.5' : ''}`}>
             {/* Left side - media icons */}
             <div className="flex items-center space-x-4">
               {/* Media Upload */}
@@ -1918,7 +1922,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
       </div>
 
       {/* Desktop Layout - Original */}
-      <div className="hidden md:block">
+      <div className={composeMode ? 'block' : 'hidden md:block'}>
         <div className="relative">
           <HighlightedTextarea
             value={text}
@@ -2064,8 +2068,12 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
         )}
 
         {/* Functionality Icons */}
-        <div className={`flex items-center justify-between ${replyTo ? 'mt-1.5' : 'mt-4'}`}>
-          <div className="flex items-center space-x-3">
+        <div className={`flex items-center justify-between gap-2 ${replyTo ? 'mt-1.5' : 'mt-4'} ${
+          composeMode && hasMedia
+            ? `sticky -bottom-px pt-3 pb-3 border-t ${isDark ? 'bg-black border-white/10' : 'bg-white border-gray-200'}`
+            : ''
+        }`}>
+          <div className={`flex items-center min-w-0 ${composeMode ? 'space-x-1' : 'space-x-3'}`}>
             {/* Media Upload */}
             <button
               onClick={() => fileInputRef.current?.click()}
@@ -2251,7 +2259,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
           <div className="flex items-center space-x-3">
             {/* Token ownership and character counter */}
             <div className="flex items-center space-x-3">
-              {isThreadMode && (
+              {isThreadMode && !composeMode && (
                 <span className={`text-sm font-medium px-2 py-0.5 rounded ${
                   isDark ? 'bg-yellow-500/20 text-yellow-400' : 'bg-yellow-100 text-yellow-700'
                 }`}>
@@ -2280,7 +2288,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                 const btn2 = (
                   <button
                     ref={submitBtnRef}
-                    className="px-5 py-2 bg-yellow-500 text-black font-semibold text-base rounded-full hover:bg-yellow-400 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-lg hover:shadow-xl cursor-pointer"
+                    className="px-5 py-2 bg-yellow-500 text-black font-semibold text-base rounded-full hover:bg-yellow-400 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-lg hover:shadow-xl cursor-pointer flex-shrink-0 whitespace-nowrap"
                     disabled={isDisabled2}
                     onClick={handleSubmit}
                   >

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -20,6 +20,7 @@ import { BsWallet } from 'react-icons/bs'
 import MediaUpload from './MediaUpload'
 import { useHasActiveSession } from '~/hooks/useHasActiveSession'
 import { usePendingPostsStore } from '~/store/pendingPostsStore'
+import { useComposeDraftStore } from '~/store/composeDraftStore'
 import { useUserByUsername } from '~/hooks/useUserData'
 import Tooltip from '~/components/Tooltip'
 import { apiFetch } from '~/api/client'
@@ -307,9 +308,11 @@ interface PostFormProps {
   placeholder?: string;
   /** force the spacious compose layout (used by the mobile compose sheet) */
   composeMode?: boolean;
+  /** when true, publish draft state to the compose store so the mobile bottom nav can hide while typing */
+  trackDraft?: boolean;
 }
 
-const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placeholder, composeMode = false }) => {
+const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placeholder, composeMode = false, trackDraft = false }) => {
   const { isConnected } = useAccount();
   const { openConnectModal } = useConnectModal();
   const hasActiveSession = useHasActiveSession();
@@ -340,6 +343,14 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
   const [text, setText] = useState('')
   const [cursorPosition, setCursorPosition] = useState(0)
+
+  // Publish draft state so MainLayout can hide the mobile bottom nav while typing
+  const setHasInlineDraft = useComposeDraftStore(s => s.setHasInlineDraft)
+  useEffect(() => {
+    if (!trackDraft) return
+    setHasInlineDraft(text.trim().length > 0)
+    return () => setHasInlineDraft(false)
+  }, [trackDraft, text, setHasInlineDraft])
   // User-facing toggle for the shorten-URLs behavior. When on (default), we
   // silently map original URLs to short URLs and use the short form for the
   // byte counter and on-chain submission. When off, URLs pass through
@@ -1538,6 +1549,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
   // For regular posts, keep it roomy when it's text-only, but when media is
   // attached the big empty textarea looks ridiculous.
   const hasMedia = selectedMedia.length > 0
+  const hasInlineFeedDraft = trackDraft && (text.trim().length > 0 || hasMedia)
   const desktopRows = replyTo
     ? Math.max(2, Math.min(lineCount, 10))
     : hasMedia
@@ -2069,9 +2081,11 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
         {/* Functionality Icons */}
         <div className={`flex items-center justify-between gap-2 ${replyTo ? 'mt-1.5' : 'mt-4'} ${
-          composeMode && hasMedia
-            ? `sticky -bottom-px pt-3 pb-3 border-t ${isDark ? 'bg-black border-white/10' : 'bg-white border-gray-200'}`
-            : ''
+          hasInlineFeedDraft
+            ? `fixed md:static bottom-0 left-0 right-0 z-[60] px-4 py-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] border-t ${isDark ? 'bg-black border-white/10' : 'bg-white border-gray-200'}`
+            : composeMode && hasMedia
+              ? `sticky -bottom-px pt-3 pb-3 border-t ${isDark ? 'bg-black border-white/10' : 'bg-white border-gray-200'}`
+              : ''
         }`}>
           <div className={`flex items-center min-w-0 ${composeMode ? 'space-x-1' : 'space-x-3'}`}>
             {/* Media Upload */}

--- a/client/src/services/FrontEnd/src/components/UserHoverCard.tsx
+++ b/client/src/services/FrontEnd/src/components/UserHoverCard.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useUserByUsername } from '~/hooks/useUserData'
+import { useTheme } from '~/hooks/useTheme'
+import { useActiveToken } from '~/store/tokenDataStore'
+import { getUserAvatar } from '~/utils/defaultAvatar'
+import Avatar from './Avatar'
+import { FollowButton } from './FollowButton'
+
+const SHOW_DELAY = 300
+const HIDE_DELAY = 150
+
+interface Props {
+  username: string
+  children: React.ReactNode
+}
+
+const UserHoverCard: React.FC<Props> = ({ username, children }) => {
+  const [open, setOpen] = useState(false)
+  const showTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { isDark } = useTheme()
+  const activeToken = useActiveToken()
+  // Fetch only once the card is intent-to-show; React Query caches across mounts.
+  const { data: user } = useUserByUsername(open ? username : undefined)
+  const isSelf = !!activeToken && user?.tokenId === activeToken.tokenId
+
+  const clearTimers = () => {
+    if (showTimer.current) { clearTimeout(showTimer.current); showTimer.current = null }
+    if (hideTimer.current) { clearTimeout(hideTimer.current); hideTimer.current = null }
+  }
+  const handleEnter = () => {
+    clearTimers()
+    showTimer.current = setTimeout(() => setOpen(true), SHOW_DELAY)
+  }
+  const handleLeave = () => {
+    clearTimers()
+    hideTimer.current = setTimeout(() => setOpen(false), HIDE_DELAY)
+  }
+  useEffect(() => clearTimers, [])
+
+  return (
+    <span className="relative inline-block" onMouseEnter={handleEnter} onMouseLeave={handleLeave}>
+      {children}
+      {open && (
+        <div
+          className={`hidden md:block absolute left-0 top-full mt-2 z-50 w-72 p-4 rounded-2xl shadow-xl ${
+            isDark ? 'bg-black border border-white/10' : 'bg-white border border-gray-200'
+          }`}
+          onMouseEnter={handleEnter}
+          onMouseLeave={handleLeave}
+        >
+          {!user ? (
+            <div className={`text-sm ${isDark ? 'text-white/50' : 'text-gray-500'}`}>Loading…</div>
+          ) : (
+            <>
+              <div className="flex items-start justify-between gap-2 mb-2">
+                <Link to={`/users/${user.username}`} className="block flex-shrink-0">
+                  <div className="w-12 h-12 rounded-full overflow-hidden border border-gray-700">
+                    <Avatar src={getUserAvatar(user)} alt={user.username} size="small" className="w-full h-full rounded-full" />
+                  </div>
+                </Link>
+                {!isSelf && (
+                  <FollowButton
+                    targetUserId={user.tokenId}
+                    initialIsFollowing={!!user.isFollowing}
+                    initialIsPending={!!user.followPending}
+                    size="small"
+                  />
+                )}
+              </div>
+              <Link to={`/users/${user.username}`} className="block">
+                <div className={`font-semibold truncate ${isDark ? 'text-white' : 'text-black'}`}>
+                  {user.displayName || user.username}
+                </div>
+                <div className={`text-sm truncate ${isDark ? 'text-white/50' : 'text-gray-500'}`}>@{user.username}</div>
+              </Link>
+              {user.bio && (
+                <p className={`text-sm mt-2 line-clamp-3 ${isDark ? 'text-white/80' : 'text-gray-700'}`}>{user.bio}</p>
+              )}
+              <div className={`flex gap-4 mt-3 text-sm ${isDark ? 'text-white/70' : 'text-gray-600'}`}>
+                <span>
+                  <strong className={isDark ? 'text-white' : 'text-black'}>{user.followingCount ?? 0}</strong> Following
+                </span>
+                <span>
+                  <strong className={isDark ? 'text-white' : 'text-black'}>{user.followerCount ?? 0}</strong> Followers
+                </span>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </span>
+  )
+}
+
+export default UserHoverCard

--- a/client/src/services/FrontEnd/src/components/forms/ThemedListbox.tsx
+++ b/client/src/services/FrontEnd/src/components/forms/ThemedListbox.tsx
@@ -26,7 +26,7 @@ export default function ThemedListbox<T extends string | number>({
 }: Props<T>) {
   const selected = useMemo(() => options.find(o => o.value === value), [options, value])
 
-  const buttonClass = `w-full px-3 py-2 rounded-lg text-sm border outline-none transition cursor-pointer flex items-center justify-between ${themeInput(isDark)} ${themeBorder(isDark)}`
+  const buttonClass = `w-full px-3 py-4 rounded-lg text-sm outline-none focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0 transition cursor-pointer flex items-center justify-between ${themeInput(isDark)}`
   const panelClass = `absolute mt-1 w-full rounded-xl border shadow-lg z-[60] overflow-hidden ${
     isDark ? 'bg-neutral-900' : 'bg-white'
   } ${themeBorder(isDark)}`

--- a/client/src/services/FrontEnd/src/components/icons/crow.svg
+++ b/client/src/services/FrontEnd/src/components/icons/crow.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 366.6 197.5">
+  <!-- Generator: Adobe Illustrator 29.8.6, SVG Export Plug-In . SVG Version: 2.1.1 Build 1)  -->
+  <defs>
+    <style>
+      .st0 {
+        stroke: #000;
+        stroke-miterlimit: 10;
+        stroke-width: .8px;
+      }
+    </style>
+  </defs>
+  <path class="st0" d="M162.6,51.2l20.5-47.1,22.1,47.5s15.3-18.1,55.6-13.3c0,0,37.4,4,40.7,4.4l59.6,79.7s-68.8-8.5-103.9-9.3c-35-.8-53.1,15.3-53.9,20.9s14.5,57.6,14.5,57.6c0,0-27,7.6-69.7.8,0,0,16.9-52.3,10.9-61.6s-23.4-20.9-51.1-17.7L3.2,122,62.8,41.5s48.7-5.6,62-4.4c0,0,19.7,1.2,37.8,14.1Z"/>
+</svg>

--- a/client/src/services/FrontEnd/src/components/modals/ComposePostModal.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/ComposePostModal.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { HiX } from 'react-icons/hi'
 import PostForm from '~/components/PostForm'
 import ModalWrapper from './ModalWrapper'
 import { useTheme } from '~/hooks/useTheme'
@@ -12,13 +13,68 @@ interface ComposePostModalProps {
 const ComposePostModal: React.FC<ComposePostModalProps> = ({ isOpen, onClose }) => {
   const { isDark } = useTheme()
   const t = useT()
-  // Mobile: stronger backdrop so the page underneath fully recedes.
-  // Desktop: keep the existing theme defaults.
+
+  // Track viewport — desktop uses ModalWrapper (portaled to body, can't be
+  // hidden via parent className), mobile uses an in-tree fullscreen sheet.
+  const [isDesktop, setIsDesktop] = useState(() =>
+    typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches
+  )
+  useEffect(() => {
+    const mql = window.matchMedia('(min-width: 768px)')
+    const onChange = (e: MediaQueryListEvent) => setIsDesktop(e.matches)
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
+
+  // Lock body scroll while the mobile fullscreen sheet is open.
+  useEffect(() => {
+    if (!isOpen) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = prev }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  // Desktop: keep the existing modal experience.
+  // Mobile: fullscreen Twitter-style sheet — no backdrop padding, own header.
   const backdropClass = `bg-black/85 ${isDark ? 'md:bg-black/70' : 'md:bg-black/40'}`
+
+  if (isDesktop) {
+    return (
+      <ModalWrapper
+        isOpen={isOpen}
+        onClose={onClose}
+        maxWidth="max-w-xl"
+        className="overflow-hidden md:-translate-x-[2.75rem]"
+        backdropClass={backdropClass}
+      >
+        <PostForm onSuccess={onClose} placeholder={t('compose.placeholder')} />
+      </ModalWrapper>
+    )
+  }
+
   return (
-    <ModalWrapper isOpen={isOpen} onClose={onClose} maxWidth="max-w-xl" className="overflow-hidden md:-translate-x-[2.75rem]" backdropClass={backdropClass}>
-      <PostForm onSuccess={onClose} placeholder={t('compose.placeholder')} />
-    </ModalWrapper>
+    <div
+      className={`fixed left-0 right-0 bottom-0 z-[70] overflow-y-auto ${
+        isDark ? 'bg-black text-white' : 'bg-white text-black'
+      }`}
+      style={{ top: '4rem' }}
+    >
+      <div className="flex items-center px-3 py-2">
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className={`p-2 rounded-full transition-colors cursor-pointer ${
+            isDark ? 'hover:bg-white/10 text-white' : 'hover:bg-gray-100 text-black'
+          }`}
+        >
+          <HiX className="w-6 h-6" />
+        </button>
+      </div>
+      <PostForm onSuccess={onClose} placeholder={t('compose.placeholder')} composeMode />
+    </div>
   )
 }
 

--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -8,10 +8,13 @@ import BugIcon from "~/components/icons/BugIcon";
 import { useTheme } from "~/hooks/useTheme";
 import Tooltip from "~/components/Tooltip";
 import { useT } from "~/i18n/I18nProvider";
-import { useState, lazy, Suspense } from "react";
-import { HiOutlineMenu, HiOutlineX, HiOutlinePencilAlt } from "react-icons/hi";
+import { useState, useEffect, useRef, lazy, Suspense } from "react";
+import { HiOutlineMenu, HiOutlineX, HiOutlinePencilAlt, HiOutlineHome, HiOutlineSearch, HiOutlineColorSwatch, HiOutlineBell, HiOutlineUser, HiOutlineChat } from "react-icons/hi";
 import { Link, useLocation } from "react-router-dom";
 import { useModalStore } from "~/store";
+import { useDmUnreadStore } from "~/store/dmUnreadStore";
+import { useNotificationUnreadStore } from "~/store/notificationUnreadStore";
+import { useOffersUnreadStore } from "~/store/offersUnreadStore";
 import { useActiveToken } from "~/store/tokenDataStore";
 import { useLayoutStore } from "~/store/layoutStore";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
@@ -36,6 +39,26 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
   const { isConnected } = useAccount()
   const { openConnectModal } = useConnectModal()
   const openModal = useModalStore(s => s.openModal)
+  const dmUnreadCount = useDmUnreadStore(s => s.totalUnread)
+  const notifUnreadCount = useNotificationUnreadStore(s => s.unreadCount)
+  const offersUnreadCount = useOffersUnreadStore(s => s.unreadCount)
+
+  // Bottom-nav transparency while scrolling: solid when idle, translucent
+  // while the user actively scrolls so feed content can peek through.
+  const [isScrolling, setIsScrolling] = useState(false)
+  const scrollIdleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    const onScroll = () => {
+      setIsScrolling(true)
+      if (scrollIdleTimer.current) clearTimeout(scrollIdleTimer.current)
+      scrollIdleTimer.current = setTimeout(() => setIsScrolling(false), 180)
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      if (scrollIdleTimer.current) clearTimeout(scrollIdleTimer.current)
+    }
+  }, [])
 
   // Captive mode: no username and on a public page like /help/*
   const isCaptive = !activeToken?.username
@@ -80,6 +103,23 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
           >
             {isMobileMenuOpen ? <HiOutlineX className="w-6 h-6" /> : <HiOutlineMenu className="w-6 h-6" />}
           </button>
+
+          <Link
+            to="/messages"
+            aria-label="Messages"
+            className={`absolute right-4 p-2 rounded-lg transition-colors duration-200 ${
+              isDark ? 'text-white hover:bg-white/10' : 'text-black hover:bg-gray-100'
+            }`}
+          >
+            <span className="relative inline-flex">
+              <HiOutlineChat className="w-8 h-8" />
+              {dmUnreadCount > 0 && (
+                <span className={`absolute -top-1 -right-1 min-w-[18px] h-[18px] flex items-center justify-center text-[11px] font-bold rounded-full bg-yellow-500 text-black px-1 border-2 ${isDark ? 'border-black' : 'border-white'}`}>
+                  {dmUnreadCount > 99 ? '99+' : dmUnreadCount}
+                </span>
+              )}
+            </span>
+          </Link>
 
           <Link to="/home" className="caw-logo-lockup flex items-center justify-center w-full">
             <img
@@ -216,6 +256,45 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
         </div>
       )}
 
+      {/* Mobile bottom nav */}
+      {!hideSidebars && !isCaptive && (
+        <nav className={`md:hidden fixed bottom-0 left-0 right-0 z-[55] flex items-center justify-around h-14 pb-[env(safe-area-inset-bottom)] [height:calc(theme(height.14)+env(safe-area-inset-bottom))] border-t transition-opacity duration-200 ${
+          isScrolling ? 'opacity-30' : 'opacity-100'
+        } ${
+          isDark ? 'bg-black border-white/10' : 'bg-white border-gray-200'
+        }`}>
+          {[
+            { to: '/home', icon: HiOutlineHome, match: '/home', badge: 0 },
+            { to: '/explore', icon: HiOutlineSearch, match: '/explore', badge: 0 },
+            { to: '/usernames', icon: HiOutlineColorSwatch, match: '/usernames', badge: offersUnreadCount },
+            { to: '/notifications', icon: HiOutlineBell, match: '/notifications', badge: notifUnreadCount },
+            { to: activeToken?.username ? `/users/${activeToken.username}` : '/welcome', icon: HiOutlineUser, match: activeToken?.username ? `/users/${activeToken.username}` : '/welcome', badge: 0 },
+          ].map(({ to, icon: Icon, match, badge }) => {
+            const active = location.pathname === match || location.pathname.startsWith(match + '/')
+            return (
+              <Link
+                key={to}
+                to={to}
+                className={`flex-1 h-full flex items-center justify-center transition-colors ${
+                  active
+                    ? (isDark ? 'text-yellow-500' : 'text-yellow-600')
+                    : (isDark ? 'text-white/70 hover:text-white' : 'text-gray-600 hover:text-black')
+                }`}
+              >
+                <span className="relative inline-flex">
+                  <Icon className="w-7 h-7" />
+                  {badge > 0 && (
+                    <span className={`absolute -top-1 -right-1 min-w-[18px] h-[18px] flex items-center justify-center text-[11px] font-bold rounded-full bg-yellow-500 text-black px-1 border-2 ${isDark ? 'border-black' : 'border-white'}`}>
+                      {badge > 99 ? '99+' : badge}
+                    </span>
+                  )}
+                </span>
+              </Link>
+            )
+          })}
+        </nav>
+      )}
+
       {/* Mobile compose FAB */}
       {!hideSidebars && !isCaptive && !(
         location.pathname.startsWith('/messages') ||
@@ -226,7 +305,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
         <button
           onClick={() => openModal('post')}
           aria-label={t('main_layout.post_aria')}
-          className="md:hidden fixed right-10 bottom-12 z-[60] w-16 h-16 rounded-full bg-yellow-500 hover:bg-yellow-400 active:bg-yellow-600 text-black flex items-center justify-center shadow-lg shadow-black/30 transition-all cursor-pointer"
+          className="md:hidden fixed right-6 bottom-20 z-[60] w-14 h-14 rounded-full bg-yellow-500 hover:bg-yellow-400 active:bg-yellow-600 text-black flex items-center justify-center shadow-lg shadow-black/30 transition-all cursor-pointer"
         >
           <HiOutlinePencilAlt className="w-8 h-8" />
         </button>

--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -15,6 +15,7 @@ import { useModalStore } from "~/store";
 import { useDmUnreadStore } from "~/store/dmUnreadStore";
 import { useNotificationUnreadStore } from "~/store/notificationUnreadStore";
 import { useOffersUnreadStore } from "~/store/offersUnreadStore";
+import { useComposeDraftStore } from "~/store/composeDraftStore";
 import { useActiveToken } from "~/store/tokenDataStore";
 import { useLayoutStore } from "~/store/layoutStore";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
@@ -42,6 +43,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
   const dmUnreadCount = useDmUnreadStore(s => s.totalUnread)
   const notifUnreadCount = useNotificationUnreadStore(s => s.unreadCount)
   const offersUnreadCount = useOffersUnreadStore(s => s.unreadCount)
+  const hasInlineDraft = useComposeDraftStore(s => s.hasInlineDraft)
 
   // Bottom-nav transparency while scrolling: solid when idle, translucent
   // while the user actively scrolls so feed content can peek through.
@@ -107,7 +109,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
           <Link
             to="/messages"
             aria-label="Messages"
-            className={`absolute right-4 p-2 rounded-lg transition-colors duration-200 ${
+            className={`absolute right-4 translate-y-[2px] p-2 rounded-lg transition-colors duration-200 ${
               isDark ? 'text-white hover:bg-white/10' : 'text-black hover:bg-gray-100'
             }`}
           >
@@ -258,8 +260,8 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
 
       {/* Mobile bottom nav */}
       {!hideSidebars && !isCaptive && (
-        <nav className={`md:hidden fixed bottom-0 left-0 right-0 z-[55] flex items-center justify-around h-14 pb-[env(safe-area-inset-bottom)] [height:calc(theme(height.14)+env(safe-area-inset-bottom))] border-t transition-opacity duration-200 ${
-          isScrolling ? 'opacity-30' : 'opacity-100'
+        <nav className={`md:hidden fixed bottom-0 left-0 right-0 z-[55] flex items-center justify-around h-14 pb-[env(safe-area-inset-bottom)] [height:calc(theme(height.14)+env(safe-area-inset-bottom))] border-t transition-all duration-200 ${
+          hasInlineDraft ? 'opacity-0 translate-y-full pointer-events-none' : isScrolling ? 'opacity-30' : 'opacity-100'
         } ${
           isDark ? 'bg-black border-white/10' : 'bg-white border-gray-200'
         }`}>
@@ -305,7 +307,9 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
         <button
           onClick={() => openModal('post')}
           aria-label={t('main_layout.post_aria')}
-          className="md:hidden fixed right-6 bottom-20 z-[60] w-14 h-14 rounded-full bg-yellow-500 hover:bg-yellow-400 active:bg-yellow-600 text-black flex items-center justify-center shadow-lg shadow-black/30 transition-all cursor-pointer"
+          className={`md:hidden fixed right-6 bottom-20 z-[60] w-14 h-14 rounded-full bg-yellow-500 hover:bg-yellow-400 active:bg-yellow-600 text-black flex items-center justify-center shadow-lg shadow-black/30 transition-all duration-200 cursor-pointer ${
+            hasInlineDraft ? 'opacity-0 translate-y-24 pointer-events-none' : isScrolling ? 'opacity-30' : 'opacity-100'
+          }`}
         >
           <HiOutlinePencilAlt className="w-8 h-8" />
         </button>

--- a/client/src/services/FrontEnd/src/pages/AccountSettings.tsx
+++ b/client/src/services/FrontEnd/src/pages/AccountSettings.tsx
@@ -718,7 +718,7 @@ const AccountSettings: React.FC = () => {
   )
 
   return (
-      <div className="max-w-2xl mx-auto px-6 py-4">
+      <div className="max-w-2xl mx-auto px-3 sm:px-6 py-4">
         {/* Header */}
         <div className="flex items-center gap-4 mb-6">
           <Link

--- a/client/src/services/FrontEnd/src/pages/LanguageSettings.tsx
+++ b/client/src/services/FrontEnd/src/pages/LanguageSettings.tsx
@@ -8,6 +8,7 @@ import { apiFetch } from '~/api/client'
 import { useUserByToken } from '~/hooks/useUserData'
 import { useActiveToken } from '~/store/tokenDataStore'
 import { useT } from '~/i18n/I18nProvider'
+import ThemedListbox from '~/components/forms/ThemedListbox'
 
 const LanguageSettings: React.FC = () => {
   const { isDark } = useTheme()
@@ -70,7 +71,7 @@ const LanguageSettings: React.FC = () => {
   )
 
   return (
-      <div className="max-w-2xl mx-auto px-6 py-4">
+      <div className="max-w-2xl mx-auto px-3 sm:px-6 py-4">
         <div className="flex items-center gap-4 mb-6">
           <Link
             to="/settings"
@@ -109,22 +110,19 @@ const LanguageSettings: React.FC = () => {
                 <p className={`text-sm mb-3 ${isDark ? 'text-white/50' : 'text-gray-500'}`}>
                   {t('language_settings.your_language.description')}
                 </p>
-                <select
+                <ThemedListbox
+                  isDark={isDark}
                   value={preferredLanguage}
-                  onChange={(e) => onLanguageChange(e.target.value)}
-                  className={`w-full max-w-xs px-3 py-2 rounded-lg border transition-colors cursor-pointer ${
-                    isDark
-                      ? 'bg-black border-white/20 text-white hover:border-white/40'
-                      : 'bg-white border-gray-300 text-gray-900 hover:border-gray-500'
-                  }`}
-                >
-                  <option value="">{t('language_settings.browser_default')}</option>
-                  {LANGUAGES.map(l => (
-                    <option key={l.code} value={l.code}>
-                      {l.name}{l.name !== l.native ? ` (${l.native})` : ''}
-                    </option>
-                  ))}
-                </select>
+                  onChange={onLanguageChange}
+                  className="max-w-xs"
+                  options={[
+                    { value: '', label: t('language_settings.browser_default') },
+                    ...LANGUAGES.map(l => ({
+                      value: l.code,
+                      label: l.name + (l.name !== l.native ? ` (${l.native})` : ''),
+                    })),
+                  ]}
+                />
               </div>
             </div>
           </div>

--- a/client/src/services/FrontEnd/src/pages/Main/Main.tsx
+++ b/client/src/services/FrontEnd/src/pages/Main/Main.tsx
@@ -74,7 +74,7 @@ export const Main: React.FC = () => {
       />
       {/* PostForm - Always visible */}
       <div className={`border-b ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
-        <PostForm onSuccess={() => feedRef.current?.refresh()} composeMode/>
+        <PostForm onSuccess={() => feedRef.current?.refresh()} composeMode trackDraft/>
       </div>
       <div className="w-full">
         <Feed

--- a/client/src/services/FrontEnd/src/pages/Main/Main.tsx
+++ b/client/src/services/FrontEnd/src/pages/Main/Main.tsx
@@ -74,7 +74,7 @@ export const Main: React.FC = () => {
       />
       {/* PostForm - Always visible */}
       <div className={`border-b ${isDark ? 'border-white/10' : 'border-gray-200'}`}>
-        <PostForm onSuccess={() => feedRef.current?.refresh()}/>
+        <PostForm onSuccess={() => feedRef.current?.refresh()} composeMode/>
       </div>
       <div className="w-full">
         <Feed

--- a/client/src/services/FrontEnd/src/pages/MutedContent.tsx
+++ b/client/src/services/FrontEnd/src/pages/MutedContent.tsx
@@ -217,7 +217,7 @@ const MutedContentPage: React.FC = () => {
     preferences.blockedAccounts.length
 
   return (
-      <div className="max-w-2xl mx-auto px-6 py-4">
+      <div className="max-w-2xl mx-auto px-3 sm:px-6 py-4">
         {/* Header */}
         <div className="flex items-center gap-4 mb-6">
           <Link

--- a/client/src/services/FrontEnd/src/pages/NotificationSettings.tsx
+++ b/client/src/services/FrontEnd/src/pages/NotificationSettings.tsx
@@ -99,7 +99,7 @@ const NotificationSettings: React.FC = () => {
   )
 
   return (
-      <div className="max-w-2xl mx-auto px-6 py-4">
+      <div className="max-w-2xl mx-auto px-3 sm:px-6 py-4">
         {/* Header */}
         <div className="flex items-center gap-4 mb-6">
           <Link

--- a/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
+++ b/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
@@ -10,7 +10,7 @@ import { useEnsureWallet } from '~/hooks/useEnsureWallet'
 import { formatWalletError } from '~/utils/errorMessage'
 import { useActiveToken } from '~/store/tokenDataStore'
 import { useModalStore } from '~/store/modalStore'
-import { HiPencil, HiX, HiCamera, HiGlobe, HiLink, HiLocationMarker, HiOutlineMail, HiDotsHorizontal, HiOutlineCurrencyDollar, HiOutlineLockClosed } from 'react-icons/hi'
+import { HiPencil, HiX, HiCamera, HiGlobe, HiLink, HiLocationMarker, HiOutlineMail, HiDotsHorizontal, HiOutlineCurrencyDollar, HiOutlineLockClosed, HiArrowLeft } from 'react-icons/hi'
 import CopyAddressButton from '~/components/CopyAddressButton'
 import XBadge from '~/components/XBadge'
 import { apiFetch, retryOnIndexing } from '~/api/client'
@@ -889,6 +889,20 @@ export const Profile: React.FC = () => {
               style={isDark ? undefined : { background: 'linear-gradient(to bottom, white, #282828, white)' }}
             />
           )}
+          <button
+            type="button"
+            aria-label="Back"
+            onClick={() => {
+              if (window.history.state && window.history.state.idx > 0) {
+                navigate(-1)
+              } else {
+                navigate('/home')
+              }
+            }}
+            className="absolute top-3 left-3 z-10 w-9 h-9 rounded-full flex items-center justify-center bg-black/40 hover:bg-black/60 text-white backdrop-blur-sm transition-colors cursor-pointer"
+          >
+            <HiArrowLeft className="w-5 h-5" />
+          </button>
         </div>
 
         {/* Profile Picture - Positioned within max-w-2xl bounds */}

--- a/client/src/services/FrontEnd/src/pages/SessionKeySettings.tsx
+++ b/client/src/services/FrontEnd/src/pages/SessionKeySettings.tsx
@@ -168,7 +168,7 @@ const SessionKeySettings: React.FC = () => {
   }
 
   return (
-      <div className={`max-w-2xl mx-auto px-6 py-4 ${isDark ? 'bg-black' : 'bg-white'}`}>
+      <div className={`max-w-2xl mx-auto px-3 sm:px-6 py-4 ${isDark ? 'bg-black' : 'bg-white'}`}>
         {/* Header */}
         <div className="flex items-center gap-4 mb-6">
           <Link to="/settings" className={`p-2 rounded-full transition-colors ${

--- a/client/src/services/FrontEnd/src/pages/Settings.tsx
+++ b/client/src/services/FrontEnd/src/pages/Settings.tsx
@@ -62,7 +62,7 @@ export const SettingsPage: React.FC = () => {
   )
 
   return (
-      <div className={`max-w-2xl mx-auto px-6 py-4 ${isDark ? 'bg-black' : 'bg-white'}`}>
+      <div className={`max-w-2xl mx-auto px-3 sm:px-6 py-4 ${isDark ? 'bg-black' : 'bg-white'}`}>
         {/* Settings Header */}
         <div className="mb-6">
           <h1 className={`text-2xl font-bold mb-2 transition-colors duration-300 ${

--- a/client/src/services/FrontEnd/src/store/composeDraftStore.ts
+++ b/client/src/services/FrontEnd/src/store/composeDraftStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface ComposeDraftState {
+  hasInlineDraft: boolean
+  setHasInlineDraft: (value: boolean) => void
+}
+
+export const useComposeDraftStore = create<ComposeDraftState>((set) => ({
+  hasInlineDraft: false,
+  setHasInlineDraft: (value) => set({ hasInlineDraft: value }),
+}))


### PR DESCRIPTION
Two commits on top of latest master.

  **Hover cards, mobile compose sheet, mobile bottom nav, settings padding, language dropdown:**
  - Add Twitter/X-style UserHoverCard (avatar, name, handle, bio, follow counts, Follow/Following). Desktop only. Wired
  into FeedItem header username and Notifications actor.
  - Replace the mobile compose modal with a Twitter-style fullscreen sheet that sits below the app header and locks body
   scroll while open. Desktop keeps the ModalWrapper.
  - Add composeMode prop to PostForm: forces the spacious desktop layout on mobile (rows=5, fontSize=xl, autoResize) so
  the textarea grows downward and pushes the toolbar with it. Applied to the mobile compose sheet and the feed inline
  input.
  - When composeMode is on and media is attached, the icon/Post toolbar becomes sticky to the bottom of the sheet with a
   solid theme background.
  - Tighten icon spacing in compose mode (space-x-1); flex-shrink-0 + whitespace-nowrap on the Post button so the
  "Thread (N)" label doesn't get cut off on narrow screens. Hide the redundant 1/N chunk badge in compose mode.
  - Replace the native <select> in Language Settings with ThemedListbox to match marketplace ForSale filters; bump
  button vertical padding, remove border + focus outline.
  - Add a mobile-only bottom navigation bar in MainLayout (Home, Explore, Usernames, Notifications, Profile). Active
  route highlighted yellow. Respects iOS safe-area-inset-bottom.
  - Bottom nav fades to 30% opacity while the user scrolls (180ms idle debounce) and snaps back when scrolling stops.
  - Reposition and resize the mobile compose FAB (bottom-12 right-10 w-16 → bottom-20 right-6 w-14) so it floats above
  - Add a mobile-only Messages chat icon to the top header on the right, mirroring the hamburger on the left.
  - Wire unread badges (yellow circle, sidebar style) on the new mobile nav and the top-right Messages icon:
  dmUnreadCount on Messages, offersUnreadCount on Usernames, notifUnreadCount on Notifications.
  - Settings pages padding tightened on mobile (px-6 → px-3 sm:px-6) across Settings, Account, Notification, Language,
  - Settings pages padding tightened on mobile (px-6 → px-3 sm:px-6) across Settings, Account, Notification, Language,
  SessionKey and MutedContent.


  **Draft-aware mobile composer:**
  - Nudge the mobile top-header Messages icon 2px down (translate-y-[2px]) so it sits more in line with the centered
  logo.
  - Mobile compose FAB now mirrors the bottom-nav scroll behavior: fades to 30% opacity while the user is actively
  scrolling and snaps back to fully solid when scrolling stops (shares the same isScrolling flag).
  - New composeDraftStore (Zustand) with a single hasInlineDraft flag. PostForm gains an opt-in trackDraft prop that
  publishes draft state to the store on every text change and resets it on unmount. Only the feed inline PostForm in
  Main passes trackDraft; the FAB compose modal, reply/quote/comment modals and CawPage stay untouched.
  - Mobile bottom nav hides while the user is composing in the inline feed input (translate-y-full + opacity-0 +
  pointer-events-none when hasInlineDraft); otherwise the existing scroll-fade behavior. Comes back when the input is
  emptied, the post is submitted, or the form unmounts.
  - Mobile compose FAB hides on the same trigger (opacity-0 + translate-y-24 + pointer-events-none when hasInlineDraft)
  — redundant while the inline composer is in use.
  - Inline feed PostForm on mobile: when there's a draft (text or media), the icon/Post toolbar becomes fixed bottom-0
  left-0 right-0 with safe-area padding (pb-[max(env(safe-area-inset-bottom),0.75rem)]), so emoji/GIF/media/Post stay
  anchored at the viewport bottom even though the page scroll context is the feed itself. md:static reverts it to
  in-flow on desktop. The previous composeMode && hasMedia sticky branch is kept as a fallback for the FAB modal path.