### PR TITLE
fix(ui): bug-bash v11 - iOS first-load race, JA IME input, posting hang, Android nav padding, AI sparkle

### DIFF
--- a/client/src/services/FrontEnd/src/components/HighlightedTextarea.tsx
+++ b/client/src/services/FrontEnd/src/components/HighlightedTextarea.tsx
@@ -5,6 +5,11 @@ import { TAG_CHAR_CLASS, HASHTAG_SIGIL_CLASS, MENTION_SIGIL_CLASS } from '~/../.
 interface HighlightedTextareaProps {
   value: string
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
+  // Fired when an IME composition (CJK candidate selection) commits. The
+  // textarea's normal onChange events are skipped by the parent while a
+  // composition is open (#322); this is how the parent learns the final
+  // composed text. Optional — non-IME callers can ignore it.
+  onCompositionEnd?: (e: React.CompositionEvent<HTMLTextAreaElement>) => void
   onClick?: (e: React.MouseEvent<HTMLTextAreaElement>) => void
   onKeyUp?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
   onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
@@ -47,6 +52,7 @@ interface HighlightedTextareaProps {
 const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
   value,
   onChange,
+  onCompositionEnd,
   onClick,
   onKeyUp,
   onKeyDown,
@@ -390,6 +396,7 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
         placeholder={placeholder}
         value={value}
         onChange={onChange}
+        onCompositionEnd={onCompositionEnd}
         onClick={onClick}
         onKeyUp={onKeyUp}
         onKeyDown={onKeyDown}

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -59,7 +59,7 @@ const AiGlitterIcon: React.FC<{ sizeClass: string }> = ({ sizeClass }) => (
         strokeLinejoin="round"
         strokeWidth={1.8}
         vectorEffect="non-scaling-stroke"
-        d="M18 6.2l.3 1a2.1 2.1 0 001.4 1.4l1 .3-1 .3a2.1 2.1 0 00-1.4 1.4l-.3 1-.3-1a2.1 2.1 0 00-1.4-1.4l-1-.3 1-.3a2.1 2.1 0 001.4-1.4l.3-1z"
+        d="M20 2.5l.3 1a2.1 2.1 0 001.4 1.4l1 .3-1 .3a2.1 2.1 0 00-1.4 1.4l-.3 1-.3-1a2.1 2.1 0 00-1.4-1.4l-1-.3 1-.3a2.1 2.1 0 001.4-1.4l.3-1z"
       />
     </g>
   </svg>
@@ -747,6 +747,13 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
 
   // Handle text change and cursor position for mention autocomplete
   const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    // Skip intermediate events fired by the IME while a CJK composition is
+    // open — committing that interim text to React state re-renders the
+    // controlled textarea and kills the IME candidate window mid-selection
+    // (#322, reported by a JA user who couldn't type past ~140 JA chars).
+    // The final composed value is committed via handleCompositionEnd below.
+    // Latin input has isComposing=false → handler runs normally, no change.
+    if ((e.nativeEvent as any).isComposing) return
     const cursor = e.target.selectionStart
     // Single-mode → thread-mode transition: when this keystroke pushes the
     // text past POST_CHAR_LIMIT, the single textarea will unmount and the
@@ -757,6 +764,16 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
     // local since there's only one chunk, so cursor IS the master offset.
     pendingMasterCursorRef.current = cursor
     setText(e.target.value)
+    setCursorPosition(cursor)
+  }
+
+  // IME commit — pushes the final composed text into state. Pairs with
+  // the isComposing skip in handleTextChange above (#322).
+  const handleCompositionEnd = (e: React.CompositionEvent<HTMLTextAreaElement>) => {
+    const ta = e.currentTarget
+    const cursor = ta.selectionStart
+    pendingMasterCursorRef.current = cursor
+    setText(ta.value)
     setCursorPosition(cursor)
   }
 
@@ -1677,7 +1694,23 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
     setTipAttachments([])
     onSuccess?.()
     } catch (error: any) {
-      // Ignore errors (user may have rejected signature)
+      // Surface real failures so the user knows what happened — #326 was
+      // reported as "stuck on the posting screen" because the prior catch
+      // swallowed every error silently, leaving the modal open with the
+      // typed text and zero feedback. Wallet rejections stay silent
+      // (intentional UX); anything else gets a toast. Mirrors the
+      // schedule path's error handling (see the schedule try/finally
+      // above), just routed through a toast since the regular composer
+      // has no inline error slot.
+      const isUserRejection = error?.code === 4001 || /rejected|denied|cancelled/i.test(error?.message || '')
+      if (!isUserRejection) {
+        console.error('[PostForm] submit failed:', error)
+        const raw = error?.message || 'Something went wrong while posting.'
+        // apiFetch wraps server messages as "API <status>: <detail>" — strip
+        // the prefix so the toast reads like a normal sentence.
+        const cleaned = raw.replace(/^API\s+\d+(?:\s+[A-Za-z ]+)?:\s*/, '')
+        toast.error(cleaned)
+      }
     } finally {
       setIsSubmitting(false)
       setSigningProgress(null)
@@ -2532,6 +2565,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                   <HighlightedTextarea
                     value={text}
                     onChange={handleTextChange}
+                    onCompositionEnd={handleCompositionEnd}
                     onClick={handleTextClick}
                     onKeyUp={handleTextKeyUp}
                     onDragOver={handleTextareaDragOver}
@@ -3022,6 +3056,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
               <HighlightedTextarea
                 value={text}
                 onChange={handleTextChange}
+                onCompositionEnd={handleCompositionEnd}
                 onClick={handleTextClick}
                 onKeyUp={handleTextKeyUp}
                 onDragOver={handleTextareaDragOver}

--- a/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
+++ b/client/src/services/FrontEnd/src/layouts/MainLayout.tsx
@@ -512,13 +512,12 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
           // suggest the row is interactive but the click lands on the nav
           // (bug #215). The nav reclaims pointer events as soon as scroll
           // settles, so its own buttons remain usable.
-          // Padding-top proportional to the bottom safe-area inset. Only
-          // takes effect on hardware with a home-bar (iPhone X+ adds
-          // ~34px → pt ≈ 17px → icon shifts ~9px down, well clear of
-          // the FAB tap zone above). On Android / emulators without a
-          // safe-area the value is 0 and the layout matches the pre-fix
-          // behaviour exactly. Fixes #287 without over-correcting on
-          // safe-area-less environments.
+          // Padding-top proportional to the bottom safe-area inset — only
+          // takes effect on iPhone X+ home-bar hardware (~17px) where it
+          // shifts the icons down out of the FAB's tap zone. On Android /
+          // emulators the value is 0 and the icons stay perfectly centered
+          // in the nav (the FAB-vs-icon clearance for Android is solved by
+          // raising the FAB itself — see the FAB's bottom-24 below, #287).
           className={`md:hidden fixed bottom-0 left-0 right-0 z-[55] flex items-center justify-around h-14 pt-[calc(env(safe-area-inset-bottom)/2)] pb-[env(safe-area-inset-bottom)] [height:calc(theme(height.14)+env(safe-area-inset-bottom))] border-t transition-all duration-200 ${
             hasInlineDraft ? 'opacity-0 translate-y-full pointer-events-none' : isScrolling ? 'opacity-30 pointer-events-none' : 'opacity-100'
           } ${
@@ -589,7 +588,7 @@ const MainLayout = ({ children, hideSidebars: hideSidebarsProp }: MainLayoutProp
           // Mirrors the bottom-nav rule: pointer-events-none while
           // scrolling so the semi-transparent FAB doesn't intercept
           // taps meant for the post action row sitting behind it.
-          className={`md:hidden fixed right-6 bottom-20 z-[60] w-12 h-12 rounded-full bg-yellow-500 hover:bg-yellow-400 active:bg-yellow-600 text-black flex items-center justify-center shadow-lg shadow-black/30 transition-all duration-200 cursor-pointer ${
+          className={`md:hidden fixed right-6 bottom-24 z-[60] w-12 h-12 rounded-full bg-yellow-500 hover:bg-yellow-400 active:bg-yellow-600 text-black flex items-center justify-center shadow-lg shadow-black/30 transition-all duration-200 cursor-pointer ${
             hasInlineDraft ? 'opacity-0 translate-y-24 pointer-events-none' : isScrolling ? 'opacity-30 pointer-events-none' : 'opacity-100'
           }`}
         >

--- a/client/src/services/FrontEnd/vite.config.ts
+++ b/client/src/services/FrontEnd/vite.config.ts
@@ -149,11 +149,19 @@ export default defineConfig({
     // tells vite-plugin-pwa not to emit its own competing one or
     // re-link it from index.html.
     //
-    // registerType: 'autoUpdate' = new SW takes control on next page
-    // load instead of stalling on a "waiting" state. Combined with
-    // skipWaiting + clientsClaim, this avoids the classic PWA
-    // problem where every deploy strands users on the previous bundle
-    // until they manually close every tab.
+    // registerType: 'autoUpdate' + skipWaiting = the new SW activates
+    // immediately on deploy instead of stalling on a "waiting" state,
+    // avoiding the classic PWA problem where every deploy strands users
+    // on the previous bundle until they manually close every tab.
+    //
+    // clientsClaim is intentionally OFF (#319): with it on, the SW that
+    // installs on the FIRST visit claims the still-loading page mid-flight
+    // — in-flight asset requests get rerouted through a half-warmed cache
+    // and Safari/iOS in particular falls back to the index.html shell for
+    // JS chunks, leaving the user staring at a blank or partial render
+    // until they reload. Without clientsClaim the first visit completes
+    // over plain network (clean render), and the SW takes control on the
+    // next navigation/reload — same end state, no first-load race.
     //
     // navigateFallback: SPA shell fallback for offline navigation.
     // navigateFallbackDenylist excludes API + uploads + the OG/short-URL
@@ -177,7 +185,9 @@ export default defineConfig({
           /^\/s\//,
         ],
         cleanupOutdatedCaches: true,
-        clientsClaim: true,
+        // clientsClaim intentionally omitted — see the block comment above
+        // the VitePWA call. Keeping skipWaiting alone is enough for the
+        // fast-deploy behaviour without the first-install race.
         skipWaiting: true,
         // Bump for large vendor chunks (rainbowkit ~1.8MB) so they get
         // precached instead of skipped with a "size exceeded" warning.


### PR DESCRIPTION

#319 — iOS Safari first-load needs a reload
- Removed `clientsClaim: true` from the VitePWA workbox config. With it on, the SW that installs on the FIRST visit claimed the still-loading page mid-flight, rerouting in-flight asset requests through a half-warmed cache. Safari/iOS in particular fell back to the index.html shell for JS chunks and rendered blank/partial until the user reloaded. Without clientsClaim the first visit completes cleanly over plain network and the SW takes control on the next navigation/reload — same end state, no first-load race. `skipWaiting: true` stays, so post-deploy updates still activate instantly. Comment block above the VitePWA call rewritten to record the reasoning (so nobody puts clientsClaim back without thinking).

#326 — Post submission hangs on "posting" screen
- PostForm's submit catch was swallowing every error silently (`// Ignore errors (user may have rejected signature)`), with no toast/log. On any real failure (network, RPC, server) the user got zero feedback — the button quietly returned to "Post" and the modal stayed open with their text, reading as a hung "posting screen". The wallet-rejection silence is intentional UX, so kept that, but every other error now surfaces via toast.error with the cleaned server message (mirroring the schedule flow's error handling). State release in `finally` was already correct.

#322 — Long-text input bug at ~200 chars (JA/CJK with IME)
- The textarea had ZERO IME-composition handling. On each intermediate `change` event during a CJK IME composition, handleTextChange ran `setText(...)`, which re-renders the controlled <textarea> and kills the IME candidate window mid-selection. Reporter (JA) couldn't type past ~140 JA chars (= 420 bytes = the on-chain limit, which also triggers the single→thread-mode textarea swap and made the glitch worse). Fix: • PostForm.handleTextChange now skips the update when `e.nativeEvent.isComposing` is true. • New handleCompositionEnd commits the final composed text on `compositionend`. • HighlightedTextarea gained an optional `onCompositionEnd` prop that passes through to the underlying <textarea>. Both PostForm usages (single + chunk-mode) wire it. • Zero impact on Latin input (`isComposing` is always false there).

#287 — Bottom-nav icon padding on Android (still pending after PR 24)
- PR 24 added `pt-[calc(env(safe-area-inset-bottom)/2)]` to the bottom nav, which only takes effect on iPhone (safe-area ≈ 34px); on Android it resolved to 0 and the icons stayed jammed at the top of the nav, colliding with the FAB's tap zone above. Tried adding a base `pt` for Android but it pushed the icons visibly off-centre on every device. Switched approach: kept the icons centred (pt unchanged) and instead RAISED THE FAB from `bottom-20` (80px) to `bottom-24` (96px). Result: • Android gap FAB↔nav-icon: 24px → 40px (+66%). • iPhone gap: 15px → 23px (bonus). • Icons perfectly centred in the nav on all devices. Comment on the nav's pt rewritten to record where the Android clearance now lives.

AI sparkle icon — composition fix
- The double-sparkle AI icon had its small sparkle starting at `M18 6.2`, which made it touch the top-right arm of the big sparkle (looked fused into one blob). Repositioned the small sparkle's start point to `M20 2.5` — clearly up-and-to-the-right of the big one, with breathing room. Visual polish, no behaviour change.

Not addressed in this PR
- #306 — Already fixed in the v10 PR (`feat/ux-ui-improvements-v10`): `lazyWithReload`'s chunk-error regex didn't match Safari's "Importing a module script failed", which is why iOS users hit the root error boundary on stale chunks. Not touched here — the v10 fix covers it once that PR lands.