### PR TITLE
fix(ux): mobile UX fixes and icons polish

### DIFF
--- a/client/src/services/FrontEnd/src/components/MessageSearch.tsx
+++ b/client/src/services/FrontEnd/src/components/MessageSearch.tsx
@@ -172,7 +172,7 @@ const MessageSearch: React.FC<MessageSearchProps> = ({ userId, onSearchComplete 
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           onKeyPress={handleKeyPress}
-          className={`w-full pl-10 pr-12 py-3 rounded-full border transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-gray-500/30 ${
+          className={`w-full pl-10 pr-12 py-3 rounded-full border text-[16px] sm:text-[15px] transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-gray-500/30 ${
             isDark
               ? 'bg-black border-gray-600 text-white placeholder-gray-400'
               : 'bg-white border-gray-300 text-black placeholder-gray-500'

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -38,25 +38,29 @@ import { useNavigate } from '~/utils/localizedRouter'
 import { HiOutlineChartBar } from 'react-icons/hi'
 import { buildPollMarker, imageUrlToPollHash, imageUrlToMeta } from '~/../../../tools/pollMarker'
 
-// AI (outline) + glitter (outline) in one icon, so proportions match toolbar.
-// Rendered as a single SVG to avoid badges/stickers.
+// AI button icon: just sparkles.
+// Rationale: letters/frames read like a sticker and look off next to toolbar icons.
+// IMPORTANT: keep strokeWeight consistent with the rest of the toolbar (2).
 const AiGlitterIcon: React.FC<{ sizeClass: string }> = ({ sizeClass }) => (
   <svg className={sizeClass} viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
-    {/* AI block (outline) — bigger, like other icons */}
-    <rect x="1.5" y="5" width="14" height="14" rx="2.5" strokeWidth={2} />
-    {/* A */}
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.9 17l2.7-10 2.7 10" />
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 13.3h3.2" />
-    {/* I (add top/bottom bars so it reads as I) */}
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.2 8.4h2.2" />
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12.3 8.4v8.2" />
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.2 16.6h2.2" />
-
-    {/* Glitter as a small accent on the right */}
-    {/* Move glitter further right without clipping: scale down + translate */}
-    <g transform="translate(6 0) scale(0.82)">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 10.5l.55 1.9a2.7 2.7 0 001.85 1.85L23.3 15l-1.9.55a2.7 2.7 0 00-1.85 1.85L19 19.3l-.55-1.9a2.7 2.7 0 00-1.85-1.85L14.7 15l1.9-.55a2.7 2.7 0 001.85-1.85L19 10.5z" />
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 6l.18.6a1.7 1.7 0 001.15 1.15l.6.18-.6.18A1.7 1.7 0 0021.18 9.3L21 9.9l-.18-.6a1.7 1.7 0 00-1.15-1.15l-.6-.18.6-.18A1.7 1.7 0 0020.82 6.6L21 6z" />
+    {/* Sparkles — outline, centered */}
+    {/* Slightly larger and nudged down to visually center inside circular button */}
+    {/* NOTE: sparkles read visually heavier than other outline icons; use slightly thinner stroke */}
+    <g transform="translate(12 12) scale(1.12) translate(-12 -12) translate(-1.6 2.6)">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.8}
+        vectorEffect="non-scaling-stroke"
+        d="M12 3.5l.8 2.7a3.6 3.6 0 002.5 2.5l2.7.8-2.7.8a3.6 3.6 0 00-2.5 2.5l-.8 2.7-.8-2.7a3.6 3.6 0 00-2.5-2.5l-2.7-.8 2.7-.8a3.6 3.6 0 002.5-2.5L12 3.5z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.8}
+        vectorEffect="non-scaling-stroke"
+        d="M18 6.2l.3 1a2.1 2.1 0 001.4 1.4l1 .3-1 .3a2.1 2.1 0 00-1.4 1.4l-.3 1-.3-1a2.1 2.1 0 00-1.4-1.4l-1-.3 1-.3a2.1 2.1 0 001.4-1.4l.3-1z"
+      />
     </g>
   </svg>
 )
@@ -2741,7 +2745,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                   onClick={openAiImages}
                   title={t('post_form.ai.tooltip')}
                   aria-label={t('post_form.ai.aria')}
-                  className={`relative p-1 rounded-full transition-all duration-200 cursor-pointer ${
+                  className={`relative p-1 -ml-0.5 rounded-full transition-all duration-200 cursor-pointer ${
                     text.trim()
                       ? (isDark
                           ? 'text-yellow-400 hover:text-yellow-300 hover:bg-yellow-400/10'
@@ -2751,6 +2755,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                           : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50')
                   }`}
                 >
+                  {/* Match hover hitbox with the rest of the toolbar */}
                   <AiGlitterIcon sizeClass="w-5 h-5" />
                 </button>
               )}
@@ -3178,7 +3183,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
               ? ''
               : ''
         }`}>
-          <div className={`flex items-center min-w-0 ${composeMode ? 'space-x-1' : 'space-x-1 sm:space-x-3'}`}>
+          <div className={`flex items-center min-w-0 ${composeMode ? 'space-x-1' : 'space-x-1 sm:space-x-2'}`}>
             {/* Media Upload */}
             <button
               onClick={() => fileInputRef.current?.click()}
@@ -3461,7 +3466,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                 onClick={openAiImages}
                 title={t('post_form.ai.tooltip')}
                 aria-label={t('post_form.ai.aria')}
-              className={`relative p-2 rounded-full transition-all duration-200 cursor-pointer ${
+                className={`relative p-2 -ml-1 rounded-full transition-all duration-200 cursor-pointer ${
                   text.trim()
                     ? (isDark
                         ? 'text-yellow-400 hover:text-yellow-300 hover:bg-yellow-400/10'
@@ -3471,6 +3476,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                         : 'text-yellow-600/70 hover:text-yellow-600 hover:bg-yellow-200/50')
                 }`}
               >
+                {/* Match hover hitbox with the rest of the toolbar */}
                 <AiGlitterIcon sizeClass="w-6 h-6" />
               </button>
             )}

--- a/client/src/services/FrontEnd/src/components/SearchBar.tsx
+++ b/client/src/services/FrontEnd/src/components/SearchBar.tsx
@@ -157,7 +157,7 @@ const SearchBar: React.FC = () => {
           onFocus={() => setShowSuggestions(true)}
           onKeyDown={handleKeyDown}
           placeholder={t('search.placeholder')}
-          className={`w-full rounded-full py-3 pl-12 pr-10 transition-all duration-300 focus:outline-none ${
+          className={`w-full rounded-full py-3 pl-12 pr-10 text-[16px] transition-all duration-300 focus:outline-none ${
             isDark
               ? 'bg-black border-yellow-500/30 text-white placeholder-white/50 focus:border-yellow-500/50 focus:bg-black'
               : 'bg-white border-gray-200 text-black placeholder-gray-500 focus:border-gray-300 focus:bg-white'

--- a/client/src/services/FrontEnd/src/components/TipAttachmentControl.tsx
+++ b/client/src/services/FrontEnd/src/components/TipAttachmentControl.tsx
@@ -444,11 +444,17 @@ const TipAttachmentControl: React.FC<Props> = ({
         {/* Dollar-sign coin icon. Filled when tips are attached, outline when not. */}
         <svg className={iconSizeClass} fill={hasTips ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
           {hasTips ? (
-            <path fillRule="evenodd" clipRule="evenodd" d="M12 2a10 10 0 100 20 10 10 0 000-20zm.75 5a.75.75 0 00-1.5 0v.5h-.5a2.25 2.25 0 000 4.5h2a.75.75 0 010 1.5h-3a.75.75 0 000 1.5h1.5v.5a.75.75 0 001.5 0V15h.5a2.25 2.25 0 000-4.5h-2a.75.75 0 010-1.5h3a.75.75 0 000-1.5h-1.5V7z" />
+            // Nudge the "$" a hair RIGHT to read centered inside the coin.
+            <g transform="translate(0.75 0)">
+              <path fillRule="evenodd" clipRule="evenodd" d="M12 2a10 10 0 100 20 10 10 0 000-20zm.75 5a.75.75 0 00-1.5 0v.5h-.5a2.25 2.25 0 000 4.5h2a.75.75 0 010 1.5h-3a.75.75 0 000 1.5h1.5v.5a.75.75 0 001.5 0V15h.5a2.25 2.25 0 000-4.5h-2a.75.75 0 010-1.5h3a.75.75 0 000-1.5h-1.5V7z" />
+            </g>
           ) : (
             <>
               <circle cx="12" cy="12" r="9" strokeWidth={2} />
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.5 9.5a3 3 0 00-3-1.5h-1a2 2 0 000 4h2a2 2 0 010 4h-1.5a3 3 0 01-3-1.5M12 7v1.5m0 7V17" />
+              {/* Nudge the "$" a hair RIGHT to read centered inside the coin. */}
+              <g transform="translate(0.75 0)">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.5 9.5a3 3 0 00-3-1.5h-1a2 2 0 000 4h2a2 2 0 010 4h-1.5a3 3 0 01-3-1.5M12 7v1.5m0 7V17" />
+              </g>
             </>
           )}
         </svg>

--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -8,6 +8,7 @@ import BugIcon from "~/components/icons/BugIcon";
 import { useTheme } from "~/hooks/useTheme";
 import Tooltip from "~/components/Tooltip";
 import { useT } from "~/i18n/I18nProvider";
+import { acquireScrollLock, releaseScrollLock } from "~/utils/scrollLock";
 import { useState, useEffect, useRef, lazy, Suspense } from "react";
 import { HiOutlineMenu, HiOutlineX, HiOutlinePencilAlt, HiOutlineHome, HiOutlineSearch, HiOutlineColorSwatch, HiOutlineBell, HiOutlineUser, HiOutlineChat } from "react-icons/hi";
 import { useLocation } from "react-router-dom";
@@ -247,6 +248,16 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
     }
   }, [showBottomNav, hasInlineDraft])
 
+  // Lock background scroll while the mobile drawer is open so the feed
+  // behind the backdrop doesn't scroll under the finger. Reuses the same
+  // refcounted lock as modals — handles iOS Safari (which ignores
+  // overflow:hidden) via position:fixed and restores scrollY on close.
+  useEffect(() => {
+    if (!isMobileMenuOpen) return
+    acquireScrollLock()
+    return () => releaseScrollLock()
+  }, [isMobileMenuOpen])
+
   return (
     <>
     {/* Fixed backdrop so scrolling doesn't reveal the root gradient */}
@@ -289,6 +300,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
           <Link
             to="/messages"
             aria-label="Messages"
+            onClick={() => { clearInlineDrawerStyles(); setIsMobileMenuOpen(false) }}
             className={`absolute right-4 translate-y-[2px] p-2 rounded-lg transition-colors duration-200 ${
               isDark ? 'text-white hover:bg-white/10' : 'text-black hover:bg-gray-100'
             }`}

--- a/client/src/services/FrontEnd/src/pages/Messages.tsx
+++ b/client/src/services/FrontEnd/src/pages/Messages.tsx
@@ -3388,7 +3388,7 @@ const MessagesPage: React.FC = () => {
                       placeholder={t('messages.search.people')}
                       value={newMessageSearch}
                       onChange={(e) => setNewMessageSearch(e.target.value)}
-                      className={`w-full pl-10 pr-4 py-2 rounded-full border transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-yellow-500/30 ${
+                      className={`w-full pl-10 pr-4 py-2 rounded-full border text-[16px] sm:text-[15px] transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-yellow-500/30 ${
                         isDark
                           ? 'bg-black border-gray-600 text-white placeholder-gray-500'
                           : 'bg-white border-gray-300 text-black placeholder-gray-400'


### PR DESCRIPTION
Mobile fixes:
- Force text-[16px] on search inputs (Explore SearchBar, MessageSearch, New-Message modal) so iOS Safari stops auto-zooming on focus and shifting the layout sideways. Reverts to 15px on sm+ (no visual change where the bug never existed).

- Lock background scroll while the mobile drawer is open via the shared acquireScrollLock/releaseScrollLock util (handles iOS, which ignores overflow:hidden, with position:fixed; refcounted to compose with modals).

- Close the drawer when tapping the Messages icon in the mobile header (clears any half-finished swipe transform first, same as the hamburger).


Icon / spacing polish:
- Redesign the AI button icon: drop the "AI letters + glitter" composite (read like a sticker) for clean centered sparkles, stroke weight aligned with the rest of the toolbar. Tighten toolbar spacing and hover hitbox.

- Nudge the "$" glyph right in the tip coin icon so it reads centered.