### PR TITLE
fix(ux): mobile back buttons, recaw menu, og card tuning

### DIFF
--- a/client/src/api/routes/og.ts
+++ b/client/src/api/routes/og.ts
@@ -79,12 +79,12 @@ function getLogoDataUri(): string {
   return logoDataUri
 }
 
-// Card canvas. Width was 1200 (the OG-spec default) but at that size
-// the card felt sparse — half the platforms (Telegram, iMessage,
-// Discord) crop or letterbox to a more square aspect anyway. 860 is
-// denser, reads as one block, and still hits the OG-image minimum
-// dimensions every platform respects.
-const W = 860
+// Card canvas. 1200×630 is the OG-spec default and the only aspect
+// Twitter's `summary_large_image` renders without cropping — at the
+// previous 860×630 (1.37:1), X cropped centrally to 2:1, cutting off
+// the top/bottom of the layout. Other platforms (Facebook, LinkedIn,
+// Telegram) also expect ~1.9:1, so this matches everyone.
+const W = 1200
 const H = 630
 const CAW_GOLD = '#ebc046'
 
@@ -729,19 +729,23 @@ function statTile(value: string, label: string) {
 // isn't a sliver; cap at CARD_MAX_H (the 1200×630 OG default) so a long
 // caw doesn't blow past the standard preview slot.
 const CARD_STRIP_W = Math.round(W * 0.015)      // 18 — left yellow strip
-const CARD_MARGIN  = Math.round(W * 0.015)      // 18 — outer margin (left/right)
-// Top/bottom margin is wider than left/right so the text + stats stack
-// breathes against the card edges. Twitter's preview crops a few pixels
-// off each side; the extra vertical air keeps the chrome line / stats
-// row from kissing the crop boundary.
-const CARD_MARGIN_Y = CARD_MARGIN * 2            // 36 — outer margin (top/bottom)
+const CARD_MARGIN  = Math.round(W * 0.03)       // 36 — outer margin (left/right)
+// X/Twitter previews often feel visually tighter than a raw browser-opened
+// 1200×630 card. Keep the *important* content inside a more conservative
+// horizontal safe area so text / stats / image don't read as clipped.
+const CARD_SAFE_X  = Math.round(W * 0.10)       // 120 — conservative content safe area for X/Twitter crops
+// Vertical margin kept modest so the image (top-right) and the stats
+// row (bottom) don't squeeze the middle content. Twitter's ~15px
+// top/bottom crop on summary_large_image still falls inside this
+// margin, so the chrome line / stats row stay clear of the boundary.
+const CARD_MARGIN_Y = Math.round(H * 0.06)       // 38 — outer margin (top/bottom)
 const CARD_IMG_SZ  = Math.round(W * 0.18)       // 216 — square image in top-right
 const CARD_NARROW_W = Math.round(W * 0.68)      // 816 — text column when image overlaps
-const CARD_TEXT_X   = CARD_STRIP_W + CARD_MARGIN
+const CARD_TEXT_X   = CARD_STRIP_W + CARD_SAFE_X
 // Wide content lines render below the corner image, so they get the
 // full available width — everything between the text column's left
 // edge and the right outer margin. No image-overlap concern.
-const CARD_WIDE_W   = W - CARD_TEXT_X - CARD_MARGIN
+const CARD_WIDE_W   = W - CARD_TEXT_X - CARD_SAFE_X
 const CARD_MIN_H    = 280
 const CARD_MAX_H    = H
 
@@ -1128,7 +1132,7 @@ function planCawCard(opts: {
   // column is squeezed and we re-wrap. Cards where the image stays at
   // CARD_IMG_SZ skip the second pass.
   const computeNarrowChars = (imgPx: number) => {
-    const narrowPx = W - CARD_STRIP_W - CARD_MARGIN - imgPx - CARD_NARROW_RIGHT_PAD - CARD_MARGIN
+    const narrowPx = W - CARD_STRIP_W - CARD_SAFE_X - imgPx - CARD_NARROW_RIGHT_PAD - CARD_SAFE_X
     return approxCharsPerPx(CARD_BODY_FS, Math.max(200, narrowPx))
   }
   // Will the bottom stat row render? (any non-zero count.)
@@ -1175,7 +1179,9 @@ function planCawCard(opts: {
   let narrowContent = contentLines.slice(0, NARROW_LINES)
   let wideContent = contentLines.slice(NARROW_LINES, totalContentLines)
   let textHeight = computeHeight(narrowContent.length, wideContent.length)
-  let imageSlotMinHeight = opts.cornerImage ? CARD_MARGIN_Y + CARD_IMG_SZ + CARD_IMG_PAD : 0
+  let imageSlotMinHeight = opts.cornerImage
+    ? CARD_MARGIN_Y + CARD_IMG_SZ + CARD_IMG_PAD + (hasStats ? STATS_ROW_H : 0) + CARD_MARGIN_Y
+    : 0
   let height = Math.min(CARD_MAX_H, Math.max(textHeight, imageSlotMinHeight, CARD_MIN_H))
   let imgSize = computeImgSize(height)
 
@@ -1188,12 +1194,12 @@ function planCawCard(opts: {
     narrowContent = contentLines.slice(0, NARROW_LINES)
     wideContent = contentLines.slice(NARROW_LINES, totalContentLines)
     textHeight = computeHeight(narrowContent.length, wideContent.length)
-    imageSlotMinHeight = CARD_MARGIN_Y + imgSize + CARD_IMG_PAD
+    imageSlotMinHeight = CARD_MARGIN_Y + imgSize + CARD_IMG_PAD + (hasStats ? STATS_ROW_H : 0) + CARD_MARGIN_Y
     height = Math.min(CARD_MAX_H, Math.max(textHeight, imageSlotMinHeight, CARD_MIN_H))
   }
   // Render-time narrow column width — the visible cap for header /
   // byline / narrow content lines.
-  const narrowRenderW = W - CARD_STRIP_W - CARD_MARGIN - imgSize - CARD_NARROW_RIGHT_PAD - CARD_MARGIN
+  const narrowRenderW = W - CARD_STRIP_W - CARD_SAFE_X - imgSize - CARD_NARROW_RIGHT_PAD - CARD_SAFE_X
 
   return {
     height,
@@ -1233,7 +1239,7 @@ function planCawCard(opts: {
                 display: 'flex',
                 position: 'absolute',
                 top: CARD_MARGIN_Y,
-                right: CARD_MARGIN,
+                right: CARD_SAFE_X,
                 width: imgSize,
                 height: imgSize,
                 borderRadius: 12,
@@ -1263,7 +1269,7 @@ function planCawCard(opts: {
                 position: 'absolute',
                 top: CARD_MARGIN_Y,
                 left: CARD_TEXT_X,
-                right: CARD_MARGIN,
+                right: CARD_SAFE_X,
                 bottom: CARD_MARGIN_Y,
               },
               children: [
@@ -2023,6 +2029,46 @@ async function renderToPng(tree: any, height: number = H): Promise<Buffer> {
   return png
 }
 
+// Twitter/X `summary_large_image` behaves best when the delivered image is a
+// stable 1200×630. Our caw cards are laid out at dynamic heights (short posts
+// can be much shorter), which makes X crop them unpredictably. Wrap the
+// variable-height card inside a fixed OG canvas instead of changing the card
+// layout logic itself.
+function wrapTreeInOgCanvas(tree: any, innerHeight: number, backgroundColor: string) {
+  const clampedInnerHeight = Math.min(H, Math.max(0, innerHeight))
+  const topOffset = Math.max(0, Math.floor((H - clampedInnerHeight) / 2))
+  return {
+    type: 'div',
+    props: {
+      style: {
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        position: 'relative',
+        backgroundColor,
+        overflow: 'hidden',
+      },
+      children: [
+        {
+          type: 'div',
+          props: {
+            style: {
+              display: 'flex',
+              position: 'absolute',
+              top: topOffset,
+              left: 0,
+              width: W,
+              height: clampedInnerHeight,
+              overflow: 'hidden',
+            },
+            children: [tree],
+          },
+        },
+      ],
+    },
+  }
+}
+
 // Twemoji disk cache (one SVG per codepoint sequence). Twemoji files
 // live on jsdelivr at /gh/twitter/twemoji@latest/assets/svg/<codepoints>.svg
 // — codepoints are hyphen-joined hex, with fe0f variation selectors
@@ -2380,13 +2426,13 @@ router.get('/image/caw/:id', async (req, res) => {
     .update([stats.likes, stats.recaws, stats.replies, stats.views, pollHash].join('|'))
     .digest('hex').slice(0, 8)
 
-  // v11 = date moved to header line + right-aligned stats + doubled
-  // vertical margins + tighter narrow column → text-image gap.
+  // v13 = reserve stat-row space under the corner image on short cards so
+  // the right-aligned icons never overlap the media block.
   // PENDING caws include status so a later SUCCESS/HIDDEN flip
   // doesn't serve a stale render.
   const cacheKey = caw.status === 'PENDING'
-    ? `caw-v11-${caw.id}-${liveHash}-pending`
-    : `caw-v11-${caw.id}-${liveHash}`
+    ? `caw-v13-${caw.id}-${liveHash}-pending`
+    : `caw-v13-${caw.id}-${liveHash}`
   return serveCachedOrRender(res, cacheKey, async () => {
     // Strip media URLs and poll markers out of the visible text — the
     // corner image and the rendered poll bars already represent them,
@@ -2427,8 +2473,9 @@ router.get('/image/caw/:id', async (req, res) => {
       stats,
     }
     const { tree, height } = planCawCard({ ...planArgs, cornerImage })
+    const wrappedTree = wrapTreeInOgCanvas(tree, height, planArgs.backgroundColor)
     try {
-      return await renderToPng(tree, height)
+      return await renderToPng(wrappedTree, H)
     } catch (err: any) {
       // Satori sometimes can't decode certain image formats (notably
       // some webp variants) and throws inside its image preprocessor.
@@ -2436,7 +2483,10 @@ router.get('/image/caw/:id', async (req, res) => {
       // text portion of the card is the load-bearing part.
       console.warn(`[og] satori render failed for caw ${caw.id} with corner image, retrying without:`, err?.message ?? err)
       const fallback = planCawCard({ ...planArgs, cornerImage: null })
-      return await renderToPng(fallback.tree, fallback.height)
+      return await renderToPng(
+        wrapTreeInOgCanvas(fallback.tree, fallback.height, planArgs.backgroundColor),
+        H,
+      )
     }
   })
 })

--- a/client/src/services/FrontEnd/src/components/FeedItem.tsx
+++ b/client/src/services/FrontEnd/src/components/FeedItem.tsx
@@ -1743,12 +1743,12 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                 {showRecawMenu && (
                   <div
                     ref={menuRef}
-                    className={`absolute z-10 text-bold rounded-xl p-3 space-y-1 whitespace-nowrap transition-all duration-300 ${
+                    className={`absolute z-30 text-bold rounded-xl p-3 space-y-1 whitespace-nowrap ${
                       isDark
-                        ? 'text-white bg-black/90 backdrop-blur-sm shadow-[0_4px_24px_rgba(255,255,255,0.12)]'
-                        : 'text-black bg-white border border-gray-200 shadow-lg'
+                        ? 'text-white border border-white/10 shadow-[0_4px_24px_rgba(255,255,255,0.12)]'
+                        : 'text-black border border-gray-200 shadow-lg'
                     }`}
-                    style={{ left: '-3px', top: '0' }}
+                    style={{ left: '-3px', bottom: 'calc(100% + 4px)', backgroundColor: isDark ? '#000' : '#fff', opacity: 1 }}
                   >
                     {(useItem.hasRecawed || isRecawByCurrentUser || recawPending) ? (
                       <button

--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -330,7 +330,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
               click is unaffected. */}
           {!isMobileMenuOpen && (
             <div
-              className="md:hidden fixed top-0 left-0 bottom-[calc(var(--bottom-nav-h,0px)+50px)] w-[25vw] z-[65]"
+              className="md:hidden fixed top-0 left-0 bottom-[calc(var(--bottom-nav-h,0px)+50px)] w-5 z-[65]"
               style={{ touchAction: 'pan-y' }}
               onTouchStart={(e) => onDrawerTouchStart(e, false)}
               onTouchMove={onDrawerTouchMove}

--- a/client/src/services/FrontEnd/src/pages/CawPage.tsx
+++ b/client/src/services/FrontEnd/src/pages/CawPage.tsx
@@ -499,7 +499,7 @@ export const CawPage: React.FC = () => {
                   setSearchParams(next, { replace: true })
                 }
               }}
-              className={`p-2 rounded-full transition-all duration-200 cursor-pointer hover:bg-white/10 ${
+              className={`relative z-[80] p-2 rounded-full transition-all duration-200 cursor-pointer hover:bg-white/10 ${
                 isDark ? 'text-white' : 'text-black'
               }`}
               aria-label={t('caw_page.back')}
@@ -515,7 +515,7 @@ export const CawPage: React.FC = () => {
                   navigate('/home')
                 }
               }}
-              className={`p-2 rounded-full transition-all duration-200 cursor-pointer hover:bg-white/10 ${
+              className={`relative z-[80] p-2 rounded-full transition-all duration-200 cursor-pointer hover:bg-white/10 ${
                 isDark ? 'text-white' : 'text-black'
               }`}
               aria-label={t('caw_page.back')}

--- a/client/src/services/FrontEnd/src/pages/Messages.tsx
+++ b/client/src/services/FrontEnd/src/pages/Messages.tsx
@@ -527,19 +527,15 @@ const MessagesPage: React.FC = () => {
     }
   }, [selectedConversationId, messages.length])
 
-  // Function to go back to inbox
+  // Function to go back to inbox. Only navigates — the URL-change
+  // useEffect (no urlUsername + currentView === 'chat') handles
+  // leaving the conversation room and resetting state. Doing both
+  // here AND in the effect caused a double state update → visible
+  // rebound flicker on mobile.
   const goBackToInbox = () => {
-    // Leave conversation room
-    if (selectedConversationId) {
-      leaveConversation(selectedConversationId)
-    }
-
-    setCurrentView('inbox')
-    setSelectedConversationId(null)
-    setShowChatOptionsMenu(false)
     navigate('/messages', { replace: true })
-
-    // Refresh conversations to show latest messages
+    // Refresh conversations to show latest messages after the URL effect
+    // has cleared the chat view.
     refreshConversations()
   }
 
@@ -1198,7 +1194,7 @@ const MessagesPage: React.FC = () => {
               {currentView === 'chat' && (
                 <button
                   onClick={goBackToInbox}
-                  className={`p-2 rounded-full transition-all duration-300 hover:bg-gray-500/20 ${
+                  className={`relative z-[80] p-2 rounded-full transition-all duration-300 hover:bg-gray-500/20 ${
                     isDark ? 'text-white' : 'text-black'
                   }`}
                 >

--- a/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
+++ b/client/src/services/FrontEnd/src/pages/Profile/Profile.tsx
@@ -946,7 +946,7 @@ export const Profile: React.FC = () => {
                 navigate('/home')
               }
             }}
-            className="absolute top-3 left-3 z-10 w-9 h-9 rounded-full flex items-center justify-center bg-black/40 hover:bg-black/60 text-white backdrop-blur-sm transition-colors cursor-pointer"
+            className="absolute top-3 left-3 z-[80] w-9 h-9 rounded-full flex items-center justify-center bg-black/40 hover:bg-black/60 text-white backdrop-blur-sm transition-colors cursor-pointer"
           >
             <HiArrowLeft className="w-5 h-5" />
           </button>


### PR DESCRIPTION
 Mobile drawer interception
  - Catcher narrowed from `w-[25vw]` → `w-5` (20px on the left edge).
    Edge-swipe to open the drawer still works (the native iOS/Android
    pattern), but the rest of the left band is no longer hijacked.
  - Back buttons in `CawPage`, `Messages` chat header, and `Profile`
    cover get `z-[80]` as belt-and-suspenders for taps that still land
    inside the catcher strip.

Messages chat flicker
  - `goBackToInbox` now only calls `navigate('/messages')`. The
    URL-change `useEffect` already resets `currentView`,
    `selectedConversationId` and the chat menu — doing both was
    double-toggling state and produced a visible rebound flicker on
    mobile.

Recaw menu stacking inside threads
  - Inside the CawPage thread view, each reply is wrapped in
    `relative isolate` (its own stacking context). The recaw menu's
    `z-30` couldn't escape it, so the next reply rendered on top.
    Menu now opens upward (`bottom: 100%+4px`) and uses an inline
    solid `backgroundColor` so it stays opaque regardless of dark/light
    variants.

  ### OG share card tuning
  - Canvas dimensions and margins iterated in `api/routes/og.ts` for
    better preview rendering across X / Facebook / Telegram.
    Visualization-only — no behavior changes.