### PR TITLE
  fix(ui): bug-bash v10 — iOS crash recovery, signing spinner, viewer swipe, follow flicker, staking circles

### DIFF
--- a/client/src/services/FrontEnd/src/components/FollowButton.tsx
+++ b/client/src/services/FrontEnd/src/components/FollowButton.tsx
@@ -104,7 +104,7 @@ export const FollowButton: React.FC<FollowButtonProps> = ({
       disabled={wrongWallet || disabled}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      className={`rounded-full font-medium transition-all duration-200 ${
+      className={`rounded-full font-medium ${
         wrongWallet || disabled ? 'opacity-50 cursor-not-allowed' :
         isPending ? 'opacity-90 cursor-pointer' :
         'cursor-pointer'

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -2785,7 +2785,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                     disabled={isDisabled}
                     onClick={handleSubmit}
                   >
-                    {wrongWallet ? t('post_form.button.wrong_wallet') : uploadProgress ? uploadProgress : signingProgress ? <>{t('post_form.button.signing_progress')} <span ref={signingCountRef1}>1</span>/{signingProgress.total}...</> : isSubmitting ? t('post_form.button.signing') : isThreadMode ? t('post_form.button.thread', { count: submittableChunkCount }) : replyTo ? t('post_form.button.reply') : t('post_form.button.post')}
+                    {wrongWallet ? t('post_form.button.wrong_wallet') : uploadProgress ? uploadProgress : signingProgress ? <span className="inline-flex items-center justify-center gap-1.5"><span className="w-4 h-4 border-2 border-black/30 border-t-black rounded-full animate-spin" /><span ref={signingCountRef1}>1</span>/{signingProgress.total}</span> : isSubmitting ? <span className="inline-flex items-center justify-center"><span className="w-4 h-4 border-2 border-black/30 border-t-black rounded-full animate-spin" /></span> : isThreadMode ? t('post_form.button.thread', { count: submittableChunkCount }) : replyTo ? t('post_form.button.reply') : t('post_form.button.post')}
                   </button>
                 )
                 return tooltipText ? <Tooltip text={tooltipText}>{btn}</Tooltip> : btn
@@ -3552,7 +3552,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                     disabled={isDisabled2}
                     onClick={handleSubmit}
                   >
-                    {wrongWallet2 ? t('post_form.button.wrong_wallet') : hasNoToken ? t('post_form.button.create_account') : uploadProgress ? uploadProgress : signingProgress ? <>{t('post_form.button.signing_progress')} <span ref={signingCountRef2}>1</span>/{signingProgress.total}...</> : isSubmitting ? t('post_form.button.signing') : isThreadMode ? t('post_form.button.thread', { count: submittableChunkCount }) : replyTo ? t('post_form.button.reply') : t('post_form.button.post')}
+                    {wrongWallet2 ? t('post_form.button.wrong_wallet') : hasNoToken ? t('post_form.button.create_account') : uploadProgress ? uploadProgress : signingProgress ? <span className="inline-flex items-center justify-center gap-1.5"><span className="w-4 h-4 border-2 border-black/30 border-t-black rounded-full animate-spin" /><span ref={signingCountRef2}>1</span>/{signingProgress.total}</span> : isSubmitting ? <span className="inline-flex items-center justify-center"><span className="w-4 h-4 border-2 border-black/30 border-t-black rounded-full animate-spin" /></span> : isThreadMode ? t('post_form.button.thread', { count: submittableChunkCount }) : replyTo ? t('post_form.button.reply') : t('post_form.button.post')}
                   </button>
                 )
                 return tooltipText2 ? <Tooltip text={tooltipText2}>{btn2}</Tooltip> : btn2

--- a/client/src/services/FrontEnd/src/components/modals/CawMediaModal.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/CawMediaModal.tsx
@@ -71,6 +71,11 @@ export default function CawMediaModal() {
     count: 0,
     setIndex: () => {},
   })
+
+  // Touch-swipe state for the image viewer (#259). `swiped` flags that the
+  // gesture crossed the swipe threshold so the panel's close-on-tap onClick
+  // can ignore the trailing click.
+  const swipeRef = useRef<{ x: number; y: number; swiped: boolean } | null>(null)
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -291,6 +296,34 @@ export default function CawMediaModal() {
 
   const current = mediaItems[activeIndex]
 
+  // Horizontal touch-swipe to change image — left = next, right = prev
+  // (X-style). Purely additive: the arrow buttons and ←/→ keys still work.
+  const SWIPE_THRESHOLD = 50
+  const onViewerTouchStart = (e: React.TouchEvent) => {
+    if (e.touches.length !== 1) { swipeRef.current = null; return }
+    swipeRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY, swiped: false }
+  }
+  const onViewerTouchMove = (e: React.TouchEvent) => {
+    const s = swipeRef.current
+    if (!s || e.touches.length !== 1) return
+    const dx = e.touches[0].clientX - s.x
+    const dy = e.touches[0].clientY - s.y
+    // Commit to a swipe once it clearly beats the vertical motion.
+    if (Math.abs(dx) > SWIPE_THRESHOLD && Math.abs(dx) > Math.abs(dy)) s.swiped = true
+  }
+  const onViewerTouchEnd = (e: React.TouchEvent) => {
+    const s = swipeRef.current
+    if (!s || mediaItems.length <= 1) return
+    const t = e.changedTouches[0]
+    if (!t) return
+    const dx = t.clientX - s.x
+    const dy = t.clientY - s.y
+    if (Math.abs(dx) < SWIPE_THRESHOLD || Math.abs(dx) <= Math.abs(dy)) return
+    s.swiped = true
+    if (dx < 0 && activeIndex < mediaItems.length - 1) setIndex(activeIndex + 1)
+    else if (dx > 0 && activeIndex > 0) setIndex(activeIndex - 1)
+  }
+
   const postPanelInner = loading
     ? <div className={`${isDark ? 'text-white/70' : 'text-gray-700'}`}>Loading…</div>
     : error || !caw
@@ -408,10 +441,16 @@ export default function CawMediaModal() {
             // Tap/click the empty area around the image closes the modal.
             // Use click (not pointerdown) to avoid click-through after unmount.
             if (e.target !== e.currentTarget) return
+            // A horizontal swipe ends with a synthetic click — ignore it so
+            // swiping over the empty margin doesn't also close the modal.
+            if (swipeRef.current?.swiped) { swipeRef.current = null; return }
             e.preventDefault()
             e.stopPropagation()
             close()
           }}
