### PR TITLE
feat(ai-proxy): BYOK image generation for OpenAI + Grok via backend proxy

### DIFF
--- a/client/src/api/middleware/originGate.ts
+++ b/client/src/api/middleware/originGate.ts
@@ -1,0 +1,122 @@
+import { Request, Response } from 'express'
+
+/**
+ * Shared origin allowlist middleware for backend proxy routes (rpc-proxy,
+ * ai-proxy, etc.). Without this, any script anywhere on the internet could
+ * POST to a proxy endpoint — CORS only stops browsers from READING
+ * cross-origin responses; it doesn't stop the server from processing the
+ * request itself.
+ *
+ * Default behaviour: allow same-host requests — i.e. the request's Origin
+ * (or Referer) host equals the Host header (the server's own public
+ * hostname). This is the common case and needs ZERO config: the FE served
+ * from https://test.caw.social fetching /api/rpc/l2 sends
+ * Origin: https://test.caw.social and Host: test.caw.social, which match.
+ *
+ * Extra allowlists for cross-origin clients (peer mirrors, dev hosts,
+ * or operator scripts):
+ *   - ALLOWED_ORIGINS env (comma-separated). '*' opens to anyone.
+ *   - PUBLIC_URL env (operator's explicit public hostname, if it
+ *     differs from the Host header — e.g. behind a CDN that rewrites).
+ *
+ * NOTE: extracted from routes/rpc-proxy.ts so multiple proxy routers can
+ * share the same gate without duplicating it. Behaviour is identical to
+ * the prior inline implementation — including the startup log prefix.
+ */
+
+function parseAllowedOrigins(): { exact: Set<string>; wildcard: boolean } {
+  const exact = new Set<string>()
+  let wildcard = false
+  for (const raw of (process.env.ALLOWED_ORIGINS || '').split(',')) {
+    const o = raw.trim()
+    if (!o) continue
+    if (o === '*') { wildcard = true; continue }
+    exact.add(o.replace(/\/$/, ''))
+  }
+  const publicUrl = (process.env.PUBLIC_URL || '').trim().replace(/\/$/, '')
+  if (publicUrl) exact.add(publicUrl)
+  return { exact, wildcard }
+}
+const allowed = parseAllowedOrigins()
+if (process.env.NODE_ENV !== 'test') {
+  if (allowed.wildcard) {
+    console.warn('[rpc-proxy] ALLOWED_ORIGINS includes "*" — anyone can hit /api/rpc/*. OK for dev, NOT for prod.')
+  } else if (allowed.exact.size > 0) {
+    console.log(`[rpc-proxy] Origin allowlist (in addition to same-host): ${Array.from(allowed.exact).join(', ')}`)
+  } else {
+    console.log('[rpc-proxy] Same-host requests allowed; no extra cross-origin allowlist configured.')
+  }
+}
+
+// Same-host check: the Origin/Referer host matches the request's
+// Host header. Express tracks the proxied Host via req.hostname when
+// 'trust proxy' is set (it is — server.ts: app.set('trust proxy', 'loopback')).
+// We also compare against req.headers.host raw as a fallback.
+function requestSelfOrigins(req: Request): string[] {
+  const hosts = new Set<string>()
+  if (req.hostname) hosts.add(req.hostname)
+  const rawHost = (req.headers.host || '').split(',')[0].trim()
+  if (rawHost) hosts.add(rawHost.replace(/:\d+$/, '')) // strip port; Origin doesn't carry it for default ports
+  // Build both http and https variants — TLS termination is at nginx,
+  // so `req.protocol` may say 'http' even when the public scheme is
+  // https. Accept both; the only attacker who could spoof either is
+  // already on the loopback interface, which we trust.
+  const origins: string[] = []
+  for (const h of hosts) {
+    origins.push(`https://${h}`)
+    origins.push(`http://${h}`)
+    if (rawHost && rawHost.includes(':')) {
+      origins.push(`https://${rawHost}`)
+      origins.push(`http://${rawHost}`)
+    }
+  }
+  return origins
+}
+
+function originAllowed(req: Request): boolean {
+  if (allowed.wildcard) return true
+  // Prefer Origin (browser-set on fetch from a different page). Fall
+  // back to Referer. One must be present AND match — no header = block.
+  const origin = (req.headers.origin || '').replace(/\/$/, '')
+  let candidate = origin
+  if (!candidate) {
+    const referer = req.headers.referer || ''
+    if (referer) {
+      try {
+        const u = new URL(referer)
+        candidate = `${u.protocol}//${u.host}`
+      } catch { /* malformed referer */ }
+    }
+  }
+  if (!candidate) return false
+
+  // Same-host: the candidate matches one of the request's own self
+  // origins. No env config needed.
+  for (const self of requestSelfOrigins(req)) {
+    if (candidate === self) return true
+  }
+  // Extra explicit allowlist for peer mirrors / dev hosts.
+  if (allowed.exact.has(candidate)) return true
+  return false
+}
+
+/**
+ * Express middleware factory: rejects any request whose Origin (or Referer
+ * fallback) doesn't match same-host or the explicit allowlist.
+ *
+ * The decision logic (originAllowed) is genuinely shared across proxies.
+ * The 403 response body is NOT — rpc-proxy speaks JSON-RPC, ai-proxy
+ * speaks a simple `{ error: { kind, message } }` shape, and a future
+ * caller might want a third. Each caller passes its own builder so the
+ * gate doesn't leak the contract of one consumer onto another.
+ *
+ * Usage:
+ *   const gate = originGate(() => ({ error: { kind: 'network', message: 'origin not allowed' } }))
+ *   router.post('/foo', gate, handler)
+ */
+export function originGate(buildBlockedBody: () => unknown) {
+  return (req: Request, res: Response, next: () => void) => {
+    if (originAllowed(req)) return next()
+    res.status(403).json(buildBlockedBody())
+  }
+}

