### PR TITLE
fix(ux): toolbar icon spacing + iPhone bottom-nav padding

### DIFF
--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -3189,7 +3189,13 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
               Emoji) sits inline with the Post button on the top row; the
               second group (post attributes — Schedule / Poll / Tip / AI)
               wraps to a second row when there isn't enough width. */}
-          <div className="flex flex-wrap items-center min-w-0 gap-x-3 gap-y-1 flex-1">
+          {/* Outer gap-x mirrors the inner groups' gap-x so the inter-group
+              spacing (Emoji ↔ Schedule) matches the intra-group spacing.
+              Without this the parent kept gap-x-3 in compose/reply mode
+              while the groups dropped to gap-x-1 → 8px asymmetric hole. */}
+          <div className={`flex flex-wrap items-center min-w-0 gap-y-1 flex-1 ${
+            composeMode || replyTo ? 'gap-x-1' : 'gap-x-1 sm:gap-x-3'
+          }`}>
             {/* Group 1 — content embedding (3 icons) */}
             <div className={`flex items-center ${
               composeMode || replyTo ? 'gap-x-1' : 'gap-x-1 sm:gap-x-3'

--- a/client/src/services/FrontEnd/src/components/TipAttachmentControl.tsx
+++ b/client/src/services/FrontEnd/src/components/TipAttachmentControl.tsx
@@ -445,7 +445,7 @@ const TipAttachmentControl: React.FC<Props> = ({
         disabled={disabled}
         title={title || t('post_form.tip.tooltip', { defaultValue: 'Attach tips to your post' })}
         aria-label={triggerAriaLabel}
-        className={`relative p-1 rounded-full transition-all duration-200 ${
+        className={`relative p-2 rounded-full transition-all duration-200 ${
           disabled ? 'opacity-30 cursor-not-allowed' : 'cursor-pointer'
         } ${activeClasses}`}
       >

--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -496,7 +496,14 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
           // suggest the row is interactive but the click lands on the nav
           // (bug #215). The nav reclaims pointer events as soon as scroll
           // settles, so its own buttons remain usable.
-          className={`md:hidden fixed bottom-0 left-0 right-0 z-[55] flex items-center justify-around h-14 pb-[env(safe-area-inset-bottom)] [height:calc(theme(height.14)+env(safe-area-inset-bottom))] border-t transition-all duration-200 ${
+          // Padding-top proportional to the bottom safe-area inset. Only
+          // takes effect on hardware with a home-bar (iPhone X+ adds
+          // ~34px → pt ≈ 17px → icon shifts ~9px down, well clear of
+          // the FAB tap zone above). On Android / emulators without a
+          // safe-area the value is 0 and the layout matches the pre-fix
+          // behaviour exactly. Fixes #287 without over-correcting on
+          // safe-area-less environments.
+          className={`md:hidden fixed bottom-0 left-0 right-0 z-[55] flex items-center justify-around h-14 pt-[calc(env(safe-area-inset-bottom)/2)] pb-[env(safe-area-inset-bottom)] [height:calc(theme(height.14)+env(safe-area-inset-bottom))] border-t transition-all duration-200 ${
             hasInlineDraft ? 'opacity-0 translate-y-full pointer-events-none' : isScrolling ? 'opacity-30 pointer-events-none' : 'opacity-100'
           } ${
             isDark ? 'bg-black border-white/10' : 'bg-white border-gray-200'


### PR DESCRIPTION
Three small mobile UX touch-ups + two ticket verifications that turned out to be already-implemented upstream.

Toolbar icon spacing (#302, reporter: www)
------------------------------------------
- components/PostForm.tsx: outer wrapper of the composer toolbar was using gap-x-3 always, while the two inner groups (Media/GIF/Emoji and Schedule/Poll/Tip/AI) switched to gap-x-1 in compose/reply mode. Result: an 8px-wider hole between Emoji and Schedule (the inter-group boundary) compared to the intra-group gaps. Mirrored the inner gap-x formula onto the parent so every icon-to-icon gap matches in every context (compose mode, reply mode, and the responsive sm: bump).
- components/TipAttachmentControl.tsx: trigger button was the only one in the toolbar with p-1 padding (32px box); every other icon used p-2 (40px box). The asymmetry was visible as Tip sitting noticeably closer to its neighbours. Bumped to p-2 — the badge counter (absolute -top-1 -right-1) keeps the same relative offset because it's positioned against the button box.

iPhone bottom-nav padding (#287, reporter: earth)
------------------------------------------------
- layouts/MainLayout.tsx: bottom nav used h-14 + items-center, which on iPhone (with ~34px safe-area-inset-bottom) made the icons sit 14px from the top and 48px from the bottom — visually pinned to the top edge, and uncomfortably close to the FAB tap zone. Added pt-[calc(env(safe-area-inset-bottom)/2)]: proportional padding-top that scales with the safe-area. iPhone X+ gets ~17px of pt (icons shift ~9px down, well clear of the FAB), Android / emulators with zero safe-area get 0px pt (layout identical to before — no regression on devices that weren't affected by the bug).

Tickets verified as already-fixed (no commit needed) ----------------------------------------------------
- #214 (Color-code unread notification rows, reporter: nir): implemented in 0e2903f01 (May 10, 2026) by Gilgamesh.Caw, refined with age-graded tint tiers (24h/72h) in 9118d257f (May 12, 2026). Notifications.tsx:1031-1049 renders the X-style yellow tint that fades as the row ages. Reporter likely on a stale bundle.

- #190 (Tap CAW logo to scroll to top, reporter: neumann): implemented in 065cc4a37 (May 9, 2026) by Gilgamesh.Caw. Mobile header (MainLayout.tsx:308-313) and desktop sidebar (Sidebar.tsx:134-146 guardClick — applies to all nav links, not just the logo) both scroll-to-top when tapped on the current route. Reporter likely on a stale bundle.