### PR TITLE
feat(ui): feed video player, reply threads, mobile nav & layout polish

### DIFF
--- a/client/src/services/FrontEnd/src/components/ContentWithHashtags.tsx
+++ b/client/src/services/FrontEnd/src/components/ContentWithHashtags.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import LinkPreview from './LinkPreview'
+import PostVideo from './PostVideo'
 import Tooltip from '~/components/Tooltip'
 import ImageLightbox from './ImageLightbox'
 import { useCachedFetch } from '~/hooks/useCachedFetch'
@@ -181,18 +182,8 @@ const ShortUrlVideo: React.FC<{
   if (!originalUrl || videoErrors.has(originalUrl)) return null
 
   return (
-    <div className="my-2 w-full max-w-full">
-      <video
-        src={originalUrl}
-        autoPlay
-        controls
-        className="w-full max-h-[32rem] min-w-[100px] rounded-lg"
-        loop
-        muted
-        onError={() => onError(originalUrl)}
-        onClick={(e) => e.stopPropagation()}
-        playsInline
-      />
+    <div className="my-2 w-full max-w-full rounded-lg overflow-hidden">
+      <PostVideo url={originalUrl} onError={() => onError(originalUrl)} />
     </div>
   )
 }

--- a/client/src/services/FrontEnd/src/components/FeedItem.tsx
+++ b/client/src/services/FrontEnd/src/components/FeedItem.tsx
@@ -26,6 +26,7 @@ import {
   HiOutlineX,
   HiOutlineShieldCheck,
 } from 'react-icons/hi'
+import PostVideo from './PostVideo'
 import Recaw from '~/assets/images/recaw.svg?react';
 import UserHoverCard from './UserHoverCard';
 import Pencil from '~/assets/images/pencil.svg?react';
@@ -124,7 +125,8 @@ const ReplyShortUrlGifThumb: React.FC<{ code: string; originHost?: string; wrapp
   )
 }
 