--- a/client/src/api/routes/ai-proxy.ts
+++ b/client/src/api/routes/ai-proxy.ts
@@ -1,0 +1,281 @@
+import { Router, Request, Response } from 'express'
+import { rateLimit } from 'express-rate-limit'
+import { originGate } from '../middleware/originGate'
+
+/**
+ * BYOK (bring-your-own-key) AI image generation proxy.
+ *
+ * Why this exists: the FE talks to Gemini directly because Google's
+ * Generative Language API serves permissive CORS. OpenAI and xAI
+ * deliberately do NOT — browser-direct fetches are blocked before the
+ * response reaches user code. This proxy gives those two providers the
+ * same browser-direct-feel by forwarding server-to-server while keeping
+ * the BYOK model intact: the user's key arrives in the request body,
+ * is used once for the upstream call, and is then discarded. We do not
+ * persist, log, or echo it back in error responses.
+ *
+ * Patterned after routes/rpc-proxy.ts:
+ *   - Shares the same originGate middleware (middleware/originGate.ts).
+ *   - Uses express-rate-limit per-IP with a lower ceiling — image gen
+ *     is heavier and slower than RPC reads.
+ *   - One handler factory per provider so adding new ones is a one-line
+ *     route registration plus an upstream descriptor.
+ *
+ * Endpoints:
+ *   POST /api/ai-proxy/openai/image  → OpenAI gpt-image-1 (see note inside)
+ *   POST /api/ai-proxy/grok/image    → xAI grok-2-image
+ *   GET  /api/ai-proxy/health        → liveness probe (no key required)
+ *
+ * Request body (both providers):
+ *   { apiKey: string, prompt: string }
+ *
+ * Success response (200):
+ *   { b64Json: string, mimeType: string }
+ *
+ * Error response (4xx/5xx):
+ *   { error: { kind: 'auth' | 'safety' | 'quota' | 'network' | 'empty', message: string } }
+ *
+ * The error `kind` mirrors AIImageError in utils/aiImage.ts so the FE
+ * can keep using a single catch-and-map code path across providers.
+ */
+
+const router = Router()
+
+// Origin gate scoped to this router's response contract. Same allowlist
+// logic as rpc-proxy but the 403 body matches what the FE expects from
+// every ai-proxy endpoint — { error: { kind, message } } — so the FE's
+// existing AIImageError mapping handles it uniformly.
+const gate = originGate(() => ({
+  error: { kind: 'network' as const, message: 'AI proxy: origin not allowed' },
+}))
+
+// Per-IP rate limit. Image gen is expensive on the upstream side and we
+// don't want a runaway tab burning a user's quota or hammering our box.
+// 30 req/min sustained (≈ 1 every 2s) is plenty for a human; bots get cut
+// off fast. Tighten via env later if abuse appears.
+const aiProxyRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: { kind: 'quota', message: 'AI proxy: rate limited' } },
+})
+
+// Upstream timeout. OpenAI/Grok image gen typically returns in 5–15s; we
+// give a generous ceiling so a slow upstream doesn't cause a false-fail,
+// but cap it so a stuck connection can't hold a worker forever.
+const UPSTREAM_TIMEOUT_MS = 60_000
+
+interface ProviderSpec {
+  url: string
+  buildBody: (prompt: string) => Record<string, unknown>
+}
+
+// Hardcoded params (n=1, 1024x1024) mirror the Gemini call in utils/aiImage.ts
+// to keep the surface uniform across providers — the modal expects one
+// square image per generation. If/when we expose size/count to the user,
+// thread them through the FE request body and validate here.
+const PROVIDERS: Record<string, ProviderSpec> = {
+  openai: {
+    url: 'https://api.openai.com/v1/images/generations',
+    // We use gpt-image-1. dall-e-3 is no longer accessible via the API
+    // for most accounts (OpenAI started returning "model does not exist"
+    // after the gpt-image-1 rollout). dall-e-2 still works but is much
+    // lower quality.
+    //
+    // Caveat: gpt-image-1 may require OpenAI "organization verification"
+    // depending on the account's tier. If a BYOK user hits 403 with a
+    // verification code, the response parser surfaces the literal
+    // upstream message so the modal can point them at the OpenAI
+    // dashboard. (If we see this in practice we can add an automatic
+    // fallback to dall-e-2.)
+    //
+    // We do NOT pass `response_format` — the current API rejects it as
+    // unknown. gpt-image-1 returns b64_json by default; if a future
+    // change makes it return `url` instead, the response parser fetches
+    // the URL server-side and converts to b64, so the FE keeps a single
+    // rendering path.
+    buildBody: (prompt) => ({
+      model: 'gpt-image-1',
+      prompt,
+      n: 1,
+      size: '1024x1024',
+    }),
+  },
+  grok: {
+    url: 'https://api.x.ai/v1/images/generations',
+    buildBody: (prompt) => ({
+      model: 'grok-2-image',
+      prompt,
+      n: 1,
+      response_format: 'b64_json',
+    }),
+  },
+}
+
+type ErrorKind = 'auth' | 'safety' | 'quota' | 'network' | 'empty'
+
+function errorResponse(res: Response, status: number, kind: ErrorKind, message: string) {
+  // NOTE: we deliberately do NOT include the upstream's raw error body —
+  // it sometimes echoes parts of the request (including the prompt) and
+  // we want to keep the response shape predictable for the FE. The kind
+  // is enough for the modal to pick the right localized message.
+  res.status(status).json({ error: { kind, message } })
+}
+
+function classifyHttpStatus(status: number): { kind: ErrorKind; message: string } {
+  if (status === 400) return { kind: 'safety', message: 'Prompt rejected by upstream (likely safety filter).' }
+  if (status === 401 || status === 403) return { kind: 'auth', message: 'Invalid or unauthorized API key.' }
+  if (status === 429) return { kind: 'quota', message: 'Upstream rate limit / quota reached.' }
+  return { kind: 'network', message: `Upstream HTTP ${status}.` }
+}
+
+async function forwardToProvider(spec: ProviderSpec, apiKey: string, prompt: string): Promise<
+  | { ok: true; b64Json: string; mimeType: string }
+  | { ok: false; status: number; kind: ErrorKind; message: string }
+> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS)
+
+  let upstream: globalThis.Response
+  try {
+    upstream = await fetch(spec.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // BYOK: the user's key authorizes the upstream call. We never
+        // log it, never echo it, never persist it.
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(spec.buildBody(prompt)),
+      signal: controller.signal,
+    })
+  } catch (err: unknown) {
+    clearTimeout(timer)
+    const aborted = (err as { name?: string })?.name === 'AbortError'
+    return {
+      ok: false,
+      status: 504,
+      kind: 'network',
+      message: aborted ? 'Upstream timed out.' : 'Network error reaching the provider.',
+    }
+  }
+  clearTimeout(timer)
+
+  if (!upstream.ok) {
+    // Parse the upstream error body so we can surface an actionable
+    // reason (e.g. content_policy_violation, billing). Both OpenAI and
+    // xAI return { error: { message, code, type } } on failure. We
+    // include the message for 4xx (user-fixable) but NOT for 5xx
+    // (provider-side, would just confuse the user). The full body is
+    // also logged server-side for operator debugging.
+    const text = await upstream.text().catch(() => '')
+    let upstreamMessage = ''
+    let upstreamCode = ''
+    try {
+      const parsed = JSON.parse(text) as { error?: { message?: string; code?: string } }
+      upstreamMessage = parsed?.error?.message || ''
+      upstreamCode = parsed?.error?.code || ''
+    } catch {
+      /* upstream returned non-JSON */
+    }
+    console.warn(`[ai-proxy] upstream ${upstream.status} ${spec.url} code=${upstreamCode || 'n/a'} message=${upstreamMessage || text.slice(0, 200)}`)
+
+    const base = classifyHttpStatus(upstream.status)
+    // For 4xx, prefer the upstream's specific message — it tells the
+    // user what to fix (e.g. "Your request was rejected by safety
+    // system"). For 5xx, stick with the generic mapping.
+    const message = upstream.status >= 400 && upstream.status < 500 && upstreamMessage
+      ? upstreamMessage
+      : base.message
+    // Content-policy violations sometimes come back as 400 generic —
+    // upgrade those to kind:'safety' so the modal renders the right
+    // icon/copy.
+    const isPolicy = /policy|moderation|safety|content/i.test(upstreamMessage) || /content_policy|moderation/i.test(upstreamCode)
+    const kind = isPolicy ? 'safety' : base.kind
+    return { ok: false, status: upstream.status, kind, message }
+  }
+
+  const data = await upstream.json().catch(() => null) as
+    | { data?: Array<{ b64_json?: string; url?: string }> }
+    | null
+
+  const first = data?.data?.[0]
+  if (!first) {
+    // Upstream returned 200 OK but no image entry — typically a silent
+    // safety block on Gemini-like providers; rare on OpenAI/xAI.
+    return {
+      ok: false,
+      status: 502,
+      kind: 'empty',
+      message: 'No image returned by upstream (prompt may have been blocked).',
+    }
+  }
+
+  // Preferred path: upstream gave us b64 directly.
+  if (first.b64_json) {
+    return { ok: true, b64Json: first.b64_json, mimeType: 'image/png' }
+  }
+
+  // Fallback path: OpenAI may return a temporary URL (when response_format
+  // is omitted, which we now do because the API rejects it as unknown).
+  // Fetch the bytes server-side and convert to b64 so the FE keeps a
+  // single rendering path regardless of provider.
+  if (first.url) {
+    try {
+      const imgRes = await fetch(first.url)
+      if (!imgRes.ok) {
+        return { ok: false, status: 502, kind: 'network', message: `Failed to fetch generated image (${imgRes.status}).` }
+      }
+      const buf = Buffer.from(await imgRes.arrayBuffer())
+      const mimeType = imgRes.headers.get('content-type') || 'image/png'
+      return { ok: true, b64Json: buf.toString('base64'), mimeType }
+    } catch {
+      return { ok: false, status: 502, kind: 'network', message: 'Failed to download generated image.' }
+    }
+  }
+
+  return {
+    ok: false,
+    status: 502,
+    kind: 'empty',
+    message: 'Upstream response contained no image data.',
+  }
+}
+
+function makeImageHandler(providerKey: string) {
+  const spec = PROVIDERS[providerKey]
+  return async (req: Request, res: Response): Promise<void> => {
+    if (!spec) {
+      errorResponse(res, 404, 'network', `Unknown provider: ${providerKey}`)
+      return
+    }
+    const body = (req.body || {}) as { apiKey?: unknown; prompt?: unknown }
+    const apiKey = typeof body.apiKey === 'string' ? body.apiKey.trim() : ''
+    const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
+    if (!apiKey) { errorResponse(res, 400, 'auth', 'Missing API key.'); return }
+    if (!prompt) { errorResponse(res, 400, 'empty', 'Missing prompt.'); return }
+
+    try {
+      const result = await forwardToProvider(spec, apiKey, prompt)
+      if (result.ok) {
+        res.json({ b64Json: result.b64Json, mimeType: result.mimeType })
+        return
+      }
+      errorResponse(res, result.status, result.kind, result.message)
+    } catch {
+      // Defensive: we don't surface stack/details (might contain the
+      // prompt or upstream-echoed body). The FE only needs the kind.
+      errorResponse(res, 500, 'network', 'AI proxy: internal error.')
+    }
+  }
+}
+
+router.post('/openai/image', gate, aiProxyRateLimit, makeImageHandler('openai'))
+router.post('/grok/image',   gate, aiProxyRateLimit, makeImageHandler('grok'))
+
+router.get('/health', (_req, res) => {
+  res.json({ providers: Object.keys(PROVIDERS) })
+})
+
+export default router

