### PR TITLE
feat(profile): UX/UI improvements — share card, lightbox, modals

### DIFF
--- a/client/src/services/FrontEnd/package.json
+++ b/client/src/services/FrontEnd/package.json
@@ -38,6 +38,7 @@
     "react-icons": "^5.4.0",
     "react-router": "^7.0.2",
     "react-router-dom": "^7.6.2",
+    "qrcode": "^1.5.4",
     "smltxt": "file:../../../../smltxt",
     "socket.io-client": "^4.8.1",
     "three": "^0.183.2",

--- a/client/src/services/FrontEnd/src/components/ImageLightbox.tsx
+++ b/client/src/services/FrontEnd/src/components/ImageLightbox.tsx
@@ -13,6 +13,8 @@ interface ImageLightboxProps {
   alt?: string
   isOpen: boolean
   onClose: () => void
+  /** Optional extra classes applied to the <img>. */
+  imgClassName?: string
 }
 
 /**
@@ -30,7 +32,7 @@ interface ImageLightboxProps {
  * Lightbox renders via portal so it's never clipped by post / feed-item
  * overflow rules.
  */
-const ImageLightbox: React.FC<ImageLightboxProps> = ({ src, largeSrc, alt = '', isOpen, onClose }) => {
+const ImageLightbox: React.FC<ImageLightboxProps> = ({ src, largeSrc, alt = '', isOpen, onClose, imgClassName }) => {
   // Start with the small src so the modal has something to show
   // immediately, then swap to largeSrc once it's available. If largeSrc
   // 404s the onError handler keeps us on `src`.
@@ -105,7 +107,10 @@ const ImageLightbox: React.FC<ImageLightboxProps> = ({ src, largeSrc, alt = '', 
       <img
         src={currentSrc}
         alt={alt}
-        className="max-w-[95vw] max-h-[95vh] object-contain rounded"
+        className={[
+          'max-w-[95vw] max-h-[95vh] object-contain',
+          imgClassName ?? 'rounded'
+        ].join(' ')}
         onClick={e => e.stopPropagation()}
         onError={() => {
           // Large variant 404? Drop to the inline `src` once and stay there.

--- a/client/src/services/FrontEnd/src/components/ShareModal.tsx
+++ b/client/src/services/FrontEnd/src/components/ShareModal.tsx
@@ -94,12 +94,12 @@ export const ShareModal: React.FC<ShareModalProps> = ({
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-black/50 z-40 transition-opacity"
+        className="fixed inset-0 bg-black/50 z-[80] transition-opacity"
         onMouseDown={onClose}
       />
 
       {/* Modal */}
-      <div className="fixed inset-x-0 bottom-0 md:inset-0 md:flex md:items-center md:justify-center z-50 px-4 md:px-0">
+      <div className="fixed inset-x-0 bottom-0 md:inset-0 md:flex md:items-center md:justify-center z-[90] px-4 md:px-0">
         <div
           className={`w-full md:w-96 rounded-t-2xl md:rounded-2xl ${
             isDark ? 'bg-black border-yellow-500/30' : 'bg-white border-gray-200'

--- a/client/src/services/FrontEnd/src/components/modals/FollowListModal.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/FollowListModal.tsx
@@ -124,7 +124,7 @@ const FollowListModal: React.FC<Props> = ({ type }) => {
       isOpen={isOpen}
       onClose={closeModal}
       maxWidth="max-w-lg"
-      className="max-h-[80vh] overflow-hidden"
+      className="max-h-[80vh] max-h-[80dvh] overflow-hidden"
     >
       <ModalHeader
         title={type === 'following' ? t('profile.stats.following') : t('profile.stats.followers')}
@@ -132,7 +132,7 @@ const FollowListModal: React.FC<Props> = ({ type }) => {
       />
 
       {/* Content */}
-      <div className="overflow-y-auto max-h-[calc(80vh-4rem)]">
+      <div className="overflow-y-auto overscroll-contain max-h-[calc(80vh-4rem)] max-h-[calc(80dvh-4rem)]">
         {loading && users.length === 0 ? (
           <div className="p-8 text-center">
             <div className="animate-spin text-2xl">⌛</div>

--- a/client/src/services/FrontEnd/src/components/modals/ModalWrapper.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/ModalWrapper.tsx
@@ -67,13 +67,26 @@ const ModalWrapper: React.FC<ModalWrapperProps> = ({
 
     document.addEventListener('keydown', handleKeyDown)
 
-    // Prevent body scroll when modal is open
+    // Prevent body scroll when modal is open.
+    // iOS Safari ignores `overflow:hidden` on body for touch, so use the
+    // position:fixed trick which works on iOS, Android Chrome, and desktop.
+    const scrollY = window.scrollY
     const originalOverflow = document.body.style.overflow
+    const originalPosition = document.body.style.position
+    const originalTop = document.body.style.top
+    const originalWidth = document.body.style.width
     document.body.style.overflow = 'hidden'
+    document.body.style.position = 'fixed'
+    document.body.style.top = `-${scrollY}px`
+    document.body.style.width = '100%'
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
       document.body.style.overflow = originalOverflow
+      document.body.style.position = originalPosition
+      document.body.style.top = originalTop
+      document.body.style.width = originalWidth
+      window.scrollTo(0, scrollY)
     }
   }, [isOpen, handleKeyDown])
 

--- a/client/src/services/FrontEnd/src/components/modals/ShareProfileCardModal.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/ShareProfileCardModal.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react'
+import { ShareProfileCard } from '~/components/share/ShareProfileCard'
+import { useTheme } from '~/hooks/useTheme'
+import { ShareModal } from '~/components/ShareModal'
+import { HiShare } from 'react-icons/hi'
+import { useLayoutStore } from '~/store/layoutStore'
+
+type ShareProfileCardModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  username: string
+  displayName?: string
+  avatarSrc: string
+  profilePath: string
+}
+
+export const ShareProfileCardModal: React.FC<ShareProfileCardModalProps> = ({
+  isOpen,
+  onClose,
+  username,
+  displayName,
+  avatarSrc,
+  profilePath
+}) => {
+  const { isDark } = useTheme()
+  const [showShareModal, setShowShareModal] = useState(false)
+  const setHideMobileNavOverride = useLayoutStore(s => s.setHideMobileNavOverride)
+  // Keep a stable string around (future: can be used for copy/share text)
+  const _profileUrl = `${window.location.origin}${profilePath}`
+
+  useEffect(() => {
+    if (!isOpen) return
+    setShowShareModal(false)
+
+    // Mobile-only: hide bottom nav + FAB while overlay is open.
+    const isMobile = window.matchMedia('(max-width: 767px)').matches
+    if (isMobile) setHideMobileNavOverride(true)
+
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKeyDown)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      document.body.style.overflow = prevOverflow
+      if (isMobile) setHideMobileNavOverride(false)
+    }
+  }, [isOpen, onClose, setHideMobileNavOverride])
+
+  if (!isOpen) return null
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-40 transition-opacity"
+        onMouseDown={onClose}
+      />
+
+      {/* Card + action container */}
+      <div
+        className="fixed inset-0 z-50 px-4 flex items-center justify-center"
+        onMouseDown={onClose}
+        onTouchStart={onClose}
+      >
+        {/* Desktop: stack card + button together. Mobile: keep card centered, button fixed bottom. */}
+        <div
+          className="w-full max-w-[420px] flex flex-col items-center md:gap-4"
+          onMouseDown={(e) => e.stopPropagation()}
+          onTouchStart={(e) => e.stopPropagation()}
+        >
+          <div className="flex justify-center -translate-y-[3vh] md:-translate-y-[6vh]">
+            <ShareProfileCard
+              username={username}
+              displayName={displayName}
+              avatarSrc={avatarSrc}
+              profilePath={profilePath}
+            />
+          </div>
+
+          <div className="hidden md:flex justify-center -translate-y-[6vh]">
+            <button
+              type="button"
+              onClick={() => setShowShareModal(true)}
+              className={[
+                'share-profile-btn px-7 py-3 rounded-full font-semibold border text-sm transition-colors duration-200',
+                'bg-yellow-500 text-black border-yellow-500'
+              ].join(' ')}
+            >
+              <span className="inline-flex items-center gap-2">
+                <HiShare className="w-5 h-5" />
+                Share profile
+              </span>
+            </button>
+          </div>
+        </div>
+
+        {/* Mobile fixed bottom action */}
+        <div
+          className="md:hidden fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom)+7.5rem)] z-[60] flex justify-center px-4"
+          onMouseDown={(e) => e.stopPropagation()}
+          onTouchStart={(e) => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            onClick={() => setShowShareModal(true)}
+            className={[
+              'w-auto max-w-[260px] px-4 py-2.5 rounded-full font-semibold border text-sm',
+              'bg-yellow-500 text-black border-yellow-500'
+            ].join(' ')}
+          >
+            <span className="inline-flex items-center justify-center gap-2">
+              <HiShare className="w-5 h-5" />
+              Share profile
+            </span>
+          </button>
+        </div>
+
+        <style>{`
+          @media (hover: hover) and (pointer: fine) {
+            .share-profile-btn { cursor: pointer; }
+            .share-profile-btn:hover { background: #f2cf5a; border-color: #f2cf5a; }
+          }
+        `}</style>
+      </div>
+
+      <ShareModal
+        isOpen={showShareModal}
+        onClose={() => setShowShareModal(false)}
+        url={profilePath}
+        title={`${displayName ?? '@' + username}'s profile`}
+      />
+    </>
+  )
+}

--- a/client/src/services/FrontEnd/src/components/share/FlipCard.tsx
+++ b/client/src/services/FrontEnd/src/components/share/FlipCard.tsx
@@ -1,0 +1,112 @@
+import React, { useMemo, useState } from 'react'
+
+type FlipCardSize = {
+  width?: string
+  height?: string
+  aspectRatio?: string
+}
+
+export type FlipCardProps = {
+  front: React.ReactNode
+  back: React.ReactNode
+  className?: string
+  size?: FlipCardSize
+  /** If true, tapping/clicking toggles flip. Keeps hover flip too. */
+  flipOnClick?: boolean
+}
+
+/**
+ * 3D flip card.
+ * - Desktop: flips on hover.
+ * - Mobile: flips on tap (optional via flipOnClick).
+ */
+export const FlipCard: React.FC<FlipCardProps> = ({
+  front,
+  back,
+  className,
+  size,
+  flipOnClick = true
+}) => {
+  const [flipped, setFlipped] = useState(false)
+
+  const outerStyle = useMemo<React.CSSProperties>(() => {
+    const width = size?.width ?? 'clamp(220px, 70vw, 340px)'
+    const aspectRatio = size?.aspectRatio ?? '190 / 254'
+    const height = size?.height
+
+    return {
+      perspective: 1000,
+      width,
+      ...(height ? { height } : { aspectRatio })
+    }
+  }, [size?.aspectRatio, size?.height, size?.width])
+
+  const innerStyle = useMemo<React.CSSProperties>(() => {
+    return {
+      transformStyle: 'preserve-3d',
+      transition: 'transform 800ms',
+      transform: flipped ? 'rotateY(180deg)' : 'rotateY(0deg)'
+    }
+  }, [flipped])
+
+  const faceStyle = useMemo<React.CSSProperties>(() => {
+    return {
+      backfaceVisibility: 'hidden',
+      WebkitBackfaceVisibility: 'hidden'
+    }
+  }, [])
+
+  return (
+    <div
+      className={['flip-card group bg-transparent', className].filter(Boolean).join(' ')}
+      style={outerStyle}
+      onClick={() => {
+        if (!flipOnClick) return
+        setFlipped(v => !v)
+      }}
+      role={flipOnClick ? 'button' : undefined}
+      tabIndex={flipOnClick ? 0 : undefined}
+      onKeyDown={(e) => {
+        if (!flipOnClick) return
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          setFlipped(v => !v)
+        }
+      }}
+      aria-label={flipOnClick ? 'Flip card' : undefined}
+    >
+      <div
+        className="relative h-full w-full text-center"
+        style={innerStyle}
+      >
+        <div
+          className="absolute inset-0 flex flex-col items-center justify-center rounded-2xl"
+          style={faceStyle}
+        >
+          {front}
+        </div>
+        <div
+          className="absolute inset-0 flex flex-col items-center justify-center rounded-2xl"
+          style={{
+            ...faceStyle,
+            transform: 'rotateY(180deg)'
+          }}
+        >
+          {back}
+        </div>
+      </div>
+
+      {/* Desktop hover behavior */}
+      <style>{`
+        @media (hover: hover) and (pointer: fine) {
+          .flip-card {
+            cursor: pointer;
+          }
+          .group:hover > div {
+            transform: rotateY(180deg) !important;
+          }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/client/src/services/FrontEnd/src/components/share/ShareProfileCard.tsx
+++ b/client/src/services/FrontEnd/src/components/share/ShareProfileCard.tsx
@@ -1,0 +1,147 @@
+import React from 'react'
+import { useTheme } from '~/hooks/useTheme'
+import Avatar from '~/components/Avatar'
+import cawLogo from '~/assets/images/caw-logo.png'
+import { FlipCard } from './FlipCard'
+
+export type ShareProfileCardProps = {
+  username: string
+  displayName?: string
+  avatarSrc: string
+  profilePath: string
+}
+
+export const ShareProfileCard: React.FC<ShareProfileCardProps> = ({ username, displayName, avatarSrc, profilePath }) => {
+  const { isDark } = useTheme()
+  const [qrDataUrl, setQrDataUrl] = React.useState<string | null>(null)
+  const profileUrl = `${window.location.origin}${profilePath}`
+
+  React.useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const mod = await import('qrcode')
+        const toDataURL = (mod as any).toDataURL as ((text: string, opts: any) => Promise<string>) | undefined
+        if (!toDataURL) throw new Error('qrcode.toDataURL missing (bad import shape)')
+
+        const url = await toDataURL(profileUrl, {
+          margin: 1,
+          errorCorrectionLevel: 'M',
+          color: {
+            // Always black-on-white for scan reliability
+            dark: '#000000',
+            light: '#FFFFFF'
+          }
+        })
+        if (!cancelled) setQrDataUrl(url)
+      } catch (err) {
+        console.error('QR generation failed:', err)
+        if (!cancelled) setQrDataUrl(null)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [profileUrl, isDark])
+
+  return (
+    <FlipCard
+      className="select-none"
+      front={
+        <div
+          className={[
+            'h-full w-full rounded-2xl border shadow-[0_8px_14px_0_rgba(0,0,0,0.20)]',
+            'flex flex-col items-center justify-center px-6',
+            isDark
+              ? 'border-[#2a2a2a] bg-gradient-to-br from-[#0b0b0b] via-[#111] to-[#0b0b0b] text-white'
+              : 'border-[#e5e7eb] bg-gradient-to-br from-white via-[#fafafa] to-[#f5f5f5] text-gray-900'
+          ].join(' ')}
+        >
+          <div className="flex flex-col items-center">
+            <img
+              src={cawLogo}
+              alt="CAW Logo"
+              width={88}
+              height={88}
+              decoding="sync"
+              loading="eager"
+              fetchPriority="high"
+              className={['w-[88px] h-[88px] object-contain', isDark ? '' : 'drop-shadow-[1px_1px_1px_rgba(0,0,0,0.8)]'].join(' ')}
+            />
+            <span
+              className="mt-1 text-[2.5rem]"
+              style={{
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: 800,
+                color: '#ebc046',
+                letterSpacing: '3px',
+                textShadow: isDark
+                  ? '0 1px 2px rgba(0, 0, 0, 0.6), 0 0 4px rgba(0, 0, 0, 0.3)'
+                  : 'rgba(0,0,0,1) 0.5px 0.5px 1px, rgba(0,0,0,0.3) 1.5px 1.5px 1px, rgba(240,177,0,1) 0px 0px 3px'
+              }}
+            >
+              CAW
+            </span>
+          </div>
+
+          <p className={['mt-2 text-center text-sm font-semibold', isDark ? 'text-white/90' : 'text-gray-800'].join(' ')}>
+            Decentralized Social Clearing House
+          </p>
+        </div>
+      }
+      back={
+        <div
+          className={[
+            'h-full w-full rounded-2xl border shadow-[0_8px_14px_0_rgba(0,0,0,0.20)]',
+            'relative flex flex-col items-center justify-center px-6',
+            isDark
+              ? 'border-[#2a2a2a] bg-gradient-to-br from-[#ebc046] via-black to-[#ebc046] text-white'
+              : 'border-[#e5e7eb] bg-gradient-to-br from-[#ffe9a5] via-white to-[#ffe3a0] text-gray-900'
+          ].join(' ')}
+        >
+          {/* NFT preview corner mark */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="20 20 70 70"
+            className="absolute top-4 left-4 w-14 h-14"
+            aria-hidden="true"
+          >
+            <path
+              d="M30.36,35.15l15.28,1.29a7.47,7.47,0,0,0,5.29-3l-1.84-7.27a33,33,0,0,1,8.77,0L56,33.42s1.69,3.13,6.6,2.94c.75,0,14-1.25,14-1.25L69.15,45.52l-5.73.54a9.57,9.57,0,0,1-4.11-.29,10.59,10.59,0,0,1-3-1.63L53.47,50.6l-2.73-6.45a10.13,10.13,0,0,0-1.52.88c-2,1.36-5.49,1.08-5.49,1.08l-5.82-.48Z"
+              fill="#000000"
+            />
+            <path
+              d="M48.32,84.39,41.8,70.51a7.45,7.45,0,0,0-5.25-3.07l-5.39,5.22a33.26,33.26,0,0,1-4.4-7.58L34,63s1.86-3-.75-7.18c-.4-.63-8.06-11.48-8.06-11.48l12.72,1.23,3.33,4.69A9.54,9.54,0,0,1,43.05,54a10.71,10.71,0,0,1,.09,3.41l7-.76-4.22,5.59a10.44,10.44,0,0,0,1.52.86c2.19,1.08,3.67,4.22,3.67,4.22l2.5,5.28Z"
+              fill="#000000"
+            />
+            <path
+              d="M82,44.21,73.25,56.8a7.46,7.46,0,0,0,0,6.09l7.22,2a32.65,32.65,0,0,1-4.36,7.6l-5.39-5.26s-3.55-.1-5.85,4.25c-.35.66-5.9,12.72-5.9,12.72l-5.3-11.64L56,67.39A9.69,9.69,0,0,1,58.34,64a10.82,10.82,0,0,1,2.9-1.78L57.07,56.5l6.95.86a11.11,11.11,0,0,0,0-1.76c-.17-2.43,1.81-5.29,1.81-5.29l3.32-4.8Z"
+              fill="#000000"
+            />
+          </svg>
+
+          <div className="flex flex-col items-center">
+            <div className="w-20 h-20 rounded-full overflow-hidden">
+              <Avatar src={avatarSrc} alt={displayName ?? username} className="w-full h-full" size="small" />
+            </div>
+            <p className={['mt-4 text-3xl font-black tracking-tight text-center', isDark ? 'text-white' : 'text-gray-900'].join(' ')}>
+              {displayName ?? `@${username}`}
+            </p>
+
+            <div className="mt-4 rounded-lg overflow-hidden bg-transparent">
+              {qrDataUrl ? (
+                <img
+                  src={qrDataUrl}
+                  alt="Profile QR"
+                  className="w-[168px] h-[168px] block"
+                />
+              ) : (
+                <div className={['w-[168px] h-[168px] flex items-center justify-center text-sm font-medium', isDark ? 'text-white' : 'text-gray-800'].join(' ')}>
+                  Generating QR…
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      }
+    />
+  )
+}

--- a/client/src/services/FrontEnd/src/hooks/useDm.ts
+++ b/client/src/services/FrontEnd/src/hooks/useDm.ts
@@ -764,7 +764,7 @@ export function useDmMessages(
 
   // Load and decrypt messages
   useEffect(() => {
-    if (!conversationId || !tokenId) return
+    if (!conversationId || !tokenId || peerUserId === undefined) return
 
     let cancelled = false
 

--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -81,6 +81,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
   // a data router, so useMatches throws. The override store covers the
   // one dynamic case we actually have.
   const hideChromeOverride = useLayoutStore(s => s.hideChromeOverride)
+  const hideMobileNavOverride = useLayoutStore(s => s.hideMobileNavOverride)
   const hideSidebars = hideChromeOverride || hideSidebarsProp || (isCaptive && (location.pathname.startsWith('/help') || location.pathname.startsWith('/usernames') || location.pathname.startsWith('/faucet')))
 
   // Publish the bottom-nav height as a CSS variable so pages with their own
@@ -88,7 +89,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
   // nav instead of being covered by it. Resolves to "0px" whenever the nav
   // isn't rendered, is `md:hidden` on desktop, or is translated off-screen
   // by the inline-draft state.
-  const showBottomNav = !hideSidebars && !isCaptive
+  const showBottomNav = !hideSidebars && !isCaptive && !hideMobileNavOverride
   useEffect(() => {
     const root = document.documentElement
     if (!showBottomNav || hasInlineDraft) {
@@ -295,7 +296,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
       )}
 
       {/* Mobile bottom nav */}
-      {!hideSidebars && !isCaptive && (
+      {!hideSidebars && !isCaptive && !hideMobileNavOverride && (
         <nav
           ref={bottomNavRef}
           className={`md:hidden fixed bottom-0 left-0 right-0 z-[55] flex items-center justify-around h-14 pb-[env(safe-area-inset-bottom)] [height:calc(theme(height.14)+env(safe-area-inset-bottom))] border-t transition-all duration-200 ${
@@ -337,7 +338,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
       )}
 
       {/* Mobile compose FAB */}
-      {!hideSidebars && !isCaptive && !(
+      {!hideSidebars && !isCaptive && !hideMobileNavOverride && !(
         location.pathname.startsWith('/messages') ||
         location.pathname.startsWith('/usernames') ||
         location.pathname.startsWith('/staking') ||

--- a/client/src/services/FrontEnd/src/pages/Messages.tsx
+++ b/client/src/services/FrontEnd/src/pages/Messages.tsx
@@ -2864,7 +2864,7 @@ const MessagesPage: React.FC = () => {
         isOpen={isNewMessageModalOpen}
         onClose={closeModal}
         maxWidth="max-w-md"
-        className="max-h-[80vh] flex flex-col"
+        className="max-h-[80vh] max-h-[80dvh] flex flex-col"
       >
             {/* Header */}
             <div className="flex items-center justify-between p-4 border-b border-white/20">
@@ -2915,7 +2915,7 @@ const MessagesPage: React.FC = () => {
                 </div>
 
                 {/* User List */}
-                <div className="flex-1 overflow-y-auto">
+                <div className="flex-1 overflow-y-auto overscroll-contain">
                   {isSearching ? (
                     <div className="flex justify-center py-8">
                       <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-yellow-500"></div>

--- a/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
+++ b/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
@@ -30,6 +30,7 @@ import { useFollowButton } from '~/hooks/useFollowButton'
 import { useT } from '~/i18n/I18nProvider'
 import { useBlockedUsersStore } from '~/store/blockedUsersStore'
 import TipModal from '~/components/modals/TipModal'
+import { ShareProfileCardModal } from '~/components/modals/ShareProfileCardModal'
 import { useTransferModalStore } from '~/store/transferModalStore'
 import { useMarketplaceStore, MarketplaceListing, MarketplaceOffer } from '~/store/marketplaceStore'
 import { CAW_NAME_MARKETPLACE_ADDRESS } from '~/../../../abi/addresses'
@@ -37,6 +38,7 @@ import { cawProfileMarketplaceAbi } from '~/../../../abi/generated'
 import Tooltip from '~/components/Tooltip'
 import { useSignInModalStore } from '~/store/signInModalStore'
 import ProfileEditForm from '~/components/ProfileEditForm'
+import ImageLightbox from '~/components/ImageLightbox'
 
 type ProfileTab = 'posts' | 'likes' | 'replies' | 'media'
 
@@ -177,6 +179,9 @@ export const Profile: React.FC = () => {
   // Options menu state (mute/block for other profiles, manage for own profile)
   const [showOptionsMenu, setShowOptionsMenu] = useState(false)
   const [showOwnProfileMenu, setShowOwnProfileMenu] = useState(false)
+  const [showShareProfileCard, setShowShareProfileCard] = useState(false)
+  const [showAvatarModal, setShowAvatarModal] = useState(false)
+  const [showCoverModal, setShowCoverModal] = useState(false)
   const [isMuted, setIsMuted] = useState(false)
   const [showBlockConfirmModal, setShowBlockConfirmModal] = useState(false)
   const [showCostExplanation, setShowCostExplanation] = useState(false)
@@ -883,7 +888,8 @@ export const Profile: React.FC = () => {
             <img
               src={profileData.coverPhotoUrl}
               alt="Cover photo"
-              className="w-full h-full object-cover"
+              className="w-full h-full object-cover cursor-pointer"
+              onClick={() => setShowCoverModal(true)}
             />
           ) : (
             <div
@@ -910,7 +916,11 @@ export const Profile: React.FC = () => {
         {/* Profile Picture - Positioned within max-w-2xl bounds */}
         <div className="max-w-2xl mx-auto relative">
           <div className="absolute -top-20 left-6">
-            <div className={`w-40 h-40 rounded-full border-4 overflow-hidden transition-all duration-300 ${
+            <button
+              type="button"
+              aria-label="View profile photo"
+              onClick={() => setShowAvatarModal(true)}
+              className={`w-40 h-40 rounded-full border-4 overflow-hidden transition-all duration-300 cursor-pointer ${
               isDark ? 'border-black bg-black' : 'border-white bg-gray-200'
             }`}>
               {profileData && (
@@ -920,7 +930,7 @@ export const Profile: React.FC = () => {
                   className="w-full h-full rounded-full"
                 />
               )}
-            </div>
+            </button>
           </div>
         </div>
       </div>
@@ -1201,11 +1211,22 @@ export const Profile: React.FC = () => {
                             <button
                               onClick={() => {
                                 setShowOwnProfileMenu(false)
+                                setShowShareProfileCard(true)
+                              }}
+                              className={`w-full px-4 py-3 text-left text-sm transition-colors cursor-pointer ${
+                                isDark ? 'hover:bg-white/10 text-white' : 'hover:bg-gray-100 text-gray-900'
+                              }`}
+                            >
+                              Share profile
+                            </button>
+                            <button
+                              onClick={() => {
+                                setShowOwnProfileMenu(false)
                                 if (profileData?.tokenId !== undefined && profileData?.username) {
                                   useMarketplaceStore.getState().openCreateListing(profileData.tokenId, profileData.username)
                                 }
                               }}
-                              className={`w-full px-4 py-3 text-left text-sm transition-colors ${
+                              className={`w-full px-4 py-3 text-left text-sm transition-colors cursor-pointer ${
                                 isDark ? 'hover:bg-white/10 text-yellow-500' : 'hover:bg-gray-100 text-yellow-600'
                               }`}
                             >
@@ -1218,7 +1239,7 @@ export const Profile: React.FC = () => {
                                   useMarketplaceStore.getState().openViewOffers(profileData.tokenId, profileData.username)
                                 }
                               }}
-                              className={`w-full px-4 py-3 text-left text-sm transition-colors ${
+                              className={`w-full px-4 py-3 text-left text-sm transition-colors cursor-pointer ${
                                 isDark ? 'hover:bg-white/10 text-yellow-500' : 'hover:bg-gray-100 text-yellow-600'
                               }`}
                             >
@@ -1231,7 +1252,7 @@ export const Profile: React.FC = () => {
                                   useTransferModalStore.getState().show(profileData.tokenId, profileData.username)
                                 }
                               }}
-                              className={`w-full px-4 py-3 text-left text-sm transition-colors ${
+                              className={`w-full px-4 py-3 text-left text-sm transition-colors cursor-pointer ${
                                 isDark ? 'hover:bg-red-500/20 text-red-400' : 'hover:bg-red-50 text-red-500'
                               }`}
                             >
@@ -1590,6 +1611,36 @@ export const Profile: React.FC = () => {
       )}
 
       {/* Tip Modal */}
+      <ShareProfileCardModal
+        isOpen={showShareProfileCard}
+        onClose={() => setShowShareProfileCard(false)}
+        username={profileData?.username || displayUsername}
+        displayName={profileData?.displayName}
+        avatarSrc={getUserAvatar(profileData ?? { tokenId: activeTokenId || 1 })}
+        profilePath={`/users/${profileData?.username || displayUsername}`}
+      />
+
+      {/* Avatar / Cover lightboxes */}
+      {profileData && (
+        <>
+          <ImageLightbox
+            isOpen={showAvatarModal}
+            onClose={() => setShowAvatarModal(false)}
+            src={optimisticAvatar || getUserAvatar(profileData)}
+            alt={`${profileData.username || displayUsername} avatar`}
+            imgClassName="rounded-full w-[70vmin] h-[70vmin] max-w-[420px] max-h-[420px] object-cover"
+          />
+          {profileData.coverPhotoUrl && (
+            <ImageLightbox
+              isOpen={showCoverModal}
+              onClose={() => setShowCoverModal(false)}
+              src={profileData.coverPhotoUrl}
+              alt="Cover photo"
+            />
+          )}
+        </>
+      )}
+
       {profileData && (
         <TipModal
           isOpen={showTipModal}

--- a/client/src/services/FrontEnd/src/store/layoutStore.ts
+++ b/client/src/services/FrontEnd/src/store/layoutStore.ts
@@ -8,9 +8,16 @@ import { create } from 'zustand'
 interface LayoutState {
   hideChromeOverride: boolean
   setHideChromeOverride: (v: boolean) => void
+
+  /** Mobile-only: hide bottom nav + compose FAB without killing headers/sidebars. */
+  hideMobileNavOverride: boolean
+  setHideMobileNavOverride: (v: boolean) => void
 }
 
 export const useLayoutStore = create<LayoutState>((set) => ({
   hideChromeOverride: false,
   setHideChromeOverride: (v) => set({ hideChromeOverride: v }),
+
+  hideMobileNavOverride: false,
+  setHideMobileNavOverride: (v) => set({ hideMobileNavOverride: v }),
 }))


### PR DESCRIPTION
Bundle of profile-page UX polish lifted from feat/ui-improvements-fixes:

- Share profile card modal: new ShareProfileCardModal with a flip-card preview (FlipCard + ShareProfileCard components) so users can share a visual representation of their profile.

- Avatar / cover lightbox: clicking the avatar or cover image on a profile now opens the existing ImageLightbox for a full-size view.

- Mobile modal scroll stability: Follow list and New Message modals no longer jitter or lose scroll position on mobile when the keyboard or address bar resizes the viewport (ModalWrapper + FollowListModal).
