### PR TITLE
fix(ui): bug-bash v12 - profile cache invalidation, video session-sticky audio

### DIFF
--- a/client/src/services/FrontEnd/src/components/PostVideo.tsx
+++ b/client/src/services/FrontEnd/src/components/PostVideo.tsx
@@ -25,6 +25,14 @@ function releaseAudio(el: HTMLVideoElement) {
   if (audioCoordinator.current === el) audioCoordinator.current = null
 }
 
+// Session-sticky "user wants audio" flag (#336). Once the user unmutes
+// any video, subsequent videos they swipe into auto-unmute too — same
+// behaviour as TikTok / X. Cleared when the user explicitly mutes via
+// our toggle. Coordinator-driven mutes (when another video claims the
+// audio slot) intentionally DON'T clear it: that mute reflects video
+// switching, not the user wanting silence.
+let userWantsAudio = false
+
 /** Video player for posts. Mobile = native browser controls (familiar UX,
  * accessibility, buffering indicator). Desktop = custom hover overlay
  * (no browser chrome, cleaner look, fullscreen modal). */
@@ -76,6 +84,16 @@ const PostVideo: React.FC<{ url: string; onError?: () => void }> = ({ url, onErr
           if (!videoUserPausedRef.current && el.paused) {
             void el.play().catch(() => { /* autoplay blocked: ignore */ })
           }
+          // #336 — if the user already unmuted a previous video this
+          // session, carry that preference into this one too. claimAudio
+          // mutes any other unmuted video so we still play at most one
+          // at a time. Browsers permit programmatic unmute once the user
+          // has interacted with the page (which they did by unmuting the
+          // first video), so this doesn't trip autoplay-with-audio.
+          if (userWantsAudio && el.muted) {
+            el.muted = false
+            claimAudio(el)
+          }
         } else {
           if (!el.paused) el.pause()
           // Reset audio state when leaving the viewport. Without this,
@@ -114,7 +132,15 @@ const PostVideo: React.FC<{ url: string; onError?: () => void }> = ({ url, onErr
     if (!el) return
     const onVolumeChange = () => {
       setIsMuted(el.muted)
-      if (!el.muted) claimAudio(el)
+      if (!el.muted) {
+        claimAudio(el)
+        // #336 — any unmute (toggle button OR native controls) means the
+        // user wants audio for the session. Don't clear on mute here:
+        // we can't distinguish a user mute from a coordinator force-mute,
+        // and clearing on the latter would defeat the sticky behaviour.
+        // Explicit user mutes flow through toggleMute below and clear it.
+        userWantsAudio = true
+      }
       else releaseAudio(el)
     }
     el.addEventListener('volumechange', onVolumeChange)
@@ -147,8 +173,13 @@ const PostVideo: React.FC<{ url: string; onError?: () => void }> = ({ url, onErr
       // Claim the global audio slot so any other unmuted PostVideo
       // gets re-muted before this one starts producing sound.
       claimAudio(v)
+      // #336 — explicit user unmute → sticky for the session.
+      userWantsAudio = true
     } else {
       releaseAudio(v)
+      // #336 — explicit user mute via our toggle → clears the session
+      // preference. Coordinator-driven mutes don't reach this path.
+      userWantsAudio = false
     }
   }
   const seek = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/client/src/services/FrontEnd/src/components/ProfileEditForm.tsx
+++ b/client/src/services/FrontEnd/src/components/ProfileEditForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { HiCamera, HiLink, HiLocationMarker } from 'react-icons/hi'
 import Tooltip from '~/components/Tooltip'
 import { apiFetch } from '~/api/client'
@@ -63,6 +64,10 @@ const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
   const containerSpacing = compactFields ? '' : 'space-y-6'
   const signAndSubmit = useSignAndSubmitAction()
   const setAvatar = useTokenDataStore(s => s.setAvatar)
+  // For invalidating user-data caches after a profile save so the new
+  // avatar / fields show up on the profile page, feed items, mentions, etc.
+  // without waiting for the natural refetch. See #330.
+  const queryClient = useQueryClient()
 
   const providerDomain = typeof window !== 'undefined' ? window.location.hostname : ''
 
@@ -270,6 +275,11 @@ const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
       if (activeToken.tokenId) {
         setAvatar(activeToken.tokenId, getUserAvatar(res.user) || null)
       }
+      // #330 — invalidate the user-data caches so the new avatar / fields
+      // reflect immediately on the profile page, FeedItem, mentions, etc.
+      // (setAvatar above only refreshes the Zustand-backed sidebar/header).
+      if (activeToken.username) queryClient.invalidateQueries({ queryKey: ['user', activeToken.username] })
+      if (activeToken.tokenId) queryClient.invalidateQueries({ queryKey: ['userByToken', activeToken.tokenId] })
       setAvatarPreview(undefined)
       setCoverPreview(undefined)
       setAvatarUrl(undefined)
@@ -321,6 +331,10 @@ const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
       if (avatarUrl && activeToken.tokenId) {
         setAvatar(activeToken.tokenId, avatarUrl)
       }
+      // #330 — same invalidation as the off-chain path; the on-chain save
+      // also mutates the same user-data caches so subscribers refetch.
+      if (activeToken.username) queryClient.invalidateQueries({ queryKey: ['user', activeToken.username] })
+      if (activeToken.tokenId) queryClient.invalidateQueries({ queryKey: ['userByToken', activeToken.tokenId] })
 
       const offChainChanges: Record<string, string> = {}
       if (formData.displayName !== (profileData?.displayName || '')) offChainChanges.displayName = formData.displayName


### PR DESCRIPTION


#330 — Profile picture won't update
- The upload + PATCH /api/users/<tokenId>/profile flow was server-side correct, but the client only updated the Zustand-backed sidebar avatar (setAvatar). React Query caches (`['user', username]` and `['userByToken', tokenId]`) — which back the profile page, every FeedItem author avatar, mentions, etc. — were never invalidated, so every surface except the sidebar kept showing the stale avatar until the next natural refetch (minutes). Reporter on /users/kaito/caw/... was almost certainly kaito viewing their own caw page after editing their profile — sidebar showed the new pic, the page didn't. Fix in ProfileEditForm.tsx: after both save paths (off-chain handleSubmit and on-chain handleOnChainUpdate), call queryClient.invalidateQueries on both user-data keys so every subscriber refetches and renders the new avatar/fields immediately. Frontend-only, no server change needed.

#336 — Auto-play video sound between feed swipes
- Every PostVideo mounts with isMuted=true and re-mutes itself when it scrolls off-screen, so even after the user unmuted one video, the next one they scrolled to started silent — they had to tap unmute on every single video. Reporter wanted TikTok/X-style sticky audio. The existing module-level audioCoordinator already enforces "only one unmuted at a time" but had no memory of "the user wants audio in general". Added a sibling module-level flag, `userWantsAudio`: • Set true on any unmute (toggle button OR native controls — caught via the volumechange listener). • Cleared on explicit user mute through the toggle button. • Intentionally NOT cleared when the coordinator force-mutes a video (that's a video switch, not a user mute). • Read on viewport entry — if true and the entering video is muted, unmute it and claim the audio slot. Result: unmute once, all subsequent swiped-into videos play with sound; audioCoordinator still guarantees only one audible at a time; reload resets the preference.

Not addressed in this PR:
- #326 — Post submission hangs on "posting" screen: already fixed in the v11 PR (`feat/ux-ui-improvements-v11`). The submit catch was silently swallowing errors; v11 surfaces them via toast.error. Lands when v11 merges.
- #332 — IME breaks after 420-byte limit / thread auto-split: same root cause as #322 (fixed in v11). The v11 fix gates setText on e.nativeEvent.isComposing so the textarea-remount-on-threshold-cross no longer happens mid-composition, removing the worst case. The residual 5-6 chars of direct-input the reporter mentions is the IME re-attaching to the freshly mounted chunk textarea. Eliminating it fully would require refactoring chunk mode to a single-textarea + chunkBoundaries model (the prop already exists in HighlightedTextarea). Deferred until v11 lands and we can confirm whether the user-visible residual is acceptable.
- #331 — Desktop layout feels cramped: subjective design preference (one JA report against a 1050px shell that mirrors X's classic ~1265px feed width). A toggle-able "wide mode" in settings would be the right shape if more reports converge; a default change risks worsening UX for users who like the current X-like density.