--- a/client/src/api/routes/rpc-proxy.ts
+++ b/client/src/api/routes/rpc-proxy.ts
@@ -4,6 +4,7 @@ import {
   getL1HttpRpcUrl,
   getL2HttpRpcUrl,
 } from '../../utils/rpcProvider'
+import { originGate } from '../middleware/originGate'
 
 /**
  * FE → backend → upstream RPC proxy.
@@ -35,106 +36,15 @@ import {
 
 const router = Router()
 
-// Origin gate. Without this, any script anywhere on the internet
-// could POST /api/rpc/l2 and burn our paid Infura quota — CORS only
-// stops browsers from READING cross-origin responses; it doesn't stop
-// the server from processing the request itself.
-//
-// Default behaviour: allow same-host requests — i.e. the request's
-// Origin (or Referer) host equals the Host header (the server's own
-// public hostname). This is the common case and needs ZERO config:
-// the FE served from https://test.caw.social fetching /api/rpc/l2 sends
-// Origin: https://test.caw.social and Host: test.caw.social, which match.
-//
-// Extra allowlists for cross-origin clients (peer mirrors, dev hosts,
-// or operator scripts):
-//   - ALLOWED_ORIGINS env (comma-separated). '*' opens to anyone.
-//   - PUBLIC_URL env (operator's explicit public hostname, if it
-//     differs from the Host header — e.g. behind a CDN that rewrites).
-function parseAllowedOrigins(): { exact: Set<string>; wildcard: boolean } {
-  const exact = new Set<string>()
-  let wildcard = false
-  for (const raw of (process.env.ALLOWED_ORIGINS || '').split(',')) {
-    const o = raw.trim()
-    if (!o) continue
-    if (o === '*') { wildcard = true; continue }
-    exact.add(o.replace(/\/$/, ''))
-  }
-  const publicUrl = (process.env.PUBLIC_URL || '').trim().replace(/\/$/, '')
-  if (publicUrl) exact.add(publicUrl)
-  return { exact, wildcard }
-}
-const allowed = parseAllowedOrigins()
-if (process.env.NODE_ENV !== 'test') {
-  if (allowed.wildcard) {
-    console.warn('[rpc-proxy] ALLOWED_ORIGINS includes "*" — anyone can hit /api/rpc/*. OK for dev, NOT for prod.')
-  } else if (allowed.exact.size > 0) {
-    console.log(`[rpc-proxy] Origin allowlist (in addition to same-host): ${Array.from(allowed.exact).join(', ')}`)
-  } else {
-    console.log('[rpc-proxy] Same-host requests allowed; no extra cross-origin allowlist configured.')
-  }
-}
-
-// Same-host check: the Origin/Referer host matches the request's
-// Host header. Express tracks the proxied Host via req.hostname when
-// 'trust proxy' is set (it is — server.ts: app.set('trust proxy', 'loopback')).
-// We also compare against req.headers.host raw as a fallback.
-function requestSelfOrigins(req: Request): string[] {
-  const hosts = new Set<string>()
-  if (req.hostname) hosts.add(req.hostname)
-  const rawHost = (req.headers.host || '').split(',')[0].trim()
-  if (rawHost) hosts.add(rawHost.replace(/:\d+$/, '')) // strip port; Origin doesn't carry it for default ports
-  // Build both http and https variants — TLS termination is at nginx,
-  // so `req.protocol` may say 'http' even when the public scheme is
-  // https. Accept both; the only attacker who could spoof either is
-  // already on the loopback interface, which we trust.
-  const origins: string[] = []
-  for (const h of hosts) {
-    origins.push(`https://${h}`)
-    origins.push(`http://${h}`)
-    if (rawHost && rawHost.includes(':')) {
-      origins.push(`https://${rawHost}`)
-      origins.push(`http://${rawHost}`)
-    }
-  }
-  return origins
-}
-
-function originAllowed(req: Request): boolean {
-  if (allowed.wildcard) return true
-  // Prefer Origin (browser-set on fetch from a different page). Fall
-  // back to Referer. One must be present AND match — no header = block.
-  const origin = (req.headers.origin || '').replace(/\/$/, '')
-  let candidate = origin
-  if (!candidate) {
-    const referer = req.headers.referer || ''
-    if (referer) {
-      try {
-        const u = new URL(referer)
-        candidate = `${u.protocol}//${u.host}`
-      } catch { /* malformed referer */ }
-    }
-  }
-  if (!candidate) return false
-
-  // Same-host: the candidate matches one of the request's own self
-  // origins. No env config needed.
-  for (const self of requestSelfOrigins(req)) {
-    if (candidate === self) return true
-  }
-  // Extra explicit allowlist for peer mirrors / dev hosts.
-  if (allowed.exact.has(candidate)) return true
-  return false
-}
-
-function originGate(req: Request, res: Response, next: () => void) {
-  if (originAllowed(req)) return next()
-  res.status(403).json({
-    jsonrpc: '2.0',
-    id: null,
-    error: { code: -32001, message: 'RPC proxy: origin not allowed' },
-  })
-}
+// Origin gate lives in middleware/originGate.ts so other proxy routes
+// (ai-proxy, etc.) can share it. See that file for the allowlist semantics.
+// The gate is a factory — we pass our own JSON-RPC response body so the
+// shape stays exactly what RPC clients have always received here.
+const gate = originGate(() => ({
+  jsonrpc: '2.0',
+  id: null,
+  error: { code: -32001, message: 'RPC proxy: origin not allowed' },
+}))
 
 // Per-IP rate limit. Catches a single browser misbehaving without
 // affecting other users. Set generously: a normal user's tab fires
@@ -339,8 +249,8 @@ function makeHandler(chain: Chain) {
   }
 }
 
-router.post('/l1', originGate, proxyRateLimit, makeHandler('l1'))
-router.post('/l2', originGate, proxyRateLimit, makeHandler('l2'))
+router.post('/l1', gate, proxyRateLimit, makeHandler('l1'))
+router.post('/l2', gate, proxyRateLimit, makeHandler('l2'))
 
 // Light health probe — confirms the proxy is wired without exposing
 // upstream URLs.

--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -44,6 +44,7 @@ import moderationRouter from './routes/moderation'
 import ogRouter from './routes/og'
 import sitemapRouter from './routes/sitemap'
 import rpcProxyRouter from './routes/rpc-proxy'
+import aiProxyRouter from './routes/ai-proxy'
 import { spaPrerender } from './util/spaPrerender'
 import { cawPath, parseCawIdSlug } from './util/cawUrl'
 import { parseLocaleFromPath, withLocalePrefix } from './util/localePrefix'
