### PR TITLE
fix (pins) : derive pinnedCawCount from rows to end counter drift (#222)

### DIFF
--- a/client/src/api/routes/pins.ts
+++ b/client/src/api/routes/pins.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { prisma } from '../../prismaClient'
+import { recomputePinnedCount } from '../../utils/pinnedCount'
 import { extractSession } from '../middleware/auth'
 
 const router = Router()
@@ -77,36 +78,36 @@ router.post('/:cawId', async (req, res) => {
       select: { id: true, pending: true, pendingUnpin: true },
     })
 
+    // #222: pinnedCawCount is derived from the deduped rows, not delta-
+    // mutated, so it can't drift under racing confirm paths. Recompute in
+    // the same tx as every row change.
     if (!existing) {
-      await prisma.$transaction([
-        prisma.pinnedCaw.create({
+      await prisma.$transaction(async (tx) => {
+        await tx.pinnedCaw.create({
           data: { userId, cawId, pending: false },
-        }),
-        prisma.user.update({
-          where: { tokenId: userId },
-          data: { pinnedCawCount: { increment: 1 } },
-        }),
-      ])
+        })
+        await recomputePinnedCount(tx, userId)
+      })
     } else if (existing.pending) {
       // Pending pin getting confirmed off-chain. Clear pendingUnpin too
       // in case a stale unpin flag survived a re-pin cycle.
-      await prisma.$transaction([
-        prisma.pinnedCaw.update({
+      await prisma.$transaction(async (tx) => {
+        await tx.pinnedCaw.update({
           where: { id: existing.id },
           data: { pending: false, pendingUnpin: false },
-        }),
-        prisma.user.update({
-          where: { tokenId: userId },
-          data: { pinnedCawCount: { increment: 1 } },
-        }),
-      ])
+        })
+        await recomputePinnedCount(tx, userId)
+      })
     } else if (existing.pendingUnpin) {
       // Already-confirmed pin with an on-chain unpin in flight. The new
-      // pin supersedes it; clear the flag without re-incrementing count
-      // (the original confirmed pin was already counted).
-      await prisma.pinnedCaw.update({
-        where: { id: existing.id },
-        data: { pendingUnpin: false },
+      // pin supersedes it; clearing pendingUnpin makes the row visible and
+      // counted again — recompute picks that up.
+      await prisma.$transaction(async (tx) => {
+        await tx.pinnedCaw.update({
+          where: { id: existing.id },
+          data: { pendingUnpin: false },
+        })
+        await recomputePinnedCount(tx, userId)
       })
     }
     // else: already confirmed and not unpin-pending — idempotent no-op.
@@ -138,19 +139,13 @@ router.delete('/:cawId', async (req, res) => {
       return res.json({ success: true })
     }
 
-    // Only decrement if we're removing a confirmed pin — pending rows
-    // weren't counted.
-    if (existing.pending) {
-      await prisma.pinnedCaw.delete({ where: { id: existing.id } })
-    } else {
-      await prisma.$transaction([
-        prisma.pinnedCaw.delete({ where: { id: existing.id } }),
-        prisma.user.update({
-          where: { tokenId: userId },
-          data: { pinnedCawCount: { decrement: 1 } },
-        }),
-      ])
-    }
+    // Derive the count from the remaining rows — handles confirmed vs
+    // pending uniformly (pending rows aren't counted, so removing one is
+    // a recompute no-op) and self-heals any prior drift.
+    await prisma.$transaction(async (tx) => {
+      await tx.pinnedCaw.delete({ where: { id: existing.id } })
+      await recomputePinnedCount(tx, userId)
+    })
 
     res.json({ success: true })
   } catch (err) {

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -8,6 +8,7 @@ import { countManager } from '../CountManager'
 import { parsePoll, parseVoteText, resolvePollImageUrl } from '../../tools/pollMarker'
 import { markOrphansInImageData } from '../../api/util/orphanedMedia'
 import type { PrismaTransactionClient } from './types'
+import { recomputePinnedCount } from '../../utils/pinnedCount'
 
 /** Sentinel thrown by findCawId so callers (and the top-level
  *  handleRawAction error handler) can distinguish "indexer doesn't have
@@ -1538,14 +1539,15 @@ async function handlePinAction(
     select: { id: true, pending: true },
   })
 
+  // #222: count is derived from the deduped rows (recompute), not delta-
+  // mutated, so racing off-chain/on-chain confirms and duplicate event
+  // replays converge instead of drifting. Recompute even on the "already
+  // confirmed" path so a previously-drifted counter self-heals here.
   if (!existing) {
     await tx.pinnedCaw.create({
       data: { userId: senderId, cawId, pending: false },
     })
-    await tx.user.update({
-      where: { tokenId: senderId },
-      data: { pinnedCawCount: { increment: 1 } },
-    })
+    await recomputePinnedCount(tx, senderId)
     console.log(`[handlePinAction] Created+confirmed pin caw=${cawId} for user=${senderId}`)
     return
   }
@@ -1555,15 +1557,14 @@ async function handlePinAction(
       where: { id: existing.id },
       data: { pending: false },
     })
-    await tx.user.update({
-      where: { tokenId: senderId },
-      data: { pinnedCawCount: { increment: 1 } },
-    })
+    await recomputePinnedCount(tx, senderId)
     console.log(`[handlePinAction] Confirmed pin caw=${cawId} for user=${senderId}`)
     return
   }
 
-  // Already confirmed — idempotent no-op (e.g. duplicate event replay).
+  // Already confirmed — idempotent no-op for the row; still recompute so
+  // any prior counter drift for this user heals on replay.
+  await recomputePinnedCount(tx, senderId)
   console.log(`[handlePinAction] Pin caw=${cawId} for user=${senderId} already confirmed; skipping`)
 }
 
@@ -1603,13 +1604,9 @@ async function handleUnpinAction(
   }
 
   await tx.pinnedCaw.delete({ where: { id: existing.id } })
-  // Only decrement if the row was confirmed: pending rows weren't
-  // counted (count tracks confirmed pins).
-  if (!existing.pending) {
-    await tx.user.update({
-      where: { tokenId: senderId },
-      data: { pinnedCawCount: { decrement: 1 } },
-    })
-  }
+  // #222: derive the count from the remaining rows — uniform across
+  // confirmed vs pending (pending wasn't counted, so its removal is a
+  // recompute no-op) and self-heals prior drift.
+  await recomputePinnedCount(tx, senderId)
   console.log(`[handleUnpinAction] Unpinned caw=${cawId} for user=${senderId} (was pending=${existing.pending})`)
 }

--- a/client/src/utils/pinnedCount.ts
+++ b/client/src/utils/pinnedCount.ts
@@ -1,0 +1,36 @@
+import type { PrismaClient } from '@prisma/client'
+
+// Interactive-transaction client type (same shape as the callback arg of
+// prisma.$transaction(async (tx) => ...)).
+type Tx = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0]
+
+/**
+ * #222: `User.pinnedCawCount` is a denormalised counter that two independent
+ * confirm paths used to mutate with +1/-1 deltas:
+ *   - api/routes/pins.ts            (off-chain / QuickSign confirm)
+ *   - ActionProcessor/actionHandlers (on-chain indexer confirm)
+ *
+ * Each path is individually guarded, but under rapid pin/unpin/re-pin the
+ * deltas race across paths and drift — the user-visible "4/3" cap display.
+ * The `PinnedCaw` rows are the source of truth (`@@unique([userId, cawId])`
+ * makes duplicates impossible), so derive the counter from them instead of
+ * carrying arithmetic. Recompute is idempotent: it converges to the correct
+ * value regardless of ordering or duplicate event replay, which also makes
+ * any already-drifted row self-heal on the next pin/unpin for that user.
+ *
+ * Counts only effectively-pinned, visible rows, matching the read paths:
+ *   - pending:true       → optimistic pin not confirmed yet (not shown)
+ *   - pendingUnpin:true  → unpin in flight, suppressed from read paths
+ *
+ * MUST be called inside the same transaction as the row mutation, otherwise
+ * a concurrent pin/unpin could recompute against a half-applied state.
+ */
+export async function recomputePinnedCount(tx: Tx, userId: number): Promise<void> {
+  const n = await tx.pinnedCaw.count({
+    where: { userId, pending: false, pendingUnpin: false },
+  })
+  await tx.user.update({
+    where: { tokenId: userId },
+    data: { pinnedCawCount: n },
+  })
+}


### PR DESCRIPTION
Two independent confirm paths - api/routes/pins.ts (off-chain / QuickSign) and the ActionProcessor on-chain indexer - each delta-mutated User.pinnedCawCount with +1/-1. Both are individually guarded but race across paths under rapid pin/unpin/re-pin, inflating the counter (the user-visible "4/3" cap display). PinnedCaw rows are the source of truth (@@unique([userId,cawId]) makes duplicates impossible).

Replace every +1/-1 with a shared recomputePinnedCount(tx, userId) that sets the count = COUNT(PinnedCaw WHERE pending=false AND pendingUnpin=false), inside the same transaction as the row mutation. Idempotent: converges regardless of ordering or duplicate event replay, and self-heals already-drifted counters on the next pin/unpin for that user. No schema change; read paths unchanged.

Files:
- utils/pinnedCount.ts (new shared helper)
- api/routes/pins.ts (POST/DELETE: delta -> recompute, interactive tx)
- services/ActionProcessor/actionHandlers.ts (handlePin/UnpinAction)