### PR TITLE
fix(messages): hide mobile bottom nav inside conversation view

### DIFF
--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -258,8 +258,8 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
         </div>
       )}
 
-      {/* Mobile bottom nav */}
-      {!hideSidebars && !isCaptive && (
+      {/* Mobile bottom nav — hidden inside an open conversation (/messages/<id>) so it doesn't cover the chat input. List view (/messages) keeps it. */}
+      {!hideSidebars && !isCaptive && !location.pathname.startsWith('/messages/') && (
         <nav className={`md:hidden fixed bottom-0 left-0 right-0 z-[55] flex items-center justify-around h-14 pb-[env(safe-area-inset-bottom)] [height:calc(theme(height.14)+env(safe-area-inset-bottom))] border-t transition-all duration-200 ${
           hasInlineDraft ? 'opacity-0 translate-y-full pointer-events-none' : isScrolling ? 'opacity-30' : 'opacity-100'
         } ${


### PR DESCRIPTION
On mobile the bottom navigation bar covered the DM message input inside an open conversation. Hide it on /messages/<id> routes only. the conversation list at /messages keeps the bar so the user can still navigate between sections.