+          onTouchStart={onViewerTouchStart}
+          onTouchMove={onViewerTouchMove}
+          onTouchEnd={onViewerTouchEnd}
         >
           {/* Nav arrows */}
           {mediaItems.length > 1 && (

--- a/client/src/services/FrontEnd/src/pages/Staking.tsx
+++ b/client/src/services/FrontEnd/src/pages/Staking.tsx
@@ -946,7 +946,7 @@ const Staking = () => {
         isDark ? 'bg-black border-white/20' : 'bg-white border-gray-200'
       }`}>
         <div className="flex items-start space-x-3">
-          <div className={`w-6 h-6 rounded-full flex items-center justify-center transition-colors duration-300 ${
+          <div className={`w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 transition-colors duration-300 ${
             isDark ? 'bg-white/10' : 'bg-gray-200'
           }`}>
             <HiOutlineInformationCircle className={`w-4 h-4 transition-colors duration-300 ${
@@ -973,7 +973,7 @@ const Staking = () => {
         isDark ? 'bg-black border-white/20' : 'bg-white border-gray-200'
       }`}>
         <div className="flex items-start space-x-3">
-          <div className={`w-6 h-6 rounded-full flex items-center justify-center transition-colors duration-300 ${
+          <div className={`w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 transition-colors duration-300 ${
             isDark ? 'bg-white/10' : 'bg-gray-200'
           }`}>
             <HiOutlineInformationCircle className={`w-4 h-4 transition-colors duration-300 ${
@@ -1000,7 +1000,7 @@ const Staking = () => {
         isDark ? 'bg-black border-white/20' : 'bg-white border-gray-200'
       }`}>
         <div className="flex items-start space-x-3">
-          <div className={`w-6 h-6 rounded-full flex items-center justify-center transition-colors duration-300 ${
+          <div className={`w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 transition-colors duration-300 ${
             isDark ? 'bg-white/10' : 'bg-gray-200'
           }`}>
             <HiOutlineInformationCircle className={`w-4 h-4 transition-colors duration-300 ${

--- a/client/src/services/FrontEnd/src/routes.tsx
+++ b/client/src/services/FrontEnd/src/routes.tsx
@@ -21,7 +21,12 @@ function lazyWithReload<T extends ComponentType<any>>(
   return lazy(() =>
     loader().catch((err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err)
-      const isChunkError = /Failed to fetch dynamically imported module|Loading chunk|ChunkLoadError|error loading dynamically imported module/i.test(msg)
+      // A stale chunk 404 (post-deploy) words its failure differently per
+      // engine — match all of them. Missing the Safari/iOS variant
+      // ("Importing a module script failed") meant iOS users hit the
+      // root error boundary instead of the one-shot reload (#306), while
+      // Chrome/Android recovered silently.
+      const isChunkError = /Failed to fetch dynamically imported module|Loading chunk|ChunkLoadError|error loading dynamically imported module|Importing a module script failed/i.test(msg)
       if (isChunkError && !sessionStorage.getItem(RELOADED_KEY)) {
         sessionStorage.setItem(RELOADED_KEY, '1')
         window.location.reload()


### PR DESCRIPTION
## Fixes

  ### #306 — App crashes on left-drawer button tap (iOS)
  `lazyWithReload` only matched Chrome/Firefox chunk-load error messages.
  Safari/iOS words a stale-chunk failure "Importing a module script failed",
  which the regex missed — so iOS users hit the root error boundary (app dead
  until reload) instead of the one-shot auto-reload Chrome/Android got. Added
  the Safari variant to the regex.

  ### #304 — "Signing..." label feels unnecessary
  The Post button showed a static "Signing..." text while signing. Replaced it
  with the platform's standard spinner (CSS border-spinner, `animate-spin`):
  single post = spinner only, thread = spinner + the N/M progress counter.
  Language-agnostic — no text in any of the 22 locales.

  ### #259 — Multi-photo swipe in viewer
  The multi-image viewer (`CawMediaModal`) could only change image via the
  arrow buttons / arrow keys. Added horizontal touch-swipe: drag left = next,
  right = previous. Threshold-gated and biased against vertical motion so it
  doesn't fight a swipe-down; a completed swipe suppresses the trailing
  close-on-tap click. Arrows and keys unchanged.

  ### Follow button state flicker
  `FollowButton` carried `transition-all duration-200`, so the Follow →
  Following flip cross-faded background/text/border between the outline and
  filled styles — a smeared intermediate frame that read as the two button
  styles overlapping. Dropped the transition so the state flip is instant.

  ### Deformed info circles on /staking/info
  The `w-6 h-6` info-icon circle in each item (Requirements / Reward
  Distribution / Real-time Rewards) was a flex child with no shrink guard, so
  the long body paragraph beside it squeezed the circle's width — rendering it
  as an oval. Added `flex-shrink-0` to all three.

  ## Not addressed in this PR

  - **#297 / #298.
  - **#277.