-const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolean; hideParentPreview?: boolean; hideMedia?: boolean; contentClassName?: string; uiDensity?: 'normal' | 'compact'; onBookmarkUpdate?: (cawId: number, isBookmarked: boolean) => void; onLikeStateChange?: (cawId: string, likePending: boolean) => void; onRecawStateChange?: (cawId: string, recawPending: boolean) => void; onReplyStateChange?: (cawId: string, replyPending: boolean) => void; onTipStateChange?: (cawId: string, tipPending: boolean) => void; onPinUpdate?: (cawId: string, isPinned: boolean) => void }> = ({ item, isMainPost = false, isReply = false, hideParentPreview = false, hideMedia = false, contentClassName, uiDensity = 'normal', onBookmarkUpdate, onLikeStateChange, onRecawStateChange, onReplyStateChange, onTipStateChange, onPinUpdate }) => {
+
+const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolean; hideParentPreview?: boolean; hideMedia?: boolean; contentClassName?: string; uiDensity?: 'normal' | 'compact'; showReplyRail?: boolean; hideBottomBorder?: boolean; inThread?: boolean; onBookmarkUpdate?: (cawId: number, isBookmarked: boolean) => void; onLikeStateChange?: (cawId: string, likePending: boolean) => void; onRecawStateChange?: (cawId: string, recawPending: boolean) => void; onReplyStateChange?: (cawId: string, replyPending: boolean) => void; onTipStateChange?: (cawId: string, tipPending: boolean) => void; onPinUpdate?: (cawId: string, isPinned: boolean) => void }> = ({ item, isMainPost = false, isReply = false, hideParentPreview = false, hideMedia = false, contentClassName, uiDensity = 'normal', showReplyRail = true, hideBottomBorder = false, inThread = false, onBookmarkUpdate, onLikeStateChange, onRecawStateChange, onReplyStateChange, onTipStateChange, onPinUpdate }) => {
   // For plain recaws, pending states and counts should reflect the original post (parent),
   // not the recaw wrapper. useItem is set to item.parent for recaws further below, but
   // we need the right source for initial state here. Quotes act as their own posts.
@@ -1059,7 +1061,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
   return (
     <>
       <div onClick={handleCardClick} className="block" data-caw-id={item.id}>
-        <div className={`p-4 transition-all duration-300 feed-item-hover cursor-pointer border-b ${
+        <div className={`p-4 transition-all duration-300 feed-item-hover cursor-pointer ${hideBottomBorder ? 'feed-item-no-divider' : 'border-b'} ${
           isDark ? 'border-gray-800' : 'border-gray-200'
         } ${
           item.status === 'FAILED' ? 'opacity-60' : ''
@@ -1217,9 +1219,9 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
           )}
 
           {/* Content wrapper with left padding for replies - applies when isReply OR when it has a parent (reply in main feed), but NOT for recaws or quotes */}
-          <div className={`relative ${(isReply || (item.parent && !isRecaw && !isQuote)) ? 'pl-6' : ''}`}>
+          <div className={`relative ${(isReply || (item.parent && !isRecaw && !isQuote) || inThread) ? 'pl-6' : ''}`}>
             {/* Vertical line for replies */}
-            {(isReply || (item.parent && !isRecaw && !isQuote)) && (
+            {showReplyRail && (isReply || (item.parent && !isRecaw && !isQuote)) && (
               <div
                 className="absolute w-px bg-white/20"
                 style={{
@@ -1231,12 +1233,12 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
             )}
 
           {/* Post Header */}
-          <div className={`flex justify-between mb-3 ${isReply ? 'items-start' : 'items-center'}`}>
+          <div className={`flex justify-between mb-3 ${isReply ? 'items-start' : 'items-center'} ${inThread ? 'max-md:-ml-4 -ml-2' : ''}`}>
             <div className="flex items-center space-x-3">
               {/* Avatar */}
               <Link
                 to={`/users/${useItem.user.username}`}
-                className="w-10 h-10 rounded-full cursor-pointer overflow-hidden border border-gray-700"
+                className={`relative z-10 w-10 h-10 rounded-full cursor-pointer overflow-hidden border border-gray-700 ${inThread ? (isDark ? 'bg-black' : 'bg-white') : ''}`}
               >
                 <Avatar
                   src={getUserAvatar(useItem.user)}
@@ -1373,14 +1375,14 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
 
           {/* Post Content */}
           {isTranslating ? (
-            <div className={`mb-4 pl-2 md:pl-0 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+            <div className={`mb-4 ${inThread ? 'pl-10' : 'pl-2 md:pl-0'} ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
               <div className="flex items-center space-x-2">
                 <div className="w-4 h-4 border-2 border-gray-400 border-t-blue-500 rounded-full animate-spin"></div>
                 <span className="text-sm">{t('post.translating')}</span>
               </div>
             </div>
           ) : translatedText ? (
-            <div className="mb-4 pl-2 md:pl-0">
+            <div className={`mb-4 ${inThread ? "pl-10" : "pl-2 md:pl-0"}`}>
               <ContentWithHashtags
                 content={stripPollMarker(translatedText)}
                 postId={useItem.id}
@@ -1391,7 +1393,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
               />
             </div>
           ) : (
-            <div className="mb-4 pl-2 md:pl-0">
+            <div className={`mb-4 ${inThread ? "pl-10" : "pl-2 md:pl-0"}`}>
               <ContentWithHashtags
                 content={stripPollMarker(useItem.content)}
                 postId={useItem.id}
@@ -1407,14 +1409,14 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
               which only happens when a ::poll:...:: marker survived the
               indexer round-trip and got promoted into a Poll row. */}
           {useItem.poll && (
-            <div className="mb-4 pl-2 md:pl-0">
+            <div className={`mb-4 ${inThread ? "pl-10" : "pl-2 md:pl-0"}`}>
               <PollDisplay caw={useItem} />
             </div>
           )}
 
           {/* Video Display */}
           {!hideMedia && useItem.hasVideo && (
-            <div className="mb-4 pl-2 md:pl-0">
+            <div className={`mb-4 ${inThread ? "pl-10" : "pl-2 md:pl-0"}`}>
               {(() => {
                 // Check if videoData contains URLs
                 if (useItem.videoData) {
@@ -1423,31 +1425,8 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                   return (
                     <div className="grid grid-cols-1 gap-2 w-full">
                       {videoUrls.map((url, index) => (
-                        <div key={index} className="relative rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 bg-black">
-                          {/* src on the element directly — NOT child <source> tags
-                              with hardcoded type="video/mp4" / "video/webm".
-                              Strict browsers (Safari) refuse to play when the
-                              declared MIME doesn't match what the server returns,
-                              and a single URL can't satisfy two declared types
-                              at once. The browser sniffs MIME from the response
-                              correctly when the type isn't asserted. */}
-                          <video
-                            src={url}
-                            autoPlay
-                            controls
-                            className="w-full h-auto max-h-[32rem]"
-                            loop
-                            muted
-                            playsInline
-                            preload="metadata"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                            }}
-                            onError={(e) => {
-                              console.error('Failed to load video from URL:', url)
-                              e.currentTarget.style.display = 'none'
-                            }}
-                          />
+                        <div key={index} className="relative rounded-lg overflow-hidden">
+                          <PostVideo url={url} />
                         </div>
                       ))}
                     </div>
@@ -1460,7 +1439,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
 
           {/* Image Display */}
           {!hideMedia && useItem.hasImage && (
-            <div className="mb-4 pl-2 md:pl-0">
+            <div className={`mb-4 ${inThread ? "pl-10" : "pl-2 md:pl-0"}`}>
               {(() => {
                 // Check if imageData contains URLs or base64 data
                 if (useItem.imageData) {
@@ -1686,7 +1665,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
           })()}
 
           {/* Post Actions */}
-          <div className="flex items-center justify-between" onClick={(e) => e.stopPropagation()}>
+          <div className={`flex items-center justify-between ${inThread ? 'max-md:pl-4 pl-10' : ''}`} onClick={(e) => e.stopPropagation()}>
             <div className={`flex items-center ${uiDensity === 'compact' ? 'gap-4' : 'space-x-6'}`}>
               {/* Comments/Replies */}
               <Tooltip text={replyPending ? t('post.processing') : t('post.reply')} disabled={item.status === 'FAILED'}><button
@@ -2455,6 +2434,8 @@ export default React.memo(FeedItem, (prev, next) => {
     prev.item === next.item &&
     prev.isMainPost === next.isMainPost &&
     prev.isReply === next.isReply &&
-    prev.hideParentPreview === next.hideParentPreview
+    prev.hideParentPreview === next.hideParentPreview &&
+    prev.hideBottomBorder === next.hideBottomBorder &&
+    prev.inThread === next.inThread
   )
 })

--- a/client/src/services/FrontEnd/src/components/MediaUpload.tsx
+++ b/client/src/services/FrontEnd/src/components/MediaUpload.tsx
@@ -6,6 +6,10 @@ import {
   HiOutlineX,
   HiOutlineExclamationCircle,
   HiOutlinePlay,
+  HiOutlinePause,
+  HiOutlineVolumeUp,
+  HiOutlineVolumeOff,
+  HiOutlineArrowsExpand,
 } from 'react-icons/hi'
 import { useTheme } from '~/hooks/useTheme'
 import { useT } from '~/i18n/I18nProvider'
@@ -38,6 +42,119 @@ interface MediaUploadProps {
 const SIZE_LIMITS = {
   IMAGE_MAX: 10 * 1024 * 1024, // 10MB for images
   VIDEO_MAX: 100 * 1024 * 1024, // 100MB for videos
+}
+
+/** Video preview with hover controls (play/pause, mute, fullscreen, progress bar) */
+const VideoPreview: React.FC<{ src: string; formatDuration: (s: number) => string; onAspectReady?: (ratio: number) => void }> = ({ src, formatDuration, onAspectReady }) => {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [isPlaying, setIsPlaying] = useState(true)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [isMuted, setIsMuted] = useState(true)
+  const [showFullscreen, setShowFullscreen] = useState(false)
+
+  const togglePlay = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    const v = videoRef.current
+    if (!v) return
+    if (v.paused) v.play(); else v.pause()
+  }
+
+  const toggleMute = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    const v = videoRef.current
+    if (!v) return
+    v.muted = !v.muted
+    setIsMuted(v.muted)
+  }
+
+  const seek = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = videoRef.current
+    if (!v) return
+    v.currentTime = Number(e.target.value)
+  }
+
+  return (
+    <>
+      <div className="relative w-full group">
+        <video
+          ref={videoRef}
+          src={src}
+          autoPlay
+          muted
+          loop
+          playsInline
+          className="w-full h-auto md:max-h-[640px] object-contain cursor-pointer block"
+          onClick={togglePlay}
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+          onTimeUpdate={(e) => setCurrentTime(e.currentTarget.currentTime)}
+          onLoadedMetadata={(e) => {
+            const v = e.currentTarget
+            setDuration(v.duration)
+            if (onAspectReady && v.videoWidth && v.videoHeight) {
+              onAspectReady(v.videoWidth / v.videoHeight)
+            }
+          }}
+        />
+        <div
+          className="absolute bottom-0 left-0 right-0 px-2 py-1.5 bg-gradient-to-t from-black/80 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center gap-2 pointer-events-auto">
+            <button onClick={togglePlay} className="text-white hover:opacity-80 shrink-0 cursor-pointer" title={isPlaying ? 'Pause' : 'Play'}>
+              {isPlaying ? <HiOutlinePause className="w-8 h-8" /> : <HiOutlinePlay className="w-8 h-8" />}
+            </button>
+            <button onClick={toggleMute} className="text-white hover:opacity-80 shrink-0 cursor-pointer" title={isMuted ? 'Unmute' : 'Mute'}>
+              {isMuted ? <HiOutlineVolumeOff className="w-6 h-6" /> : <HiOutlineVolumeUp className="w-6 h-6" />}
+            </button>
+            <input
+              type="range"
+              min={0}
+              max={duration || 0}
+              value={currentTime}
+              step={0.01}
+              onChange={seek}
+              onClick={(e) => e.stopPropagation()}
+              className="flex-1 h-1 accent-yellow-500 cursor-pointer min-w-0"
+            />
+            <span className="text-[10px] text-white tabular-nums shrink-0">
+              {formatDuration(Math.floor(currentTime))} / {formatDuration(Math.floor(duration))}
+            </span>
+            <button
+              onClick={(e) => { e.stopPropagation(); setShowFullscreen(true) }}
+              className="text-white hover:opacity-80 shrink-0 cursor-pointer"
+              title="Fullscreen"
+            >
+              <HiOutlineArrowsExpand className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+      </div>
+      {showFullscreen && (
+        <div
+          className="fixed inset-0 z-[10000] bg-black/95 flex items-center justify-center p-4"
+          onClick={() => setShowFullscreen(false)}
+        >
+          <button
+            onClick={(e) => { e.stopPropagation(); setShowFullscreen(false) }}
+            className="absolute top-4 right-4 z-10 p-2 rounded-full bg-black/70 hover:bg-black/90 cursor-pointer"
+            title="Close"
+          >
+            <HiOutlineX className="w-6 h-6 text-white" />
+          </button>
+          <video
+            src={src}
+            controls
+            autoPlay
+            playsInline
+            className="max-w-full max-h-full"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
+    </>
+  )
 }
 
 /** Single media cell with preview, remove button, and drag support */
@@ -74,7 +191,7 @@ const MediaCell: React.FC<{
           : isDark ? 'bg-gray-800' : 'bg-gray-50'
     } ${draggable ? 'cursor-grab active:cursor-grabbing' : ''} ${className}`}
   >
-    <div className="relative w-full h-full bg-black">
+    <div className={`relative w-full bg-black ${media.type === 'video' ? '' : 'h-full'}`}>
       {media.type === 'image' || media.type === 'gif' ? (
         <>
           <img
@@ -92,31 +209,21 @@ const MediaCell: React.FC<{
         </>
       ) : (
         <>
-          <video src={media.preview} className="w-full h-full object-contain" />
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="bg-black/60 rounded-full p-2">
-              <HiOutlinePlay className="w-4 h-4 text-white" />
-            </div>
-          </div>
-          <span className={`absolute bottom-1 left-1 px-1 py-0.5 text-xs font-semibold rounded ${
+          <VideoPreview src={media.preview} formatDuration={formatDuration} />
+          <span className={`absolute top-1 left-1 px-1 py-0.5 text-xs font-semibold rounded pointer-events-none ${
             isDark ? 'bg-black/70 text-white' : 'bg-white/70 text-black'
           }`}>
             VIDEO
           </span>
-          {media.duration && (
-            <span className="absolute bottom-1 right-1 text-xs text-white bg-black/60 px-1 py-0.5 rounded">
-              {formatDuration(media.duration)}
-            </span>
-          )}
         </>
       )}
     </div>
     <button
       onClick={() => onRemove(index)}
-      className="absolute top-1 right-1 p-0.5 rounded-full bg-black/50 hover:bg-black/70 transition-colors"
+      className="absolute top-2 right-2 z-20 p-1.5 rounded-full bg-black/70 hover:bg-black/90 transition-colors cursor-pointer"
       title="Remove"
     >
-      <HiOutlineX className="h-3 w-3 text-white" />
+      <HiOutlineX className="h-5 w-5 text-white" />
     </button>
   </div>
 )
@@ -157,6 +264,10 @@ const MediaGrid: React.FC<{
   )
 
   if (count === 1) {
+    const isVideo = selectedMedia[0]?.type === 'video'
+    if (isVideo) {
+      return <div className="rounded-lg overflow-hidden bg-black md:max-h-[640px] flex items-center justify-center">{cell(0, 'w-full md:max-h-[640px]')}</div>
+    }
     return <div className="aspect-video rounded-lg overflow-hidden">{cell(0, 'w-full h-full')}</div>
   }
 

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -1567,7 +1567,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
   return (
       <div className={`${replyTo ? 'p-2' : 'p-4'} transition-all duration-300 ${isDark ? 'bg-black' : 'bg-white'} ${
-        hasInlineFeedDraft ? 'md:static md:p-4 md:pt-4 fixed left-0 right-0 bottom-0 top-16 z-[60] overflow-y-auto pt-14' : ''
+        hasInlineFeedDraft ? 'md:static md:p-4 md:pt-4 md:pb-4 fixed left-0 right-0 bottom-0 top-16 z-[60] overflow-y-auto pt-14 pb-[calc(env(safe-area-inset-bottom)+90px)]' : ''
       } ${composeMode ? 'flex-1 min-h-0 flex flex-col md:block md:min-h-0' : ''}`}>
       {hasInlineFeedDraft && (
         <button

--- a/client/src/services/FrontEnd/src/components/PostVideo.tsx
+++ b/client/src/services/FrontEnd/src/components/PostVideo.tsx
@@ -1,0 +1,155 @@
+import React, { useState, useRef, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  HiOutlineX,
+  HiOutlinePlay,
+  HiOutlinePause,
+  HiOutlineVolumeUp,
+  HiOutlineVolumeOff,
+  HiOutlineArrowsExpand,
+} from 'react-icons/hi'
+
+/** Video player for posts. Mobile = native browser controls (familiar UX,
+ * accessibility, buffering indicator). Desktop = custom hover overlay
+ * (no browser chrome, cleaner look, fullscreen modal). */
+const PostVideo: React.FC<{ url: string; onError?: () => void }> = ({ url, onError }) => {
+  const [isDesktop, setIsDesktop] = useState(false)
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 768px)')
+    const update = () => setIsDesktop(mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [])
+
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [isPlaying, setIsPlaying] = useState(true)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [isMuted, setIsMuted] = useState(true)
+  const [showFullscreen, setShowFullscreen] = useState(false)
+
+  useEffect(() => {
+    if (!showFullscreen) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setShowFullscreen(false) }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [showFullscreen])
+
+  const fmt = (s: number) => {
+    if (!isFinite(s)) return '0:00'
+    const m = Math.floor(s / 60)
+    const sec = Math.floor(s % 60)
+    return `${m}:${sec.toString().padStart(2, '0')}`
+  }
+  const togglePlay = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    const v = videoRef.current; if (!v) return
+    if (v.paused) v.play(); else v.pause()
+  }
+  const toggleMute = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    const v = videoRef.current; if (!v) return
+    v.muted = !v.muted; setIsMuted(v.muted)
+  }
+  const seek = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = videoRef.current; if (!v) return
+    v.currentTime = Number(e.target.value)
+  }
+
+  if (!isDesktop) {
+    return (
+      <video
+        src={url}
+        autoPlay
+        controls
+        className="w-full h-auto max-h-[32rem] block outline-none"
+        loop
+        muted
+        playsInline
+        preload="metadata"
+        onClick={(e) => e.stopPropagation()}
+        onError={onError}
+      />
+    )
+  }
+
+  return (
+    <>
+      <div className="relative w-full group">
+        <video
+          ref={videoRef}
+          src={url}
+          autoPlay
+          muted
+          loop
+          playsInline
+          preload="metadata"
+          className="w-full h-auto max-h-[32rem] block outline-none cursor-pointer"
+          onClick={togglePlay}
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+          onTimeUpdate={(e) => setCurrentTime(e.currentTarget.currentTime)}
+          onLoadedMetadata={(e) => setDuration(e.currentTarget.duration)}
+          onError={onError}
+        />
+        <div
+          className="absolute bottom-0 left-0 right-0 px-3 py-2 bg-gradient-to-t from-black/80 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center gap-2 pointer-events-auto">
+            <button onClick={togglePlay} className="text-white hover:opacity-80 shrink-0 cursor-pointer" title={isPlaying ? 'Pause' : 'Play'}>
+              {isPlaying ? <HiOutlinePause className="w-7 h-7" /> : <HiOutlinePlay className="w-7 h-7" />}
+            </button>
+            <button onClick={toggleMute} className="text-white hover:opacity-80 shrink-0 cursor-pointer" title={isMuted ? 'Unmute' : 'Mute'}>
+              {isMuted ? <HiOutlineVolumeOff className="w-5 h-5" /> : <HiOutlineVolumeUp className="w-5 h-5" />}
+            </button>
+            <input
+              type="range"
+              min={0}
+              max={duration || 0}
+              value={currentTime}
+              step={0.01}
+              onChange={seek}
+              onClick={(e) => e.stopPropagation()}
+              className="flex-1 h-1 accent-yellow-500 cursor-pointer min-w-0"
+            />
+            <span className="text-[11px] text-white tabular-nums shrink-0">{fmt(currentTime)} / {fmt(duration)}</span>
+            <button
+              onClick={(e) => { e.stopPropagation(); setShowFullscreen(true) }}
+              className="text-white hover:opacity-80 shrink-0 cursor-pointer"
+              title="Fullscreen"
+            >
+              <HiOutlineArrowsExpand className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+      </div>
+      {showFullscreen && createPortal(
+        <div
+          className="fixed inset-0 z-[10000] bg-black/95 flex items-center justify-center p-4"
+          onClick={() => setShowFullscreen(false)}
+        >
+          <button
+            onClick={(e) => { e.stopPropagation(); setShowFullscreen(false) }}
+            className="absolute top-4 right-4 z-10 p-2 rounded-full bg-black/70 hover:bg-black/90 cursor-pointer"
+            title="Close"
+          >
+            <HiOutlineX className="w-6 h-6 text-white" />
+          </button>
+          <video
+            src={url}
+            controls
+            autoPlay
+            playsInline
+            className="max-w-full max-h-full"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>,
+        document.body
+      )}
+    </>
+  )
+}
+
+export default PostVideo

--- a/client/src/services/FrontEnd/src/components/modals/ModalWrapper.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/ModalWrapper.tsx
@@ -129,7 +129,7 @@ const ModalWrapper: React.FC<ModalWrapperProps> = ({
     >
       <div
         ref={modalRef}
-        className={`w-full ${maxWidth} rounded-2xl transition-all duration-300 ${
+        className={`w-full ${maxWidth} max-h-[calc(100dvh-2rem)] overflow-y-auto rounded-2xl transition-all duration-300 ${
           isDark ? 'bg-black border border-yellow-500/30' : 'bg-white border border-gray-200'
         } ${className}`}
         onMouseDown={e => e.stopPropagation()}

--- a/client/src/services/FrontEnd/src/index.css
+++ b/client/src/services/FrontEnd/src/index.css
@@ -150,6 +150,9 @@ html.theme-switching *::after {
   height: 1px;
   pointer-events: none;
 }
+.feed-item-hover.feed-item-no-divider::after {
+  display: none;
+}
 :root.dark .feed-item-hover::after {
   background: linear-gradient(to right,
     transparent 0%,

--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -23,6 +23,9 @@ import { useAccount } from "wagmi";
 import WalletAccountButton from "~/components/buttons/WalletAccountButton";
 import cawLogo from '~/assets/images/caw-logo.png';
 import { themeLayoutShell } from '~/utils/theme'
+import Avatar from '~/components/Avatar';
+import { getUserAvatar } from '~/utils/defaultAvatar';
+import { useTokenDataStore } from '~/store/tokenDataStore';
 
 const BoidsBg = lazy(() => import('~/components/BoidsBg'))
 
@@ -45,6 +48,10 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
   const notifUnreadCount = useNotificationUnreadStore(s => s.unreadCount)
   const offersUnreadCount = useOffersUnreadStore(s => s.unreadCount)
   const hasInlineDraft = useComposeDraftStore(s => s.hasInlineDraft)
+  const avatarsByTokenId = useTokenDataStore(s => s.avatarsByTokenId)
+  const activeAvatarSrc = activeToken?.tokenId
+    ? (avatarsByTokenId[activeToken.tokenId] || getUserAvatar({ tokenId: activeToken.tokenId }))
+    : null
 
   // Bottom-nav transparency while scrolling: solid when idle, translucent
   // while the user actively scrolls so feed content can peek through.
@@ -322,13 +329,14 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
           }`}
         >
           {[
-            { to: '/home', icon: HiOutlineHome, match: '/home', badge: 0 },
-            { to: '/explore', icon: HiOutlineSearch, match: '/explore', badge: 0 },
-            { to: '/usernames', icon: HiOutlineColorSwatch, match: '/usernames', badge: offersUnreadCount },
-            { to: '/notifications', icon: HiOutlineBell, match: '/notifications', badge: notifUnreadCount },
-            { to: activeToken?.username ? `/users/${activeToken.username}` : '/welcome', icon: HiOutlineUser, match: activeToken?.username ? `/users/${activeToken.username}` : '/welcome', badge: 0 },
-          ].map(({ to, icon: Icon, match, badge }) => {
+            { to: '/home', icon: HiOutlineHome, match: '/home', badge: 0, isProfile: false },
+            { to: '/explore', icon: HiOutlineSearch, match: '/explore', badge: 0, isProfile: false },
+            { to: '/usernames', icon: HiOutlineColorSwatch, match: '/usernames', badge: offersUnreadCount, isProfile: false },
+            { to: '/notifications', icon: HiOutlineBell, match: '/notifications', badge: notifUnreadCount, isProfile: false },
+            { to: activeToken?.username ? `/users/${activeToken.username}` : '/welcome', icon: HiOutlineUser, match: activeToken?.username ? `/users/${activeToken.username}` : '/welcome', badge: 0, isProfile: true },
+          ].map(({ to, icon: Icon, match, badge, isProfile }) => {
             const active = location.pathname === match || location.pathname.startsWith(match + '/')
+            const showAvatar = isProfile && !!activeAvatarSrc
             return (
               <Link
                 key={to}
@@ -350,7 +358,15 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
                 }`}
               >
                 <span className="relative inline-flex">
-                  <Icon className="w-7 h-7" />
+                  {showAvatar ? (
+                    <span className={`w-7 h-7 rounded-full overflow-hidden block ${
+                      active ? (isDark ? 'ring-2 ring-yellow-500' : 'ring-2 ring-yellow-600') : ''
+                    }`}>
+                      <Avatar src={activeAvatarSrc!} size="small" className="w-full h-full object-cover" />
+                    </span>
+                  ) : (
+                    <Icon className="w-7 h-7" />
+                  )}
                   {badge > 0 && (
                     <span className={`absolute -top-1 -right-1 min-w-[18px] h-[18px] flex items-center justify-center text-[11px] font-bold rounded-full bg-yellow-500 text-black px-1 border-2 ${isDark ? 'border-black' : 'border-white'}`}>
                       {badge > 99 ? '99+' : badge}

--- a/client/src/services/FrontEnd/src/pages/CawPage.tsx
+++ b/client/src/services/FrontEnd/src/pages/CawPage.tsx
@@ -117,17 +117,36 @@ export const CawPage: React.FC = () => {
   const isQuoteItem = (c: CawItem) =>
     c.isQuote === true || (c.action === 'RECAW' && !!c.content && c.content !== '')
 
-  const feedItems = useMemo(() => {
-    return comments
+  const replyRows = useMemo(() => {
+    const replies = comments
       .filter(comm => {
         if (isQuoteItem(comm)) return false
         if (comm.status !== 'PENDING') return true
         const sig = `${comm.user.tokenId}:${comm.content?.trim()}`
         return !pendingReplies.some(p => `${p.user?.tokenId}:${p.content?.trim()}` === sig)
       })
-      .map(comm => ({ kind: 'reply' as const, timestamp: comm.timestamp, comm }))
       .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
-  }, [comments, pendingReplies])
+
+    const rootId = String(caw?.id ?? id ?? '')
+    const replyIds = new Set(replies.map(reply => String(reply.id)))
+    const directReplies = replies.filter(reply => {
+      const parentId = String(reply.parent?.id ?? '')
+      return !parentId || parentId === rootId || !replyIds.has(parentId)
+    })
+    const usedIds = new Set<string>()
+
+    const rows = directReplies.map(reply => {
+      const children = replies.filter(candidate => String(candidate.parent?.id ?? '') === String(reply.id))
+      usedIds.add(String(reply.id))
+      children.forEach(child => usedIds.add(String(child.id)))
+      return { reply, children }
+    })
+
+    const leftovers = replies.filter(reply => !usedIds.has(String(reply.id)))
+    leftovers.forEach(reply => rows.push({ reply, children: [] }))
+
+    return rows
+  }, [comments, pendingReplies, caw?.id, id])
 
   // Quotes — kept in their original order from the API so they don't
   // shuffle under any of the merge logic above.
@@ -193,17 +212,24 @@ export const CawPage: React.FC = () => {
   useEffect(() => {
     if (searchParams.get('reply') !== '1') return
     if (!isAuthenticated) return
-    // Wait for PostForm to render.
-    requestAnimationFrame(() => {
+    // Re-align after media (images/videos) finishes loading and reflows the page.
+    const scrollToForm = (behavior: ScrollBehavior) => {
       const el = document.getElementById('caw-reply-form')
-      if (!el) return
-      el.scrollIntoView({ block: 'start', behavior: 'smooth' })
-      // Focus the first textarea inside the reply form.
-      setTimeout(() => {
-        const ta = el.querySelector('textarea') as HTMLTextAreaElement | null
-        ta?.focus()
-      }, 60)
+      if (!el) return false
+      el.scrollIntoView({ block: 'start', behavior })
+      return true
+    }
+    const timers: number[] = []
+    requestAnimationFrame(() => {
+      scrollToForm('auto')
+      const el = document.getElementById('caw-reply-form')
+      const ta = el?.querySelector('textarea') as HTMLTextAreaElement | null
+      timers.push(window.setTimeout(() => ta?.focus(), 60))
+      // Catch late layout shifts from images/videos loading.
+      timers.push(window.setTimeout(() => scrollToForm('smooth'), 350))
+      timers.push(window.setTimeout(() => scrollToForm('smooth'), 900))
     })
+    return () => { timers.forEach(clearTimeout) }
   }, [searchParams, isAuthenticated])
 
   // Function to refresh comments after posting a reply
@@ -457,7 +483,7 @@ export const CawPage: React.FC = () => {
 
   return (
       <div
-        className="max-w-2xl mx-auto px-6 py-4"
+        className="max-w-2xl mx-auto px-0 md:px-6 py-4"
         style={{ paddingBottom: 'calc(var(--bottom-nav-h, 0px) + 96px)' }}
       >
         {/* Header with back button and title */}
@@ -581,7 +607,7 @@ export const CawPage: React.FC = () => {
                           .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
                           .map(c => (
                             <div key={`reply-tab-${c.id}`} className="relative">
-                              <FeedItem item={c} isReply={true} hideParentPreview={true} />
+                              <FeedItem item={c} isReply={true} hideParentPreview={true} showReplyRail={false} />
                             </div>
                           ))}
                       </div>
@@ -692,10 +718,17 @@ export const CawPage: React.FC = () => {
                   <span>Pending — waiting for on-chain confirmation</span>
                 </div>
               )}
-              <div className="relative z-10">
+              <div className="relative">
+                {((!!caw?.parent && (replyRows.length > 0 || pendingReplies.length > 0)) || (replyRows[0]?.children.length ?? 0) > 0) && (
+                  <div className={`pointer-events-none absolute left-[40px] md:left-[48px] top-9 bottom-[-72px] z-0 w-px ${isDark ? 'bg-white/20' : 'bg-gray-300'}`} />
+                )}
                 <FeedItem
                   item={caw}
                   isMainPost={true}
+                  showReplyRail={false}
+                  hideParentPreview={true}
+                  hideBottomBorder={(!!caw?.parent && (replyRows.length > 0 || pendingReplies.length > 0)) || (replyRows[0]?.children.length ?? 0) > 0}
+                  inThread={(!!caw?.parent && (replyRows.length > 0 || pendingReplies.length > 0)) || (replyRows[0]?.children.length ?? 0) > 0}
                   onReplyStateChange={(cawId, replyPending) => {
                     if (caw && caw.id === cawId) {
                       setCaw({ ...caw, replyPending })
@@ -726,19 +759,6 @@ export const CawPage: React.FC = () => {
               </div>
             )}
 
-            {/* Reply Form — only for authenticated users */}
-            {isAuthenticated && (
-              <div id="caw-reply-form" className="border-b border-white/20 mb-2">
-                <PostForm
-                  replyTo={caw}
-                  onSuccess={() => {
-                    setCaw(prev => prev ? { ...prev, replyPending: true } : prev)
-                    refreshComments()
-                  }}
-                />
-              </div>
-            )}
-
             {/* Comments Section */}
             {isAuthenticated ? (
               <div className="space-y-0 relative">
@@ -759,33 +779,91 @@ export const CawPage: React.FC = () => {
                     <FeedItem item={quote} hideParentPreview={true} />
                   </div>
                 ))}
-                {/* Replies are oldest-first (feedItems is sorted asc by
-                    timestamp), so pending replies render AFTER the
-                    confirmed list to match where they'll land once the
-                    chain catches up. Otherwise the user sees their fresh
-                    pending reply at the top, then it visibly jumps to
-                    the bottom on refresh. */}
-                {feedItems.map((entry) => {
-                  return (
-                    <div key={`reply-${entry.comm.id}`} className="relative">
-                      <FeedItem
-                        item={entry.comm}
-                        isReply={true}
-                        hideParentPreview={true}
-                        onLikeStateChange={(cawId, likePending) => {
-                          setComments(current =>
-                            current.map(item =>
-                              item.id === cawId ? { ...item, likePending } : item
+                {/* Replies render oldest-first; pending replies live at
+                    the bottom (see master fa73f585) to match where they
+                    land once the chain catches up. Thread mode (when this
+                    caw is itself a reply) draws connecting rails between
+                    rows. */}
+                {replyRows.map((row, rowIdx) => {
+                  const isFirstDirect = rowIdx === 0
+                  const isLastRow = rowIdx === replyRows.length - 1
+                  if (row.children.length === 0) {
+                    return (
+                      <div key={`reply-${row.reply.id}`} className="relative isolate">
+                        <FeedItem
+                          item={row.reply}
+                          isReply={true}
+                          hideParentPreview={true}
+                          showReplyRail={false}
+                          hideBottomBorder={!isLastRow}
+                          inThread={!!caw?.parent}
+                          onLikeStateChange={(cawId, likePending) => {
+                            setComments(current =>
+                              current.map(item =>
+                                item.id === cawId ? { ...item, likePending } : item
+                              )
                             )
-                          )
-                        }}
-                      />
+                          }}
+                        />
+                      </div>
+                    )
+                  }
+
+                  return (
+                    <div key={`thread-${row.reply.id}`} className="relative isolate">
+                      <div className="relative">
+                        {isFirstDirect && (
+                          <div className={`pointer-events-none absolute left-[40px] md:left-[48px] top-0 h-9 z-0 w-px ${isDark ? 'bg-white/20' : 'bg-gray-300'}`} />
+                        )}
+                        <div className={`pointer-events-none absolute left-[40px] md:left-[48px] top-9 bottom-0 z-0 w-px ${isDark ? 'bg-white/20' : 'bg-gray-300'}`} />
+                        <FeedItem
+                          item={row.reply}
+                          isReply={true}
+                          hideParentPreview={true}
+                          showReplyRail={false}
+                          hideBottomBorder={true}
+                          inThread={true}
+                          onLikeStateChange={(cawId, likePending) => {
+                            setComments(current =>
+                              current.map(item =>
+                                item.id === cawId ? { ...item, likePending } : item
+                              )
+                            )
+                          }}
+                        />
+                      </div>
+                      {row.children.map((child, childIndex) => {
+                        const isLastChild = childIndex === row.children.length - 1
+                        return (
+                          <div key={`reply-${child.id}`} className="relative isolate">
+                            <div className={`pointer-events-none absolute left-[40px] md:left-[48px] top-0 h-9 z-0 w-px ${isDark ? 'bg-white/20' : 'bg-gray-300'}`} />
+                            {!isLastChild && (
+                              <div className={`pointer-events-none absolute left-[40px] md:left-[48px] top-9 bottom-0 z-0 w-px ${isDark ? 'bg-white/20' : 'bg-gray-300'}`} />
+                            )}
+                            <FeedItem
+                              item={child}
+                              isReply={true}
+                              hideParentPreview={true}
+                              showReplyRail={false}
+                              hideBottomBorder={!isLastChild}
+                              inThread={true}
+                              onLikeStateChange={(cawId, likePending) => {
+                                setComments(current =>
+                                  current.map(item =>
+                                    item.id === cawId ? { ...item, likePending } : item
+                                  )
+                                )
+                              }}
+                            />
+                          </div>
+                        )
+                      })}
                     </div>
                   )
                 })}
                 {pendingReplies.map((post) => (
-                  <div key={post.tempId} className="relative">
-                    <FeedItem item={post as CawItem} isReply={true} hideParentPreview={true} />
+                  <div key={post.tempId} className="relative isolate">
+                    <FeedItem item={post as CawItem} isReply={true} hideParentPreview={true} showReplyRail={false} inThread={!!caw?.parent} />
                   </div>
                 ))}
                 {hasMoreComments && (
@@ -799,6 +877,23 @@ export const CawPage: React.FC = () => {
                     {loadingMore ? t('common.loading') : t('caw_page.load_more_replies')}
                   </button>
                 )}
+                <div id="caw-reply-form" className="border-t border-white/20 mt-2">
+                  <PostForm
+                    replyTo={caw}
+                    onSuccess={() => {
+                      setCaw(prev => prev ? { ...prev, replyPending: true } : prev)
+                      refreshComments().finally(() => {
+                        const scrollToForm = (behavior: ScrollBehavior) => {
+                          const el = document.getElementById('caw-reply-form')
+                          el?.scrollIntoView({ block: 'start', behavior })
+                        }
+                        requestAnimationFrame(() => scrollToForm('smooth'))
+                        setTimeout(() => scrollToForm('smooth'), 350)
+                        setTimeout(() => scrollToForm('smooth'), 900)
+                      })
+                    }}
+                  />
+                </div>
               </div>
             ) : (
               /* Gated replies — show count and sign-in prompt */

--- a/client/src/services/FrontEnd/src/pages/Marketplace.tsx
+++ b/client/src/services/FrontEnd/src/pages/Marketplace.tsx
@@ -190,10 +190,12 @@ const Marketplace: React.FC = () => {
             </TabButton>
           </div>
 
-          {activeTab === 'listings' && <ListingsTab />}
-          {activeTab === 'sales' && <SalesTab />}
-          {activeTab === 'mine' && <MyProfilesTab />}
-          {activeTab === 'offers' && <MyOffersTab />}
+          <div className="pb-[calc(var(--bottom-nav-h,0px)+16px)]">
+            {activeTab === 'listings' && <ListingsTab />}
+            {activeTab === 'sales' && <SalesTab />}
+            {activeTab === 'mine' && <MyProfilesTab />}
+            {activeTab === 'offers' && <MyOffersTab />}
+          </div>
         </div>
       </div>
   )

--- a/client/src/services/FrontEnd/src/pages/Staking.tsx
+++ b/client/src/services/FrontEnd/src/pages/Staking.tsx
@@ -1079,12 +1079,23 @@ const Staking = () => {
         </div>
 
         {/* Portfolio Overview */}
-        <div className="mb-8">
-          <h3 className={`text-lg font-semibold mb-4 transition-colors duration-300 ${
-            isDark ? 'text-white' : 'text-black'
-          }`}>
-            Portfolio Overview
-          </h3>
+        <div className="mb-8 md:mb-12">
+          <div className="mb-4 flex items-center justify-between">
+            <h3 className={`text-lg font-semibold transition-colors duration-300 ${
+              isDark ? 'text-white' : 'text-black'
+            }`}>
+              Portfolio Overview
+            </h3>
+
+            {/* Desktop-only Activity link — aligns with section title */}
+            <button
+              type="button"
+              onClick={() => navigate('/staking/activity')}
+              className="hidden md:inline-flex items-center px-3 py-1.5 bg-yellow-500 text-black font-semibold text-xs rounded-full hover:bg-yellow-400 transition-colors cursor-pointer"
+            >
+              View activity →
+            </button>
+          </div>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
             <div className={`px-1 pb-1 rounded-lg border transition-all duration-300 flex flex-col items-center justify-between ${isDark ? 'bg-black' : 'bg-white'} ${
               isDark ? 'border-white/20' : 'border-gray-300'
@@ -1153,7 +1164,7 @@ const Staking = () => {
             </div>
           </div>
           {/* Activity link — opens day-by-day flow page. */}
-          <div className="mt-3 flex justify-end">
+          <div className="mt-3 flex justify-end md:hidden">
             <button
               type="button"
               onClick={() => navigate('/staking/activity')}
@@ -1218,7 +1229,7 @@ const Staking = () => {
         </div>
 
         {/* Tab Content */}
-        <div className="mt-6">
+        <div className="mt-6 pb-[calc(var(--bottom-nav-h,0px)+16px)]">
           {activeTab === 'stake' && renderStakePanel()}
           {activeTab === 'unstake' && renderUnstakePanel()}
           {activeTab === 'info' && renderInfoPanel()}


### PR DESCRIPTION
 A UX/UI pass across the feed, post page, mobile nav, modals and a few page-level layout fixes. Six self-contained commits, each revertible independently if anything regresses.

  ### Feed - video player & thread-aware FeedItem (`038aed7e`)
  - New `PostVideo` component: custom desktop hover overlay (play/pause,
    mute, seek, fullscreen with ESC) and native controls on mobile.
  - Replaces the native `<video controls>` in three render paths
    (attached videos in `FeedItem`, short-URL videos in
    `ContentWithHashtags`, and the compose preview in `MediaUpload`),
    removing Chrome's hovering "control card" frame.
  - `FeedItem` gains `showReplyRail`, `hideBottomBorder`, `inThread`
    props so the post page can stitch nested reply threads.
  - `.feed-item-no-divider` modifier in `index.css`.

  ### Post page - nested reply threads & reply UX (`ee390f2b`)
  - Direct replies are grouped with their one-level children into
    `replyRows`, drawing connector rails between the main post, each
    direct reply, and its children (Twitter-style threading).
  - Reply form moved to the bottom of the comments list.
  - `?reply=1` deeplink: staggered scroll-to-form (rAF + 350ms + 900ms)
    to realign after late media reflows, plus textarea auto-focus.
  - After publishing, same staggered scroll so the new reply lands
    visible above the form.
  - Mobile container is edge-to-edge (`px-0 md:px-6`) so rails align.
  - Preserves master's `pending-replies-at-bottom` and FAB
    `paddingBottom` patterns.

  ### Mobile bottom nav - active profile avatar (`1f0ecece`)
  - The profile tab renders the active token's avatar (yellow ring when
    active) in place of the generic user icon. Falls back to the icon
    when no avatar is available.

  ### Modals - long content scrolls (`c1811c8f`)
  - `ModalWrapper` caps height at `calc(100dvh - 2rem)` and enables
    internal vertical overflow so long content scrolls inside the modal
    instead of clipping.

  ### Compose - inline draft mobile padding (`c20f5a90`)
  - When the inline feed draft is expanded fullscreen on mobile, the
    bottom padding now respects safe-area-inset-bottom + the bottom nav
    height, so the submit footer is no longer covered.

  ### Layout - marketplace/staking bottom nav + staking pill (`1b3e8636`)
  - Bottom padding (`--bottom-nav-h + 16px`) on Marketplace tabs and
    Staking tab content so the last row isn't hidden under the nav.
  - Staking "View activity" on desktop moves inline with the
    *Portfolio Overview* heading as a yellow pill button; mobile button
    unchanged (`md:hidden`).