@@ -381,6 +382,12 @@ export function createApp() {
   // the FE bundle and gives us a single chokepoint for retries,
   // failover, and rate limiting.
   app.use('/api/rpc', rpcProxyRouter)
+
+  // BYOK AI image gen proxy for providers that don't allow browser-direct
+  // calls (OpenAI, xAI). Gemini stays browser-direct in utils/aiImage.ts
+  // because Google serves permissive CORS — see ai-proxy.ts header for
+  // the full rationale.
+  app.use('/api/ai-proxy', aiProxyRouter)
 
   app.get('/api/__sentry-test', (_req, _res) => {
     throw new Error('Sentry backend test error')

--- a/client/src/services/FrontEnd/scripts/i18n-provider-placeholder.mjs
+++ b/client/src/services/FrontEnd/scripts/i18n-provider-placeholder.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * One-shot i18n fix: replace the hardcoded "Gemini" brand name in
+ *   settings.ai_provider.get_key
+ * across every locale with a {{provider}} placeholder, so the same key
+ * works for OpenAI/Grok/etc. without adding new keys.
+ *
+ * Run from anywhere:
+ *   node client/src/services/FrontEnd/scripts/i18n-provider-placeholder.mjs
+ *
+ * Idempotent — re-running is a no-op once every file already has the
+ * placeholder. Preserves the existing JSON formatting (2-space indent,
+ * trailing newline) so the diff stays small.
+ */
+import { promises as fs } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const LOCALES_DIR = path.resolve(__dirname, '../src/i18n/locales')
+const KEY = 'settings.ai_provider.get_key'
+
+// "Gemini" verbatim covers 21/22 locales. Hindi transliterates to
+// "जेमिनी" (devanagari for "jemini"). Add more variants here if a
+// future translator picks a different surface form.
+const VARIANTS = ['Gemini', 'जेमिनी']
+
+async function main() {
+  const files = (await fs.readdir(LOCALES_DIR)).filter(f => f.endsWith('.json')).sort()
+  let changed = 0
+  let skipped = 0
+  for (const file of files) {
+    const full = path.join(LOCALES_DIR, file)
+    const raw = await fs.readFile(full, 'utf8')
+    const json = JSON.parse(raw)
+    const before = json[KEY]
+    if (typeof before !== 'string') {
+      console.log(`-- ${file}: key missing, skipping`)
+      skipped++
+      continue
+    }
+    if (before.includes('{{provider}}')) {
+      console.log(`-- ${file}: already has placeholder, skipping`)
+      skipped++
+      continue
+    }
+    let after = before
+    for (const v of VARIANTS) {
+      after = after.split(v).join('{{provider}}')
+    }
+    if (after === before) {
+      console.log(`!! ${file}: no variant matched — manual review needed: "${before}"`)
+      skipped++
+      continue
+    }
+    json[KEY] = after
+    // 2-space indent + trailing newline matches the existing file style.
+    await fs.writeFile(full, JSON.stringify(json, null, 2) + '\n', 'utf8')
+    console.log(`✓  ${file}: "${before}" → "${after}"`)
+    changed++
+  }
+  console.log(`\nDone. changed=${changed}, skipped=${skipped}, total=${files.length}`)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/client/src/services/FrontEnd/src/components/MediaUpload.tsx
+++ b/client/src/services/FrontEnd/src/components/MediaUpload.tsx
@@ -162,6 +162,11 @@ const MediaCell: React.FC<{
   media: any
   index: number
   className?: string
+  /** How the image fills its cell. 'cover' (default) crops to fill — used
+   *  by the 2/3/4-image grid tiles. 'contain' preserves the source aspect
+   *  ratio — used by the single-image preview so square AI outputs don't
+   *  get cropped before they hit the feed. */
+  imageFit?: 'cover' | 'contain'
   isDark: boolean
   draggable: boolean
   draggedIndex: number | null
@@ -173,7 +178,7 @@ const MediaCell: React.FC<{
   onReorderDrop: (e: React.DragEvent, i: number) => void
   onRemove: (i: number) => void
   formatDuration: (s: number) => string
-}> = ({ media, index, className = '', isDark, draggable, draggedIndex, dragOverIndex,
+}> = ({ media, index, className = '', imageFit = 'cover', isDark, draggable, draggedIndex, dragOverIndex,
         onReorderDragStart, onReorderDragEnd, onReorderDragOver, onReorderDragLeave,
         onReorderDrop, onRemove, formatDuration }) => (
   <div
@@ -197,7 +202,7 @@ const MediaCell: React.FC<{
           <img
             src={media.preview || media.originalUrl || media.url}
             alt={`Selected ${index + 1}`}
-            className="w-full h-full object-cover"
+            className={`w-full h-full ${imageFit === 'contain' ? 'object-contain' : 'object-cover'}`}
           />
           {media.type === 'gif' && (
             <span className={`absolute bottom-1 left-1 px-1 py-0.5 text-xs font-semibold rounded ${
@@ -252,12 +257,16 @@ const MediaGrid: React.FC<{
   const count = selectedMedia.length
   const draggable = count > 1
 
-  const cell = (index: number, className?: string) => (
+  // imageFit defaults to 'cover' — preserves the grid-tile look for 2/3/4
+  // image layouts. Single-image passes 'contain' so square sources render
+  // at their natural aspect ratio without being cropped to 16:9.
+  const cell = (index: number, className?: string, imageFit: 'cover' | 'contain' = 'cover') => (
     <MediaCell
       key={index}
       media={selectedMedia[index]}
       index={index}
       className={className}
+      imageFit={imageFit}
       draggable={draggable}
       {...cellProps}
     />
@@ -268,7 +277,12 @@ const MediaGrid: React.FC<{
     if (isVideo) {
       return <div className="rounded-lg overflow-hidden bg-black md:max-h-[640px] flex items-center justify-center">{cell(0, 'w-full md:max-h-[640px]')}</div>
     }
-    return <div className="aspect-video rounded-lg overflow-hidden">{cell(0, 'w-full h-full')}</div>
+    // Single image: preserve the source aspect ratio in the preview so
+    // square outputs (AI providers default to 1:1 — Imagen, gpt-image-1,
+    // grok-2-image) don't get visually cropped to 16:9 only to render
+    // un-cropped in the feed afterwards. Match the video container's
+    // bg/centering so the bounding box still feels uniform.
+    return <div className="rounded-lg overflow-hidden bg-black md:max-h-[640px] flex items-center justify-center">{cell(0, 'w-full md:max-h-[640px]', 'contain')}</div>
   }
 
   if (count === 2) {

--- a/client/src/services/FrontEnd/src/components/modals/AiImageGenerateModal.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/AiImageGenerateModal.tsx
@@ -3,8 +3,21 @@ import ModalWrapper from './ModalWrapper'
 import { useTheme } from '~/hooks/useTheme'
 import { useT } from '~/i18n/I18nProvider'
 import { themeText, themeTextSecondary, themeSecondaryButton } from '~/utils/theme'
-import { useAIProviderStore } from '~/store/aiProviderStore'
+import { useAIProviderStore, type AIProvider } from '~/store/aiProviderStore'
 import { generateAIImage, AIImageError } from '~/utils/aiImage'
+import { SiOpenai, SiGooglegemini, SiX } from 'react-icons/si'
+import type { IconType } from 'react-icons'
+
+// Provider tag metadata shown in the modal header. Brand marks come
+// from react-icons/si (Simple Icons) — already a dep, zero new bundle
+// cost. xAI doesn't have a dedicated mark in the set; we reuse SiX
+// because xAI uses the same X letterform visually as their parent
+// brand. Names aren't translated (brand names never are).
+const PROVIDER_TAG: Record<AIProvider, { label: string; Icon: IconType }> = {
+  gemini: { label: 'Gemini', Icon: SiGooglegemini },
+  openai: { label: 'OpenAI', Icon: SiOpenai },
+  grok:   { label: 'Grok',   Icon: SiX },
+}
 
 interface Props {
   isOpen: boolean
@@ -59,7 +72,25 @@ const AiImageGenerateModal: React.FC<Props> = ({ isOpen, onClose, onImage }) => 
   return (
     <ModalWrapper isOpen={isOpen} onClose={onClose} maxWidth="max-w-md" zIndex={90} usePortal backdropClass="bg-black/60">
       <div className="p-6">
-        <h2 className={`text-lg font-bold mb-4 ${themeText(isDark)}`}>{t('post_form.ai.gen.title')}</h2>
+        <div className="flex items-center gap-2 mb-4">
+          <h2 className={`text-lg font-bold ${themeText(isDark)}`}>{t('post_form.ai.gen.title')}</h2>
+          {provider && (() => {
+            const { label, Icon } = PROVIDER_TAG[provider]
+            return (
+              <span
+                className={`inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full border ${
+                  isDark
+                    ? 'border-yellow-500/30 bg-yellow-500/10 text-yellow-400'
+                    : 'border-yellow-500/40 bg-yellow-500/10 text-yellow-700'
+                }`}
+                title={t('settings.ai_provider.title')}
+              >
+                <Icon className="w-3 h-3" aria-hidden />
+                {label}
+              </span>
+            )
+          })()}
+        </div>
 
         <textarea
           value={prompt}
@@ -91,7 +122,15 @@ const AiImageGenerateModal: React.FC<Props> = ({ isOpen, onClose, onImage }) => 
             disabled={loading || !prompt.trim()}
             className={`px-4 py-2 rounded-lg text-sm font-medium transition cursor-pointer ${themeSecondaryButton(isDark)} disabled:opacity-50`}
           >
-            {loading ? t('post_form.ai.gen.generating') : result ? t('post_form.ai.gen.regenerate') : t('post_form.ai.gen.generate')}
+            {loading ? (
+              <span className="inline-flex items-center gap-2">
+                {/* Inline spinner — same border-spin pattern used across
+                    the app (TrendingHashtags, ReplyItem). Sized small to
+                    sit next to the label without changing button height. */}
+                <span className="w-3.5 h-3.5 border-2 border-gray-400 border-t-yellow-500 rounded-full animate-spin" />
+                {t('post_form.ai.gen.generating')}
+              </span>
+            ) : result ? t('post_form.ai.gen.regenerate') : t('post_form.ai.gen.generate')}
           </button>
           {result && (
             <button

--- a/client/src/services/FrontEnd/src/i18n/locales/ar.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/ar.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "قم بتوصيل مفتاح موفر الذكاء الاصطناعي الخاص بك لإنشاء صور من المطالبة. يتم استخدام المفتاح مباشرة من متصفحك ولا يتم إرساله مطلقًا إلى خوادمنا.",
   "settings.ai_provider.provider_label": "مزود",
   "settings.ai_provider.key_label": "مفتاح واجهة برمجة التطبيقات",
-  "settings.ai_provider.get_key": "احصل على مفتاح Gemini API →",
+  "settings.ai_provider.get_key": "احصل على مفتاح {{provider}} API →",
   "settings.ai_provider.remember": "تذكر على هذا الجهاز",
   "settings.ai_provider.remember_warning": "مخزنة غير مشفرة في هذا المتصفح. قم بالتمكين فقط على الجهاز الذي تثق به.",
   "settings.ai_provider.save": "يحفظ",

--- a/client/src/services/FrontEnd/src/i18n/locales/de.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/de.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Verbinden Sie Ihren eigenen KI-Anbieterschlüssel, um Bilder aus einer Eingabeaufforderung zu generieren. Der Schlüssel wird direkt von Ihrem Browser verwendet und niemals an unsere Server gesendet.",
   "settings.ai_provider.provider_label": "Anbieter",
   "settings.ai_provider.key_label": "API-Schlüssel",
-  "settings.ai_provider.get_key": "Holen Sie sich einen Gemini-API-Schlüssel →",
+  "settings.ai_provider.get_key": "Holen Sie sich einen {{provider}}-API-Schlüssel →",
   "settings.ai_provider.remember": "Denken Sie an dieses Gerät",
   "settings.ai_provider.remember_warning": "Wird unverschlüsselt in diesem Browser gespeichert. Aktivieren Sie die Funktion nur auf einem Gerät, dem Sie vertrauen.",
   "settings.ai_provider.save": "Speichern",

--- a/client/src/services/FrontEnd/src/i18n/locales/en.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/en.json
@@ -198,7 +198,6 @@
   "post_form.tip.preview_label": "Approx.",
   "post_form.tip.loading_price": "Loading CAW price…",
   "post_form.tip.need_recipient": "Pick a recipient — start with @username to find someone.",
-
   "post_form.ai.tooltip": "Create AI images",
   "post_form.ai.aria": "Create AI images",
   "post_form.ai.modal.title": "Connect your AI provider",
@@ -220,7 +219,7 @@
   "settings.ai_provider.menu_description": "Connect your own AI provider key to generate images",
   "settings.ai_provider.provider_label": "Provider",
   "settings.ai_provider.key_label": "API key",
-  "settings.ai_provider.get_key": "Get a Gemini API key →",
+  "settings.ai_provider.get_key": "Get a {{provider}} API key →",
   "settings.ai_provider.remember": "Remember on this device",
   "settings.ai_provider.remember_warning": "Stored unencrypted in this browser. Only enable on a device you trust.",
   "settings.ai_provider.save": "Save",

--- a/client/src/services/FrontEnd/src/i18n/locales/es.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/es.json
@@ -1332,7 +1332,7 @@
   "settings.ai_provider.description": "Conecte su propia clave de proveedor de IA para generar imágenes a partir de un mensaje. La clave se utiliza directamente desde su navegador y nunca se envía a nuestros servidores.",
   "settings.ai_provider.provider_label": "Proveedor",
   "settings.ai_provider.key_label": "clave API",
-  "settings.ai_provider.get_key": "Obtenga una clave API de Gemini →",
+  "settings.ai_provider.get_key": "Obtenga una clave API de {{provider}} →",
   "settings.ai_provider.remember": "Recuerda en este dispositivo",
   "settings.ai_provider.remember_warning": "Almacenado sin cifrar en este navegador. Habilítelo solo en un dispositivo en el que confíe.",
   "settings.ai_provider.save": "Ahorrar",

--- a/client/src/services/FrontEnd/src/i18n/locales/fa.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/fa.json
@@ -1353,7 +1353,7 @@
   "settings.ai_provider.description": "کلید ارائه دهنده هوش مصنوعی خود را برای تولید تصاویر از یک درخواست وصل کنید. کلید مستقیماً از مرورگر شما استفاده می شود و هرگز به سرورهای ما ارسال نمی شود.",
   "settings.ai_provider.provider_label": "ارائه دهنده",
   "settings.ai_provider.key_label": "کلید API",
-  "settings.ai_provider.get_key": "یک کلید API Gemini دریافت کنید →",
+  "settings.ai_provider.get_key": "یک کلید API {{provider}} دریافت کنید →",
   "settings.ai_provider.remember": "در این دستگاه به خاطر بسپارید",
   "settings.ai_provider.remember_warning": "به صورت رمزگذاری نشده در این مرورگر ذخیره می شود. فقط در دستگاهی که به آن اعتماد دارید فعال کنید.",
   "settings.ai_provider.save": "ذخیره کنید",

--- a/client/src/services/FrontEnd/src/i18n/locales/fr.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/fr.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Connectez votre propre clé de fournisseur d'IA pour générer des images à partir d'une invite. La clé est utilisée directement depuis votre navigateur et n'est jamais envoyée à nos serveurs.",
   "settings.ai_provider.provider_label": "Fournisseur",
   "settings.ai_provider.key_label": "Clé API",
-  "settings.ai_provider.get_key": "Obtenir une clé API Gemini →",
+  "settings.ai_provider.get_key": "Obtenir une clé API {{provider}} →",
   "settings.ai_provider.remember": "N'oubliez pas sur cet appareil",
   "settings.ai_provider.remember_warning": "Stocké en clair dans ce navigateur. Activez uniquement sur un appareil en qui vous avez confiance.",
   "settings.ai_provider.save": "Sauvegarder",

--- a/client/src/services/FrontEnd/src/i18n/locales/he.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/he.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "חבר מפתח ספק AI משלך כדי ליצור תמונות מהנחיה. המפתח משמש ישירות מהדפדפן שלך ולעולם לא נשלח לשרתים שלנו.",
   "settings.ai_provider.provider_label": "ספק",
   "settings.ai_provider.key_label": "מפתח API",
-  "settings.ai_provider.get_key": "קבל מפתח API של Gemini →",
+  "settings.ai_provider.get_key": "קבל מפתח API של {{provider}} →",
   "settings.ai_provider.remember": "זכור במכשיר הזה",
   "settings.ai_provider.remember_warning": "מאוחסן לא מוצפן בדפדפן זה. הפעל רק במכשיר שאתה סומך עליו.",
   "settings.ai_provider.save": "לְהַצִיל",

--- a/client/src/services/FrontEnd/src/i18n/locales/hi.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/hi.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "प्रॉम्प्ट से छवियाँ उत्पन्न करने के लिए अपनी स्वयं की AI प्रदाता कुंजी कनेक्ट करें। कुंजी का उपयोग सीधे आपके ब्राउज़र से किया जाता है और कभी भी हमारे सर्वर पर नहीं भेजा जाता है।",
   "settings.ai_provider.provider_label": "प्रदाता",
   "settings.ai_provider.key_label": "एपीआई कुंजी",
-  "settings.ai_provider.get_key": "जेमिनी एपीआई कुंजी प्राप्त करें →",
+  "settings.ai_provider.get_key": "{{provider}} एपीआई कुंजी प्राप्त करें →",
   "settings.ai_provider.remember": "इस डिवाइस पर याद रखें",
   "settings.ai_provider.remember_warning": "इस ब्राउज़र में अनएन्क्रिप्टेड संग्रहीत। केवल उसी डिवाइस पर सक्षम करें जिस पर आपको भरोसा है।",
   "settings.ai_provider.save": "बचाना",

--- a/client/src/services/FrontEnd/src/i18n/locales/id.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/id.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Hubungkan kunci penyedia AI Anda sendiri untuk menghasilkan gambar dari perintah. Kuncinya digunakan langsung dari browser Anda dan tidak pernah dikirim ke server kami.",
   "settings.ai_provider.provider_label": "Penyedia",
   "settings.ai_provider.key_label": "Kunci API",
-  "settings.ai_provider.get_key": "Dapatkan kunci API Gemini →",
+  "settings.ai_provider.get_key": "Dapatkan kunci API {{provider}} →",
   "settings.ai_provider.remember": "Ingat di perangkat ini",
   "settings.ai_provider.remember_warning": "Disimpan tidak terenkripsi di browser ini. Hanya aktifkan di perangkat yang Anda percayai.",
   "settings.ai_provider.save": "Menyimpan",

--- a/client/src/services/FrontEnd/src/i18n/locales/it.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/it.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Connetti la tua chiave del provider AI per generare immagini da un prompt. La chiave viene utilizzata direttamente dal tuo browser e non viene mai inviata ai nostri server.",
   "settings.ai_provider.provider_label": "Fornitore",
   "settings.ai_provider.key_label": "Chiave API",
-  "settings.ai_provider.get_key": "Ottieni una chiave API Gemini →",
+  "settings.ai_provider.get_key": "Ottieni una chiave API {{provider}} →",
   "settings.ai_provider.remember": "Ricorda su questo dispositivo",
   "settings.ai_provider.remember_warning": "Memorizzato non crittografato in questo browser. Abilita solo su un dispositivo di cui ti fidi.",
   "settings.ai_provider.save": "Salva",

--- a/client/src/services/FrontEnd/src/i18n/locales/ja.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/ja.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "独自の AI プロバイダー キーを接続して、プロンプトから画像を生成します。キーはブラウザから直接使用され、当社のサーバーに送信されることはありません。",
   "settings.ai_provider.provider_label": "プロバイダー",
   "settings.ai_provider.key_label": "APIキー",
-  "settings.ai_provider.get_key": "Gemini API キーを取得 →",
+  "settings.ai_provider.get_key": "{{provider}} API キーを取得 →",
   "settings.ai_provider.remember": "このデバイスで記憶する",
   "settings.ai_provider.remember_warning": "このブラウザでは暗号化されずに保存されます。信頼できるデバイスでのみ有効にしてください。",
   "settings.ai_provider.save": "保存",

--- a/client/src/services/FrontEnd/src/i18n/locales/ko.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/ko.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "프롬프트에서 이미지를 생성하려면 자체 AI 공급자 키를 연결하세요. 키는 브라우저에서 직접 사용되며 당사 서버로 전송되지 않습니다.",
   "settings.ai_provider.provider_label": "공급자",
   "settings.ai_provider.key_label": "API 키",
-  "settings.ai_provider.get_key": "Gemini API 키 받기 →",
+  "settings.ai_provider.get_key": "{{provider}} API 키 받기 →",
   "settings.ai_provider.remember": "이 기기에 기억하세요",
   "settings.ai_provider.remember_warning": "이 브라우저에 암호화되지 않은 상태로 저장됩니다. 신뢰할 수 있는 장치에서만 활성화하세요.",
   "settings.ai_provider.save": "구하다",

--- a/client/src/services/FrontEnd/src/i18n/locales/nl.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/nl.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Sluit uw eigen AI-providersleutel aan om afbeeldingen te genereren op basis van een prompt. De sleutel wordt rechtstreeks vanuit uw browser gebruikt en nooit naar onze servers verzonden.",
   "settings.ai_provider.provider_label": "Aanbieder",
   "settings.ai_provider.key_label": "API-sleutel",
-  "settings.ai_provider.get_key": "Verkrijg een Gemini API-sleutel →",
+  "settings.ai_provider.get_key": "Verkrijg een {{provider}} API-sleutel →",
   "settings.ai_provider.remember": "Onthoud op dit apparaat",
   "settings.ai_provider.remember_warning": "Onversleuteld opgeslagen in deze browser. Schakel dit alleen in op een apparaat dat u vertrouwt.",
   "settings.ai_provider.save": "Redden",

--- a/client/src/services/FrontEnd/src/i18n/locales/pl.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/pl.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Podłącz własny klucz dostawcy AI, aby generować obrazy z podpowiedzi. Klucz jest używany bezpośrednio z Twojej przeglądarki i nigdy nie jest wysyłany na nasze serwery.",
   "settings.ai_provider.provider_label": "Dostawca",
   "settings.ai_provider.key_label": "Klucz API",
-  "settings.ai_provider.get_key": "Zdobądź klucz API Gemini →",
+  "settings.ai_provider.get_key": "Zdobądź klucz API {{provider}} →",
   "settings.ai_provider.remember": "Remember on this device",
   "settings.ai_provider.remember_warning": "Przechowywane w formie niezaszyfrowanej w tej przeglądarce. Włącz tylko na zaufanym urządzeniu.",
   "settings.ai_provider.save": "Ratować",

--- a/client/src/services/FrontEnd/src/i18n/locales/pt.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/pt.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Conecte sua própria chave de provedor de IA para gerar imagens a partir de um prompt. A chave é usada diretamente do seu navegador e nunca é enviada aos nossos servidores.",
   "settings.ai_provider.provider_label": "Provedor",
   "settings.ai_provider.key_label": "Chave de API",
-  "settings.ai_provider.get_key": "Obtenha uma chave de API Gemini →",
+  "settings.ai_provider.get_key": "Obtenha uma chave de API {{provider}} →",
   "settings.ai_provider.remember": "Lembre-se neste dispositivo",
   "settings.ai_provider.remember_warning": "Armazenado sem criptografia neste navegador. Ative apenas em um dispositivo em que você confia.",
   "settings.ai_provider.save": "Salvar",

--- a/client/src/services/FrontEnd/src/i18n/locales/ru.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/ru.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Подключите свой собственный ключ поставщика искусственного интеллекта, чтобы генерировать изображения из подсказки. Ключ используется непосредственно из вашего браузера и никогда не отправляется на наши серверы.",
   "settings.ai_provider.provider_label": "Поставщик",
   "settings.ai_provider.key_label": "API-ключ",
-  "settings.ai_provider.get_key": "Получить ключ Gemini API →",
+  "settings.ai_provider.get_key": "Получить ключ {{provider}} API →",
   "settings.ai_provider.remember": "Помните, на этом устройстве",
   "settings.ai_provider.remember_warning": "Хранится в незашифрованном виде в этом браузере. Включайте только на том устройстве, которому вы доверяете.",
   "settings.ai_provider.save": "Сохранять",

--- a/client/src/services/FrontEnd/src/i18n/locales/th.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/th.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "เชื่อมต่อคีย์ผู้ให้บริการ AI ของคุณเองเพื่อสร้างภาพจากข้อความแจ้ง รหัสนี้ถูกใช้โดยตรงจากเบราว์เซอร์ของคุณ และไม่เคยส่งไปยังเซิร์ฟเวอร์ของเรา",
   "settings.ai_provider.provider_label": "ผู้ให้บริการ",
   "settings.ai_provider.key_label": "คีย์เอพีไอ",
-  "settings.ai_provider.get_key": "รับคีย์ Gemini API →",
+  "settings.ai_provider.get_key": "รับคีย์ {{provider}} API →",
   "settings.ai_provider.remember": "จำไว้ในอุปกรณ์นี้",
   "settings.ai_provider.remember_warning": "จัดเก็บแบบไม่เข้ารหัสในเบราว์เซอร์นี้ เปิดใช้งานบนอุปกรณ์ที่คุณเชื่อถือเท่านั้น",
   "settings.ai_provider.save": "บันทึก",

--- a/client/src/services/FrontEnd/src/i18n/locales/tl.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/tl.json
@@ -1353,7 +1353,7 @@
   "settings.ai_provider.description": "Ikonekta ang iyong sariling AI provider key para makabuo ng mga larawan mula sa isang prompt. Ang susi ay direktang ginagamit mula sa iyong browser at hindi kailanman ipinadala sa aming mga server.",
   "settings.ai_provider.provider_label": "Provider",
   "settings.ai_provider.key_label": "API key",
-  "settings.ai_provider.get_key": "Kumuha ng Gemini API key →",
+  "settings.ai_provider.get_key": "Kumuha ng {{provider}} API key →",
   "settings.ai_provider.remember": "Tandaan sa device na ito",
   "settings.ai_provider.remember_warning": "Naka-imbak nang hindi naka-encrypt sa browser na ito. Paganahin lang sa isang device na pinagkakatiwalaan mo.",
   "settings.ai_provider.save": "I-save",

--- a/client/src/services/FrontEnd/src/i18n/locales/tr.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/tr.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Bir istemden görüntüler oluşturmak için kendi AI sağlayıcı anahtarınızı bağlayın. Anahtar doğrudan tarayıcınızdan kullanılır ve hiçbir zaman sunucularımıza gönderilmez.",
   "settings.ai_provider.provider_label": "sağlayıcı",
   "settings.ai_provider.key_label": "API anahtarı",
-  "settings.ai_provider.get_key": "Gemini API anahtarı edinin →",
+  "settings.ai_provider.get_key": "{{provider}} API anahtarı edinin →",
   "settings.ai_provider.remember": "Bu cihazda hatırla",
   "settings.ai_provider.remember_warning": "Bu tarayıcıda şifrelenmemiş olarak saklanıyor. Yalnızca güvendiğiniz bir cihazda etkinleştirin.",
   "settings.ai_provider.save": "Kaydetmek",

--- a/client/src/services/FrontEnd/src/i18n/locales/uk.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/uk.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Підключіть власний ключ постачальника штучного інтелекту, щоб генерувати зображення з підказки. Ключ використовується безпосередньо з вашого браузера і ніколи не надсилається на наші сервери.",
   "settings.ai_provider.provider_label": "Провайдер",
   "settings.ai_provider.key_label": "Ключ API",
-  "settings.ai_provider.get_key": "Отримайте ключ Gemini API →",
+  "settings.ai_provider.get_key": "Отримайте ключ {{provider}} API →",
   "settings.ai_provider.remember": "Запам'ятати на цьому пристрої",
   "settings.ai_provider.remember_warning": "Зберігається в незашифрованому вигляді в цьому браузері. Увімкніть лише на пристрої, якому ви довіряєте.",
   "settings.ai_provider.save": "зберегти",

--- a/client/src/services/FrontEnd/src/i18n/locales/vi.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/vi.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "Kết nối khóa nhà cung cấp AI của riêng bạn để tạo hình ảnh từ lời nhắc. Khóa được sử dụng trực tiếp từ trình duyệt của bạn và không bao giờ được gửi đến máy chủ của chúng tôi.",
   "settings.ai_provider.provider_label": "nhà cung cấp",
   "settings.ai_provider.key_label": "Khóa API",
-  "settings.ai_provider.get_key": "Nhận khóa API Gemini →",
+  "settings.ai_provider.get_key": "Nhận khóa API {{provider}} →",
   "settings.ai_provider.remember": "Ghi nhớ trên thiết bị này",
   "settings.ai_provider.remember_warning": "Được lưu trữ không được mã hóa trong trình duyệt này. Chỉ kích hoạt trên thiết bị mà bạn tin tưởng.",
   "settings.ai_provider.save": "Cứu",

--- a/client/src/services/FrontEnd/src/i18n/locales/zh.json
+++ b/client/src/services/FrontEnd/src/i18n/locales/zh.json
@@ -1354,7 +1354,7 @@
   "settings.ai_provider.description": "连接您自己的 AI 提供商密钥以根据提示生成图像。密钥直接从您的浏览器使用，不会发送到我们的服务器。",
   "settings.ai_provider.provider_label": "提供商",
   "settings.ai_provider.key_label": "API密钥",
-  "settings.ai_provider.get_key": "获取 Gemini API 密钥 →",
+  "settings.ai_provider.get_key": "获取 {{provider}} API 密钥 →",
   "settings.ai_provider.remember": "在此设备上记住",
   "settings.ai_provider.remember_warning": "未加密地存储在此浏览器中。仅在您信任的设备上启用。",
   "settings.ai_provider.save": "节省",

--- a/client/src/services/FrontEnd/src/pages/AIProviderSettings.tsx
+++ b/client/src/services/FrontEnd/src/pages/AIProviderSettings.tsx
@@ -3,8 +3,32 @@ import { useNavigate } from '~/utils/localizedRouter'
 import { useTheme } from '~/hooks/useTheme'
 import { useT } from '~/i18n/I18nProvider'
 import { themeText, themeTextSecondary, themeSecondaryButton } from '~/utils/theme'
-import { useAIProviderStore } from '~/store/aiProviderStore'
+import { useAIProviderStore, type AIProvider } from '~/store/aiProviderStore'
 import { HiArrowLeft } from 'react-icons/hi'
+import ThemedListbox from '~/components/forms/ThemedListbox'
+
+// Single source of truth for the per-provider UI metadata (label shown in
+// the selector, where to grab a key, placeholder hint). Adding a fourth
+// provider = one entry here + matching backend route + AIProvider union.
+// Per-provider UI metadata. None of these are translated — all are
+// brand-name/format-hint strings that read the same in every locale.
+//   - `label`     : verbose name shown in the dropdown.
+//   - `shortName` : short form interpolated into the translated
+//                   "Get a {{provider}} API key →" link below the input.
+//   - `placeholder`: API-key prefix hint inside the input.
+//   - `keyHelpUrl`: where the user can fetch a key.
+interface ProviderMeta {
+  id: AIProvider
+  label: string
+  shortName: string
+  keyHelpUrl: string
+  placeholder: string
+}
+const PROVIDER_META: ProviderMeta[] = [
+  { id: 'gemini', label: 'Google Gemini', shortName: 'Gemini', keyHelpUrl: 'https://aistudio.google.com/apikey',    placeholder: 'AI...'  },
+  { id: 'openai', label: 'OpenAI (GPT)',  shortName: 'OpenAI', keyHelpUrl: 'https://platform.openai.com/api-keys', placeholder: 'sk-...' },
+  { id: 'grok',   label: 'xAI (Grok)',    shortName: 'Grok',   keyHelpUrl: 'https://console.x.ai',                 placeholder: 'xai-...' },
+]
 
 const AIProviderSettings: React.FC = () => {
   const { isDark } = useTheme()
@@ -12,16 +36,20 @@ const AIProviderSettings: React.FC = () => {
   const navigate = useNavigate()
   const { provider, apiKey, remembered, connect, disconnect } = useAIProviderStore()
 
+  // Initialize from the persisted connection if any; otherwise default to
+  // the first provider in the list so the input/help link have a target.
+  const [selected, setSelected] = useState<AIProvider>(provider ?? 'gemini')
   const [key, setKey] = useState(apiKey ?? '')
   const [remember, setRemember] = useState(remembered)
   const [saved, setSaved] = useState(false)
 
   const connected = !!apiKey && !!provider
+  const selectedMeta = PROVIDER_META.find(p => p.id === selected) ?? PROVIDER_META[0]
 
   const onSave = () => {
     const trimmed = key.trim()
     if (!trimmed) return
-    connect('gemini', trimmed, remember)
+    connect(selected, trimmed, remember)
     setSaved(true)
     setTimeout(() => setSaved(false), 2000)
   }
@@ -48,10 +76,13 @@ const AIProviderSettings: React.FC = () => {
       <label className={`block text-sm font-medium mb-1 ${themeText(isDark)}`}>
         {t('settings.ai_provider.provider_label')}
       </label>
-      <div className={`mb-4 px-3 py-2 rounded-lg border text-sm ${
-        isDark ? 'border-white/15 bg-white/5 text-white' : 'border-gray-300 bg-gray-50 text-black'
-      }`}>
-        Google Gemini
+      <div className="mb-4">
+        <ThemedListbox<AIProvider>
+          isDark={isDark}
+          value={selected}
+          onChange={setSelected}
+          options={PROVIDER_META.map(p => ({ value: p.id, label: p.label }))}
+        />
       </div>
 
       <label className={`block text-sm font-medium mb-1 ${themeText(isDark)}`}>
@@ -61,19 +92,19 @@ const AIProviderSettings: React.FC = () => {
         type="password"
         value={key}
         onChange={(e) => setKey(e.target.value)}
-        placeholder="AI..."
+        placeholder={selectedMeta.placeholder}
         autoComplete="off"
         className={`w-full mb-2 px-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2 focus:ring-yellow-500/40 ${
           isDark ? 'border-white/15 bg-black text-white' : 'border-gray-300 bg-white text-black'
         }`}
       />
       <a
-        href="https://aistudio.google.com/apikey"
+        href={selectedMeta.keyHelpUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="text-xs text-yellow-500 hover:underline"
       >
-        {t('settings.ai_provider.get_key')}
+        {t('settings.ai_provider.get_key', { provider: selectedMeta.shortName })}
       </a>
 
       <label className={`flex items-start gap-2 mt-5 mb-1 cursor-pointer ${themeText(isDark)}`}>

--- a/client/src/services/FrontEnd/src/store/aiProviderStore.ts
+++ b/client/src/services/FrontEnd/src/store/aiProviderStore.ts
@@ -9,7 +9,12 @@ import { create } from 'zustand'
 // the user explicitly opts into "remember on this device", and even then just
 // their own provider key at their own risk (clear security note in the UI).
 
-export type AIProvider = 'gemini'
+export type AIProvider = 'gemini' | 'openai' | 'grok'
+
+// Keep this in sync with the AIProvider union — used to validate the
+// persisted blob so a stale localStorage entry from a previous provider
+// list can't crash the rehydrate path.
+const VALID_PROVIDERS: ReadonlyArray<AIProvider> = ['gemini', 'openai', 'grok']
 
 const LS_KEY = 'caw.ai.connection'
 
@@ -23,7 +28,7 @@ function loadPersisted(): Persisted | null {
     const raw = localStorage.getItem(LS_KEY)
     if (!raw) return null
     const p = JSON.parse(raw)
-    if (p && typeof p.apiKey === 'string' && p.provider === 'gemini') return p
+    if (p && typeof p.apiKey === 'string' && VALID_PROVIDERS.includes(p.provider)) return p
   } catch {
     /* corrupt / unavailable storage — treat as not connected */
   }

--- a/client/src/services/FrontEnd/src/utils/aiImage.ts
+++ b/client/src/services/FrontEnd/src/utils/aiImage.ts
@@ -1,14 +1,23 @@
-// Client-side AI image generation (BYOK). Calls the provider directly from
-// the browser with the user's own key — same rationale as utils/translate.ts
-// (no backend, no key custody). Gemini's Generative Language API accepts the
-// key as an x-goog-api-key request header (not ?key= query param). We use the
-// header form deliberately: Sentry's default fetch instrumentation captures
-// URLs in breadcrumbs/Replay but does NOT capture request headers, so the
-// header form prevents the key from appearing in Sentry payloads.
-// OpenAI does NOT support permissive CORS and would need a backend proxy —
-// intentionally not added here.
+// Client-side AI image generation (BYOK). Two transport modes depending on
+// the provider's CORS posture:
+//
+//   - Gemini: browser → Google directly. Google's Generative Language API
+//     serves permissive CORS and accepts the key in an `x-goog-api-key`
+//     header. We use the header form deliberately: Sentry's default fetch
+//     instrumentation captures URLs in breadcrumbs/Replay but does NOT
+//     capture request headers, so the key never lands in Sentry payloads.
+//
+//   - OpenAI / Grok: browser → our backend → upstream. These providers
+//     do NOT serve permissive CORS, so direct browser fetches are blocked
+//     before the response reaches user code. We forward through
+//     /api/ai-proxy/{provider}/image with the user's key in the JSON body;
+//     the backend uses it for the upstream call and discards it (no
+//     persistence, no logging). See api/routes/ai-proxy.ts for the
+//     server-side contract.
+//
+// Either way the key stays the user's (BYOK) — we never custody it.
 
-export type AIProvider = 'gemini'
+export type AIProvider = 'gemini' | 'openai' | 'grok'
 
 export interface AIImageResult {
   blob: Blob
@@ -77,6 +86,46 @@ async function generateGemini(prompt: string, apiKey: string): Promise<AIImageRe
   return { blob: base64ToBlob(pred.bytesBase64Encoded, mimeType), mimeType }
 }
 
+// OpenAI and Grok go through our backend proxy (see header). Both share
+// the same proxy response shape — { b64Json, mimeType } on success, or
+// { error: { kind, message } } with a non-2xx status. We re-map the kind
+// straight into AIImageError so the modal's existing catch path works
+// uniformly across providers.
+type ProxyErrorKind = AIImageError['kind']
+
+async function generateViaProxy(
+  proxyPath: '/api/ai-proxy/openai/image' | '/api/ai-proxy/grok/image',
+  prompt: string,
+  apiKey: string,
+): Promise<AIImageResult> {
+  let res: Response
+  try {
+    res = await fetch(proxyPath, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // Body-only auth: the key never appears in URL/query (Sentry safe)
+      // and is consumed once by the backend, never persisted there.
+      body: JSON.stringify({ apiKey, prompt }),
+    })
+  } catch {
+    throw new AIImageError('Network error reaching the AI proxy.', 'network')
+  }
+
+  if (!res.ok) {
+    const data = await res.json().catch(() => null) as { error?: { kind?: ProxyErrorKind; message?: string } } | null
+    const kind = data?.error?.kind || 'network'
+    const message = data?.error?.message || `AI proxy error (${res.status}).`
+    throw new AIImageError(message, kind)
+  }
+
+  const data = await res.json().catch(() => null) as { b64Json?: string; mimeType?: string } | null
+  if (!data?.b64Json) {
+    throw new AIImageError('No image returned by AI proxy.', 'empty')
+  }
+  const mimeType = data.mimeType || 'image/png'
+  return { blob: base64ToBlob(data.b64Json, mimeType), mimeType }
+}
+
 /**
  * Generate one image from a prompt using the connected provider. Throws
  * AIImageError with a typed `kind` so the modal can show an actionable message.
@@ -89,7 +138,16 @@ export async function generateAIImage(
   switch (provider) {
     case 'gemini':
       return generateGemini(prompt, apiKey)
-    default:
+    case 'openai':
+      return generateViaProxy('/api/ai-proxy/openai/image', prompt, apiKey)
+    case 'grok':
+      return generateViaProxy('/api/ai-proxy/grok/image', prompt, apiKey)
+    default: {
+      // Exhaustiveness check: if AIProvider grows and we forget to handle
+      // it here, tsc flags this assignment.
+      const _exhaustive: never = provider
+      void _exhaustive
       throw new AIImageError('Unsupported provider.', 'network')
+    }
   }
 }


### PR DESCRIPTION

Adds OpenAI (gpt-image-1) and xAI (grok-2-image) as AI image providers alongside the existing Gemini path. Browser-direct calls aren't possible for those two — they don't serve permissive CORS — so they're routed through a new backend proxy that keeps the BYOK model intact (user key is consumed once and never persisted or logged).

Backend
-------
- New api/middleware/originGate.ts: shared origin allowlist extracted from rpc-proxy.ts. Refactored into a factory that accepts the caller's preferred 403 response body so each proxy keeps its own contract (rpc-proxy still returns JSON-RPC; ai-proxy returns the FE-friendly { error: { kind, message } } shape).
- New api/routes/ai-proxy.ts: POST /api/ai-proxy/openai/image and /grok/image. Per-IP rate limit (30/min), 60s AbortController timeout, upstream error message surfaced for 4xx (logged server-side too), handles both b64_json and url upstream payload shapes.
- api/server.ts: mounts /api/ai-proxy.
- api/routes/rpc-proxy.ts: imports the shared gate; behaviour identical to before the refactor (verified with response-shape regression test).

Frontend — store / util
-----------------------
- store/aiProviderStore.ts: AIProvider union extended to 'gemini' | 'openai' | 'grok', with rehydrate validation against a VALID_PROVIDERS list.
- utils/aiImage.ts: Gemini still calls Google directly; OpenAI and Grok go through the proxy. Single AIImageError catch path across all three. Exhaustiveness check via `never` so adding a 4th provider fails type- check until it's wired through.

Frontend — settings
-------------------
- pages/AIProviderSettings.tsx: replaced the hardcoded "Google Gemini" block with a ThemedListbox (same styling as the language picker). Per-provider metadata table drives the dropdown label, key prefix placeholder, and "Get a … API key" link.
- The "Get a … API key →" link now uses i18n interpolation with the provider name — translated across all 22 locales (see i18n section).

Frontend — AI generation modal
------------------------------
- components/modals/AiImageGenerateModal.tsx: provider chip in the header showing the brand mark (react-icons/si: SiGooglegemini, SiOpenai, SiX) + short label. Already-installed dependency.
- Inline spinner next to "Generating…" matching the project's existing spinner pattern (TrendingHashtags, ReplyItem).

Frontend — media preview fix
----------------------------
- components/MediaUpload.tsx: single-image preview no longer forces a 16:9 aspect-video crop. New imageFit prop on MediaCell ('cover' for multi-image grids, 'contain' for single image) preserves the source aspect ratio so square AI outputs (which all three providers return by default) render uncropped in the composer — matching how the feed already renders them.

i18n
----
- New scripts/i18n-provider-placeholder.mjs: one-shot, idempotent rewrite of settings.ai_provider.get_key across all 22 locales. Replaces the hardcoded "Gemini" (and the Hindi transliteration "जेमिनी") with {{provider}} so the same key works for every provider.
- 22 locale files updated. Spot-checked: ES "Obtenga una clave API de {{provider}} →", JA "{{provider}} API キーを取得 →", AR "احصل على مفتاح {{provider}} API →", etc.

Verification done autonomously
------------------------------
- TypeScript: clean across every touched file.
- Backend smoke test: routes mount, origin gate blocks no-Origin, OpenAI endpoint reached with real upstream auth (got real 401 with dummy key, not 404 — confirms endpoint + model name + auth header).
- RPC proxy response byte-identical to before the originGate refactor (regression test).
- AIProviderSettings is reachable via /settings/ai-provider route and the Settings menu entry.

Not verified (FE/QA path)
-------------------------
- End-to-end image gen with real keys: pending user verification.
- i18n rendering of the translated "Get a … API key →" link in the browser at non-English locales.