### PR TITLE
test-foundry: prove session-key spendLimit + transfer bounds; add SESSION_KEY_GUARANTEES.md (C41)

### DIFF
--- a/docs/SESSION_KEY_GUARANTEES.md
+++ b/docs/SESSION_KEY_GUARANTEES.md
@@ -63,8 +63,8 @@ depends on whether the path accepts a caller-supplied bitmap — see §2.
 
 | Enforcement | Contract | Test | Assertion |
 |---|---|---|---|
-| **revert** (wallet-scoped) | `CawProfileLedger.sol:741` — `if ((scopeBitmap & 0x40) != 0) revert NoWithdraw();` | `test-foundry/SessionRegisterFuzz.t.sol` — `testFuzz_WithdrawDelegationBlocked` (L200) | **L213** `vm.expectRevert(abi.encodeWithSelector(CawProfileLedger.NoWithdraw.selector));` |
-| **mask** (token-scoped) | `CawProfileLedger.sol:824` — `uint8 bm = scopeBitmap & 0xBF;` | `test/token-scoped-sessions-test.js` — test 9 (L554) — *blocked by #195* | **L563** `expect(Number(sess.scopeBitmap)).to.equal(0xBF, ...)` |
+| **revert** (wallet-scoped) | `CawProfileLedger.sol:749` — `if ((scopeBitmap & 0x40) != 0) revert NoWithdraw();` | `test-foundry/SessionRegisterFuzz.t.sol` — `testFuzz_WithdrawDelegationBlocked` (L200) | **L213** `vm.expectRevert(abi.encodeWithSelector(CawProfileLedger.NoWithdraw.selector));` |
+| **mask** (token-scoped) | `CawProfileLedger.sol:832` — `uint8 bm = scopeBitmap & 0xBF;` | `test/token-scoped-sessions-test.js` — test 9 (L554) — *blocked by #195* | **L563** `expect(Number(sess.scopeBitmap)).to.equal(0xBF, ...)` |
 
 The fuzz test sets bit 6 **plus arbitrary other bits**
 (`uint8 scope = 0x40 | (extraBits & 0xBF)`, L206) across the full fuzz domain, so
@@ -98,7 +98,7 @@ remains 5000. This proves the accumulator and its storage round trip, not a
 per-call bound.
 
 > **Integrator note.** `spendLimit == 0` is **unlimited**, not zero-spend —
-> documented at `CawProfileLedger.sol:726` and gated at `CawActions.sol:1380`
+> documented at `CawProfileLedger.sol:734` and gated at `CawActions.sol:1380`
 > (`if (ba.spendLimit > 0)`). It reads like the opposite of what it does.
 
 ---
@@ -109,7 +109,7 @@ Checked on two sides:
 
 | Side | Contract | Test | Assertion |
 |---|---|---|---|
-| **Register-time** | `CawProfileLedger.sol` `Expired()` (also `:800`, `:894` on trusted-caller paths) | `test-foundry/SessionRegisterFuzz.t.sol` — `testFuzz_RejectsExpired` (L84) | **L96** `vm.expectRevert(abi.encodeWithSelector(CawProfileLedger.Expired.selector));` |
+| **Register-time** | `CawProfileLedger.sol` `Expired()` (also `:808`, `:902` on trusted-caller paths) | `test-foundry/SessionRegisterFuzz.t.sol` — `testFuzz_RejectsExpired` (L84) | **L96** `vm.expectRevert(abi.encodeWithSelector(CawProfileLedger.Expired.selector));` |
 | **Use-time** | `CawActions.sol:569` — `if (s.expiry <= block.timestamp) revert SessionExpired();` | `test-foundry/SessionProfileScoping.t.sol` (L438) | **L483** `vm.expectRevert(CawActions.SessionExpired.selector);` |
 
 Expiry is the gate at every signature-recovery entry point — a session only
@@ -133,7 +133,7 @@ session to full owner authority. Audit fix M-1, 2026-05-08.
 
 Sessions are keyed on the **owner address** and carry the epoch they were
 registered at (`StoredSession.epoch`, `CawProfileLedger.sol:127`). On owner
-change, `_setOwnerOf` (`:676`) bumps **both** epochs (`:691-692`):
+change, `_setOwnerOf` (`:684`) bumps **both** epochs (`:699-700`):
 
 - `ownerSessionEpoch[prev]++` — invalidates **every** wallet-scoped session of
   the previous wallet, including for tokens it still owns
@@ -141,7 +141,7 @@ change, `_setOwnerOf` (`:676`) bumps **both** epochs (`:691-692`):
   that profileId
 
 `validSession` (`:175-183`) then returns a zeroed struct on epoch mismatch. This
-is the **CL-4** invariant; the rationale (`:682-687`) is the intermediate-holder
+is the **CL-4** invariant; the rationale (`:690-695`) is the intermediate-holder
 drain from `project_l1l2_ownership_desync` — an unordered LayerZero redelivery
 could re-stamp `ownerOf` back to a previous holder and reanimate sessions they
 registered during brief ownership.
@@ -168,7 +168,7 @@ Three surfaces, three defences:
 |---|---|---|---|
 | **EIP-712 register-by-sig** — nonce | `CawProfileLedger` `BadNonce()` | `test-foundry/SessionRegisterFuzz.t.sol` — `testFuzz_NonceReplayBlocked` (L133) | **L152** `vm.expectRevert(abi.encodeWithSelector(CawProfileLedger.BadNonce.selector));` (1000 runs) |
 | **Revoke → held pre-signed register** | revoke bumps `sessionNonce` | `test-foundry/SessionRegisterFuzz.t.sol` — `test_SES1_revoke_invalidates_presigned_register` (L106) | **L125** `vm.expectRevert(abi.encodeWithSelector(CawProfileLedger.BadNonce.selector));` |
-| **personal_sign register** — no nonce in the message, so the **digest** is consumed | `CawProfileLedger.sol:794-795` — `if (consumedSessionMessage[digest]) revert Replayed(); consumedSessionMessage[digest] = true;` (audit fix 2026-05-08) | `test/session-personal-replay-test.js` (L75) — *blocked by #195* | **L105** `expect(reason).to.match(/replay|replayed|0xf6c62c02/);` + state assertion **L109** |
+| **personal_sign register** — no nonce in the message, so the **digest** is consumed | `CawProfileLedger.sol:802-803` — `if (consumedSessionMessage[digest]) revert Replayed(); consumedSessionMessage[digest] = true;` (audit fix 2026-05-08) | `test/session-personal-replay-test.js` (L75) — *blocked by #195* | **L105** `expect(reason).to.match(/replay|replayed|0xf6c62c02/);` + state assertion **L109** |
 
 `0xf6c62c02` = `bytes4(keccak256("Replayed()"))`.
 
@@ -182,12 +182,12 @@ Two accept a caller-supplied `scopeBitmap`; four do not offer one and hard-code
 
 | Path | file:line | Accepts `scopeBitmap`? | Withdraw handling |
 |---|---|---|---|
-| `registerSession` (EIP-712) | `CawProfileLedger.sol:725` | **yes** | `:741` revert `NoWithdraw()` |
-| `registerTokenScopedSession` | `CawProfileLedger.sol:807` | **yes** | `:824` mask `& 0xBF` |
-| `lzDepositMintSession` | `CawProfileLedger.sol:424` | no | `:457` hard-coded `0xBF` |
-| `registerSessionFromL1` | `CawProfileLedger.sol:619` | no | `:626` hard-coded `0xBF` |
-| `registerSessionPersonal` | `CawProfileLedger.sol:777` | no — the parser returns `spendLimit, perActionTipRate, expiry, sessionKey` only (`:797`) | `:803` hard-coded `0xBF` |
-| `registerSessionFromActions` | `CawProfileLedger.sol:882` | no | `:895` hard-coded `0xBF` |
+| `registerSession` (EIP-712) | `CawProfileLedger.sol:733` | **yes** | `:749` revert `NoWithdraw()` |
+| `registerTokenScopedSession` | `CawProfileLedger.sol:815` | **yes** | `:832` mask `& 0xBF` |
+| `lzDepositMintSession` | `CawProfileLedger.sol:432` | no | `:465` hard-coded `0xBF` |
+| `registerSessionFromL1` | `CawProfileLedger.sol:627` | no | `:634` hard-coded `0xBF` |
+| `registerSessionPersonal` | `CawProfileLedger.sol:785` | no — the parser returns `spendLimit, perActionTipRate, expiry, sessionKey` only (`:805`) | `:811` hard-coded `0xBF` |
+| `registerSessionFromActions` | `CawProfileLedger.sol:890` | no | `:903` hard-coded `0xBF` |
 
 **No path drops a caller-supplied bitmap on the floor.** The four hard-coded
 paths do not expose a scope parameter, so `0xBF` is the documented contract, not
@@ -251,5 +251,5 @@ while its counterpart at `:1578` reverts with `SessionExpired()`. Tightening
 
 ---
 
-*Verified against `5ac4f02` plus the tests introduced alongside this document.
+*Verified against `d62fa219` plus the tests introduced alongside this document.
 Re-pin line numbers when the referenced files change.*

--- a/docs/SESSION_KEY_GUARANTEES.md
+++ b/docs/SESSION_KEY_GUARANTEES.md
@@ -1,0 +1,255 @@
+# Session-Key Guarantees
+
+Closes **C41** / `PROOF_OF_COMPLIANCE_BACKLOG.md` item 8.
+
+A session key is a delegated signer registered against a profile owner. This
+document is the citable evidence bundle for the five bounds a session key
+**cannot** cross:
+
+1. delegate `withdraw`
+2. spend over `spendLimit`
+3. survive expiry
+4. survive transfer
+5. replay
+
+Each bound below cites a **specific test file and assertion line**, plus the
+**contract line that enforces it**. Line numbers are pinned to the commit noted
+at the bottom; re-pin them when the referenced files change.
+
+---
+
+## Running these
+
+```bash
+cd solidity
+npm install --legacy-peer-deps
+forge install foundry-rs/forge-std      # not vendored — see "Prerequisites"
+forge test --match-path 'test-foundry/Session*.t.sol'
+```
+
+Expected: **25 passed, 0 failed.**
+
+### Prerequisites
+
+- `forge-std` is not vendored and there is no `.gitmodules`, so `forge test`
+  fails at parse on a fresh clone until `forge install foundry-rs/forge-std` is
+  run.
+- `npm install` requires `--legacy-peer-deps` (LayerZero peer conflict).
+
+### Truffle counterparts
+
+`test/*.js` is a **Truffle** suite (not Hardhat). Several files contain
+session-bound assertions covering the same ground — `token-scoped-sessions-test.js`,
+`session-tip-batched-test.js`, `session-personal-replay-test.js`. They are
+currently **not runnable**: `CawProfileLedger.new()` fails with `contains
+unresolved libraries: SessionMessageParser` even when the linker helper runs
+first. See `test/helpers/link-libraries.js` (task **#195**).
+
+Foundry links `SessionMessageParser` from artifact metadata and is unaffected.
+**Every bound below is therefore cited against `test-foundry/`** — that is the
+runner these guarantees are provable on today. The Truffle tests remain valuable
+(they exercise the real L1→LayerZero→L2 transfer path, which the Foundry tests
+deliberately shortcut) and should be re-cited here once #195 is resolved.
+
+---
+
+## 1. The five bounds
+
+### ① A session key cannot delegate `withdraw`
+
+`withdraw` is `ActionType.WITHDRAW` = 6 (`CawActions.sol:83`), i.e. bit 6
+(`0x40`) of `scopeBitmap`. **No registration path can set it.** Enforcement
+depends on whether the path accepts a caller-supplied bitmap — see §2.
+
+| Enforcement | Contract | Test | Assertion |
+|---|---|---|---|
+| **revert** (wallet-scoped) | `CawProfileLedger.sol:741` — `if ((scopeBitmap & 0x40) != 0) revert NoWithdraw();` | `test-foundry/SessionRegisterFuzz.t.sol` — `testFuzz_WithdrawDelegationBlocked` (L200) | **L213** `vm.expectRevert(abi.encodeWithSelector(CawProfileLedger.NoWithdraw.selector));` |
+| **mask** (token-scoped) | `CawProfileLedger.sol:824` — `uint8 bm = scopeBitmap & 0xBF;` | `test/token-scoped-sessions-test.js` — test 9 (L554) — *blocked by #195* | **L563** `expect(Number(sess.scopeBitmap)).to.equal(0xBF, ...)` |
+
+The fuzz test sets bit 6 **plus arbitrary other bits**
+(`uint8 scope = 0x40 | (extraBits & 0xBF)`, L206) across the full fuzz domain, so
+the guarantee is not tied to one bitmap value. 1000 runs.
+
+> **Integrator note.** The two paths differ. Registering `0xFF` on a
+> **wallet-scoped** session **reverts** `NoWithdraw()`; registering `0xFF` on a
+> **token-scoped** session **succeeds silently** and stores `0xBF`. Both are safe
+> — withdraw is never delegated — but the API surface is not symmetric.
+
+---
+
+### ② A session key cannot spend over `spendLimit`
+
+Enforcement: `CawActions.sol:1386` — `if (ba.groupSpent > ba.spendLimit) revert SessionLimitExceeded();`
+(single throw site). Spend is accumulated in `BatchAuth.groupSpent` across a
+signature group and flushed to `sessionSpent[owner][signer]` at group end
+(`:584`, `:766`, `:922`, `:1199`), then re-loaded on the next call (`:1382`).
+
+| Property | Test | Assertion |
+|---|---|---|
+| Exceeding the limit reverts with the named custom error | `test-foundry/SessionProfileScoping.t.sol` — `test_sessionSpendLimit_cumulative` | `vm.expectRevert(CawActions.SessionLimitExceeded.selector)` |
+| Accounting is exact, and the limit is **cumulative** across transactions | same test | `assertEq(actions.sessionSpent(owner, sessionKey), 5000)` before and after the reverted attempt |
+| `spendLimit == 0` means **unlimited** | `test-foundry/SessionProfileScoping.t.sol` — `test_sessionSpendLimit_zeroMeansUnlimited` | 15000 spent successfully; `assertEq(sessionSpent, 0)` |
+
+`test_sessionSpendLimit_cumulative` sets `spendLimit = 7000` against a CAW action
+costing 5000 whole CAW (`CawActions.sol:1313`, cap oracle dormant), then submits
+**two separate `processActions` calls**. The first succeeds and records exactly
+5000; the second crosses the bound (10000 > 7000) and reverts; `sessionSpent`
+remains 5000. This proves the accumulator and its storage round trip, not a
+per-call bound.
+
+> **Integrator note.** `spendLimit == 0` is **unlimited**, not zero-spend —
+> documented at `CawProfileLedger.sol:726` and gated at `CawActions.sol:1380`
+> (`if (ba.spendLimit > 0)`). It reads like the opposite of what it does.
+
+---
+
+### ③ A session key cannot survive expiry
+
+Checked on two sides:
+
+| Side | Contract | Test | Assertion |
+|---|---|---|---|
+| **Register-time** | `CawProfileLedger.sol` `Expired()` (also `:800`, `:894` on trusted-caller paths) | `test-foundry/SessionRegisterFuzz.t.sol` — `testFuzz_RejectsExpired` (L84) | **L96** `vm.expectRevert(abi.encodeWithSelector(CawProfileLedger.Expired.selector));` |
+| **Use-time** | `CawActions.sol:569` — `if (s.expiry <= block.timestamp) revert SessionExpired();` | `test-foundry/SessionProfileScoping.t.sol` (L438) | **L483** `vm.expectRevert(CawActions.SessionExpired.selector);` |
+
+Expiry is the gate at every signature-recovery entry point — a session only
+authorizes an action if it is live at recovery time:
+
+| Entry point | Gate |
+|---|---|
+| `CawActions._verifySignatureMem:1555` | **:1568** `if (sess.expiry > block.timestamp)` — only a live session returns `isSessionKey = true` |
+| `CawActions._verifyBatchSignature:1610` | **:1630-1631** same shape |
+| `CawActions._zkProcessOneGroup:519` | **:569** — the ZK path skips ECDSA recovery, so it re-derives the gate |
+
+`:1578` / `:1636` additionally distinguish *"expired session record exists"*
+(revert) from *"no record"* (fall through to ERC-1271). Without that, a
+contract-owned profile whose signer is both Safe-validated **and** holds an
+expired session record would have the 1271 fallback silently elevate the expired
+session to full owner authority. Audit fix M-1, 2026-05-08.
+
+---
+
+### ④ A session key cannot survive transfer
+
+Sessions are keyed on the **owner address** and carry the epoch they were
+registered at (`StoredSession.epoch`, `CawProfileLedger.sol:127`). On owner
+change, `_setOwnerOf` (`:676`) bumps **both** epochs (`:691-692`):
+
+- `ownerSessionEpoch[prev]++` — invalidates **every** wallet-scoped session of
+  the previous wallet, including for tokens it still owns
+- `tokenSessionEpoch[tokenId]++` — invalidates token-scoped sessions bound to
+  that profileId
+
+`validSession` (`:175-183`) then returns a zeroed struct on epoch mismatch. This
+is the **CL-4** invariant; the rationale (`:682-687`) is the intermediate-holder
+drain from `project_l1l2_ownership_desync` — an unordered LayerZero redelivery
+could re-stamp `ownerOf` back to a previous holder and reanimate sessions they
+registered during brief ownership.
+
+| Property | Test | Assertion |
+|---|---|---|
+| Transfer invalidates the token's token-scoped session | `test-foundry/SessionProfileScoping.t.sol` — `test_transfer_invalidatesTokenScopedSession` | `assertEq(ledger.validSession(owner, sessionKey2).expiry, 0)`; positive control asserts live **and** bound to TOKEN_A first |
+| **CL-4**: transfer invalidates the transferring wallet's wallet-scoped sessions, including for tokens still owned | `test-foundry/SessionProfileScoping.t.sol` — `test_transfer_invalidatesWalletScopedSession_CL4` | `assertEq(ledger.validSession(owner, sessionKey).expiry, 0)`, then end-to-end `vm.expectRevert(CawActions.SessionExpired.selector)` on an action for a **still-owned** token |
+
+The CL-4 test submits a **successful** action for TOKEN_B before transferring
+TOKEN_A, so the "dead after" assertion is anchored against a demonstrated "live
+before".
+
+> A strictly newer stamp is required to trigger the bump — `_setOwnerOf:677`
+> silently skips stale or same-stamp deliveries (`if (stamp <= lastOwnerUpdateBlock[tokenId]) return;`).
+
+---
+
+### ⑤ A session key cannot replay
+
+Three surfaces, three defences:
+
+| Surface | Contract | Test | Assertion |
+|---|---|---|---|
+| **EIP-712 register-by-sig** — nonce | `CawProfileLedger` `BadNonce()` | `test-foundry/SessionRegisterFuzz.t.sol` — `testFuzz_NonceReplayBlocked` (L133) | **L152** `vm.expectRevert(abi.encodeWithSelector(CawProfileLedger.BadNonce.selector));` (1000 runs) |
+| **Revoke → held pre-signed register** | revoke bumps `sessionNonce` | `test-foundry/SessionRegisterFuzz.t.sol` — `test_SES1_revoke_invalidates_presigned_register` (L106) | **L125** `vm.expectRevert(abi.encodeWithSelector(CawProfileLedger.BadNonce.selector));` |
+| **personal_sign register** — no nonce in the message, so the **digest** is consumed | `CawProfileLedger.sol:794-795` — `if (consumedSessionMessage[digest]) revert Replayed(); consumedSessionMessage[digest] = true;` (audit fix 2026-05-08) | `test/session-personal-replay-test.js` (L75) — *blocked by #195* | **L105** `expect(reason).to.match(/replay|replayed|0xf6c62c02/);` + state assertion **L109** |
+
+`0xf6c62c02` = `bytes4(keccak256("Replayed()"))`.
+
+---
+
+## 2. Adjacent: scope is not escalatable
+
+Not required by item 8, but it is why ① holds across **six** registration paths.
+Two accept a caller-supplied `scopeBitmap`; four do not offer one and hard-code
+`0xBF` (all bits except withdraw).
+
+| Path | file:line | Accepts `scopeBitmap`? | Withdraw handling |
+|---|---|---|---|
+| `registerSession` (EIP-712) | `CawProfileLedger.sol:725` | **yes** | `:741` revert `NoWithdraw()` |
+| `registerTokenScopedSession` | `CawProfileLedger.sol:807` | **yes** | `:824` mask `& 0xBF` |
+| `lzDepositMintSession` | `CawProfileLedger.sol:424` | no | `:457` hard-coded `0xBF` |
+| `registerSessionFromL1` | `CawProfileLedger.sol:619` | no | `:626` hard-coded `0xBF` |
+| `registerSessionPersonal` | `CawProfileLedger.sol:777` | no — the parser returns `spendLimit, perActionTipRate, expiry, sessionKey` only (`:797`) | `:803` hard-coded `0xBF` |
+| `registerSessionFromActions` | `CawProfileLedger.sol:882` | no | `:895` hard-coded `0xBF` |
+
+**No path drops a caller-supplied bitmap on the floor.** The four hard-coded
+paths do not expose a scope parameter, so `0xBF` is the documented contract, not
+a silently ignored argument.
+
+Per-action scope enforcement: `CawActions.sol:642` and `:912` —
+`if ((ba.scopeBitmap & (1 << uint8(action.actionType))) == 0) revert OutOfScope();`
+
+Profile scoping (a token-scoped key cannot sign for another profile):
+`CawActions.sol:570` — `if (s.profileId != 0 && s.profileId != senderId0) revert WrongProfileForSession();`
+Tested at `test-foundry/SessionProfileScoping.t.sol:412`
+`vm.expectRevert(CawActions.WrongProfileForSession.selector);`
+
+Cross-owner impersonation is covered at `test-foundry/SessionProfileScoping.t.sol:438`,
+with a positive control (L461-468). Note the attack reverts at the **expiry**
+guard (`:569`), not the profile guard: an unregistered foreign key resolves to an
+empty `StoredSession` with `expiry == 0`, and `:569` fires before `:570`. The
+guarantee holds; the asserted selector is coupled to guard ordering inside
+`CawActions`. The test documents this in-line.
+
+---
+
+## 3. Known assertion weaknesses
+
+Four session-scope assertions in the Truffle suite are catch-alls of the form
+`A || B || revertReason.includes('revert')`. The trailing term matches any
+revert message, so they would pass on the wrong revert as readily as the right
+one. Each one's first term is also dead — `'Out of scope'` and `'Session limit'`
+do not appear anywhere in `contracts/` (they predate custom errors).
+
+| file:line | Correct error | Dead condition |
+|---|---|---|
+| `test/batched-actions-test.js:608` | `OutOfScope()` | `includes('Out of scope')` |
+| `test/batched-actions-test.js:674` | `SessionLimitExceeded()` | `includes('Session limit')` |
+| `test/session-tip-batched-test.js:740` | `SessionLimitExceeded()` | `includes('session limit')` |
+| `test/zk-actions-test.js:710` | `SessionExpired()` | `includes('session invalid')` |
+
+**These do not weaken the guarantees** — every bound in §1 is independently
+covered by a strict, selector-or-exact-value assertion on `test-foundry/`. They
+are recorded here so the bundle's citations are not overstated. All four are in
+files blocked by #195 and cannot currently run at all.
+
+Note that `CawActions.sol:1635` reverts with the legacy string `"Session expired"`
+while its counterpart at `:1578` reverts with `SessionExpired()`. Tightening
+`zk-actions-test.js:710` requires reconciling that first.
+
+---
+
+## 4. Coverage summary
+
+| Bound | Executable assertions | Runner |
+|---|---|---|
+| ① withdraw non-delegable | 1 | foundry (1000 fuzz runs) |
+| ② spendLimit | 2 | foundry |
+| ③ expiry | 2 | foundry (1000 fuzz runs) |
+| ④ transfer | 2 | foundry |
+| ⑤ replay | 2 | foundry (1000 fuzz runs) |
+
+**5/5 bounds hold, each on at least one executing strict assertion.**
+`forge test --match-path 'test-foundry/Session*.t.sol'` → 25 passed, 0 failed.
+
+---
+
+*Verified against `5ac4f02` plus the tests introduced alongside this document.
+Re-pin line numbers when the referenced files change.*

--- a/solidity/test-foundry/SessionProfileScoping.t.sol
+++ b/solidity/test-foundry/SessionProfileScoping.t.sol
@@ -484,4 +484,254 @@ contract SessionProfileScopingTest is Test {
             actions.processActions(VALIDATOR_ID, packed, sigs, 0, 0);
         }
     }
+
+    // =======================================================================
+    // Item 8 / C41 — bound ② : a session key cannot spend over `spendLimit`
+    //
+    // Ported here from test/token-scoped-sessions-test.js:578 and
+    // test/session-tip-batched-test.js:495. Both are correct tests, but the
+    // Truffle runner cannot deploy CawProfileLedger at all (task #195, see
+    // test/helpers/link-libraries.js), so ② had no executable assertion.
+    // Foundry links SessionMessageParser from artifact metadata and is
+    // structurally immune to #195.
+    // =======================================================================
+
+    uint8 constant ACTION_CAW = 0; // ActionType.CAW — see CawActions.sol:83
+
+    /// @dev Pack a single CAW action. Same layout as _packUnfollow, actionType 0.
+    function _packCaw(
+        uint32 senderId,
+        uint32 receiverId,
+        uint32 networkId,
+        uint32 cawonce
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(
+            uint16(1),      // actionCount
+            ACTION_CAW,     // actionType (uint8)
+            senderId,       // uint32
+            receiverId,     // uint32
+            uint32(0),      // receiverCawonce
+            networkId,      // uint32
+            cawonce,        // uint32
+            uint8(0),       // recipientCount
+            uint8(0),       // amountCount
+            uint16(0)       // textLength
+        );
+    }
+
+    /// @dev EIP-712 digest for a CAW action.
+    function _cawDigest(
+        uint32 senderId,
+        uint32 receiverId,
+        uint32 networkId,
+        uint32 cawonce
+    ) internal view returns (bytes32) {
+        bytes32 ACTIONDATA_TYPEHASH = keccak256(
+            "ActionData(uint8 actionType,uint32 senderId,uint32 receiverId,uint32 receiverCawonce,uint32 networkId,uint32 cawonce,uint32[] recipients,uint64[] amounts,bytes text)"
+        );
+        bytes32 recipHash = keccak256(abi.encodePacked(new uint32[](0)));
+        bytes32 amtHash   = keccak256(abi.encodePacked(new uint64[](0)));
+        bytes32 textHash  = keccak256(new bytes(0));
+
+        bytes32 structHash = keccak256(abi.encode(
+            ACTIONDATA_TYPEHASH,
+            uint256(ACTION_CAW),
+            uint256(senderId),
+            uint256(receiverId),
+            uint256(0),
+            uint256(networkId),
+            uint256(cawonce),
+            recipHash,
+            amtHash,
+            textHash
+        ));
+        return keccak256(abi.encodePacked("\x19\x01", actions.eip712DomainHash(), structHash));
+    }
+
+    /// @dev Build the packed calldata + sig for one CAW action WITHOUT making
+    ///      the submitting call. Kept separate from _doCaw because _cawDigest
+    ///      makes an external call (actions.eip712DomainHash()) and vm.expectRevert
+    ///      binds to the NEXT external call — so anything built after expectRevert
+    ///      would swallow it.
+    function _prepCaw(uint256 pk, uint32 cawonce)
+        internal
+        view
+        returns (bytes memory packed, bytes memory sigs)
+    {
+        bytes32 digest = _cawDigest(TOKEN_A, TOKEN_B, NETWORK_ID, cawonce);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        packed = _packCaw(TOKEN_A, TOKEN_B, NETWORK_ID, cawonce);
+        sigs   = _packSingleSig(v, r, s);
+    }
+
+    /// @dev Submit one CAW action from TOKEN_A signed by `pk`.
+    function _doCaw(uint256 pk, uint32 cawonce) internal {
+        (bytes memory packed, bytes memory sigs) = _prepCaw(pk, cawonce);
+        actions.processActions(VALIDATOR_ID, packed, sigs, 0, 0);
+    }
+
+    /// @notice ② A session key cannot spend over `spendLimit`.
+    ///
+    ///   CAW costs 5000 whole CAW (CawActions.sol:1313; cap oracle is dormant
+    ///   in this harness so the baseline applies unchanged). spendLimit = 7000
+    ///   means the FIRST caw succeeds (5000) and the SECOND crosses the bound
+    ///   (10000 > 7000).
+    ///
+    ///   This proves the ACCUMULATOR, not a per-call bound: `sessionSpent` is
+    ///   flushed to storage at group end (CawActions.sol:584) and re-loaded on
+    ///   the next call (:1382), so the two actions are separate transactions.
+    ///
+    ///   Enforcement: CawActions.sol:1386
+    ///     `if (ba.groupSpent > ba.spendLimit) revert SessionLimitExceeded();`
+    function test_sessionSpendLimit_cumulative() public {
+        // Fund TOKEN_A. owner == address(0) so deposit() skips _setOwnerOf and
+        // leaves ownership/epochs untouched (CawProfileLedger.sol:650).
+        ledger.deposit(NETWORK_ID, TOKEN_A, 1_000_000 ether, address(0));
+
+        uint64 expiry = uint64(block.timestamp + 7 days);
+        // scope 0xBF has bit 0 (CAW) set; spendLimit 7000 whole CAW; tipRate 0.
+        _registerWalletSession(sessionKey, OWNER_PK, expiry, 0xBF, 7000, 0);
+
+        // ---- Positive control: first CAW is under the limit ----
+        _doCaw(SESSION_PK, 1);
+        assertEq(
+            actions.sessionSpent(owner, sessionKey),
+            5000,
+            "first CAW must record exactly 5000 spent"
+        );
+
+        // ---- The bound: second CAW takes cumulative spend to 10000 > 7000 ----
+        // Build everything first — _prepCaw makes an external call, and
+        // vm.expectRevert binds to the next external call.
+        (bytes memory packed, bytes memory sigs) = _prepCaw(SESSION_PK, 2);
+        vm.expectRevert(CawActions.SessionLimitExceeded.selector);
+        actions.processActions(VALIDATOR_ID, packed, sigs, 0, 0);
+
+        // ---- The revert must not have accrued spend ----
+        assertEq(
+            actions.sessionSpent(owner, sessionKey),
+            5000,
+            "reverted action must not accrue spend"
+        );
+    }
+
+    /// @notice ② control: `spendLimit == 0` means UNLIMITED, not zero-spend.
+    ///   Documented at CawProfileLedger.sol:726 ("0 = unlimited") and gated at
+    ///   CawActions.sol:1380 `if (ba.spendLimit > 0)`. Pinning it so the
+    ///   documented semantics can't drift silently.
+    function test_sessionSpendLimit_zeroMeansUnlimited() public {
+        ledger.deposit(NETWORK_ID, TOKEN_A, 1_000_000 ether, address(0));
+
+        uint64 expiry = uint64(block.timestamp + 7 days);
+        _registerWalletSession(sessionKey, OWNER_PK, expiry, 0xBF, 0, 0);
+
+        // Three CAWs = 15000 spent. Would breach any finite limit; must pass.
+        _doCaw(SESSION_PK, 1);
+        _doCaw(SESSION_PK, 2);
+        _doCaw(SESSION_PK, 3);
+
+        // spendLimit==0 short-circuits before the accumulator is even loaded,
+        // so sessionSpent is never written.
+        assertEq(
+            actions.sessionSpent(owner, sessionKey),
+            0,
+            "spendLimit==0 must skip the accumulator entirely"
+        );
+    }
+
+    // =======================================================================
+    // Item 8 / C41 — bound ④ : a session key cannot survive transfer
+    //
+    // Ported from test/token-scoped-sessions-test.js:426 (token-scoped) and
+    // :447 (CL-4, wallet-scoped). Same #195 story as ② above.
+    //
+    // The Truffle originals drive the transfer from L1 via `transferAndSync`
+    // with an LZ mock mirroring to L2. That round trip isn't needed to prove
+    // the bound: the invalidation is the epoch bump in _setOwnerOf
+    // (CawProfileLedger.sol:691-692), reachable here through the external
+    // `setOwnerOf` (:664) because this test contract IS the L1 CawProfile and
+    // therefore passes `onlyOnMainnet`.
+    // =======================================================================
+
+    address constant NEW_OWNER = address(0xD00D);
+
+    /// @notice ④a Transferring a token invalidates the token-scoped session
+    ///   bound to that token, via `tokenSessionEpoch[tokenId]++`
+    ///   (CawProfileLedger.sol:692).
+    function test_transfer_invalidatesTokenScopedSession() public {
+        uint64 expiry = uint64(block.timestamp + 7 days);
+        _registerTokenSession(TOKEN_A, sessionKey2, OWNER_PK, expiry, 0xBF, 0, 0);
+
+        // ---- Positive control: the session is live and bound to TOKEN_A ----
+        assertGt(
+            ledger.validSession(owner, sessionKey2).expiry,
+            0,
+            "precondition: token-scoped session must be live before transfer"
+        );
+        assertEq(
+            ledger.validSession(owner, sessionKey2).profileId,
+            TOKEN_A,
+            "precondition: session must be bound to TOKEN_A"
+        );
+
+        // ---- Transfer. A strictly newer stamp is required or _setOwnerOf
+        //      silently skips (CawProfileLedger.sol:677). ----
+        ledger.setOwnerOf(TOKEN_A, NEW_OWNER, uint64(block.number + 1));
+
+        // ---- The bound ----
+        assertEq(
+            ledger.validSession(owner, sessionKey2).expiry,
+            0,
+            "token-scoped session must be invalidated after transfer"
+        );
+    }
+
+    /// @notice ④b CL-4: transferring ANY token invalidates EVERY wallet-scoped
+    ///   session of the transferring wallet, via `ownerSessionEpoch[prev]++`
+    ///   (CawProfileLedger.sol:691) — including for tokens the wallet still
+    ///   owns. Guards the intermediate-holder drain described at :682-687:
+    ///   an unordered LZ redelivery could re-stamp ownerOf back to prev and
+    ///   reanimate sessions registered during their brief ownership.
+    function test_transfer_invalidatesWalletScopedSession_CL4() public {
+        uint64 expiry = uint64(block.timestamp + 7 days);
+        _registerWalletSession(sessionKey, OWNER_PK, expiry, 0xBF, 0, 0);
+
+        // ---- Positive control: live, and demonstrably usable for TOKEN_B ----
+        assertGt(
+            ledger.validSession(owner, sessionKey).expiry,
+            0,
+            "precondition: wallet-scoped session must be live before transfer"
+        );
+        {
+            uint32 cawonce = 1;
+            (uint8 v, bytes32 r, bytes32 s) = _signAction(SESSION_PK, TOKEN_B, TOKEN_A, NETWORK_ID, cawonce);
+            actions.processActions(
+                VALIDATOR_ID,
+                _packUnfollow(TOKEN_B, TOKEN_A, NETWORK_ID, cawonce),
+                _packSingleSig(v, r, s),
+                0,
+                0
+            );
+        }
+
+        // ---- Transfer TOKEN_A away. owner STILL OWNS TOKEN_B. ----
+        ledger.setOwnerOf(TOKEN_A, NEW_OWNER, uint64(block.number + 1));
+
+        // ---- The bound: the wallet-scoped session is dead for TOKEN_B too ----
+        assertEq(
+            ledger.validSession(owner, sessionKey).expiry,
+            0,
+            "CL-4: every wallet-scoped session of the transferring wallet must be invalidated"
+        );
+
+        // ---- End-to-end: the dead key can no longer sign for TOKEN_B ----
+        // Build first — vm.expectRevert binds to the next external call and
+        // _signAction calls actions.eip712DomainHash().
+        uint32 cawonce2 = 2;
+        (uint8 v2, bytes32 r2, bytes32 s2) = _signAction(SESSION_PK, TOKEN_B, TOKEN_A, NETWORK_ID, cawonce2);
+        bytes memory packed2 = _packUnfollow(TOKEN_B, TOKEN_A, NETWORK_ID, cawonce2);
+        bytes memory sigs2   = _packSingleSig(v2, r2, s2);
+        vm.expectRevert(CawActions.SessionExpired.selector);
+        actions.processActions(VALIDATOR_ID, packed2, sigs2, 0, 0);
+    }
 }


### PR DESCRIPTION
# test-foundry: prove session-key spendLimit + transfer bounds; add SESSION_KEY_GUARANTEES.md

Closes **C41** / `PROOF_OF_COMPLIANCE_BACKLOG.md` item 8.

## Why

Item 8 asks for the five session-key bounds — no `withdraw` delegation, no
spending over `spendLimit`, no surviving expiry, no surviving transfer, no replay
— collected into a single citable bundle of test files + assertion lines.

Collecting them wasn't sufficient. **② `spendLimit` and ④ transfer had strict
assertions only in the Truffle suite, and that suite can't deploy
`CawProfileLedger`** — task **#195**, documented in `test/helpers/link-libraries.js`.
Reproduced on a clean clone:

```
truffle test test/session-personal-replay-test.js --network development

Error: CawProfileLedger contains unresolved libraries ... SessionMessageParser
      at Context.<anonymous> (test/session-personal-replay-test.js:44:50)
```

That file calls `linkSessionMessageParser()` at **L43**, one line above the
failing `.new()` at **L44**. The linker runs; the deploy fails anyway — exactly
as `link-libraries.js:6-12` predicts.

So ② and ④ had **zero executable assertions**, and a citable bundle can't cite a
test that doesn't run. This PR ports them to `test-foundry/`, which links
`SessionMessageParser` from artifact metadata and is structurally immune to #195.

**This does not fix #195.** It removes it from C41's critical path.

## What's in it

**`test-foundry/SessionProfileScoping.t.sol`** (+250, no other files touched):

| Test | Bound |
|---|---|
| `test_sessionSpendLimit_cumulative` | ② — `spendLimit = 7000`, CAW costs 5000. Two separate `processActions` calls: first records exactly 5000, second reverts `SessionLimitExceeded()`, `sessionSpent` stays 5000. Proves the accumulator + its flush/re-load round trip (`:584` → `:1382`), not a per-call bound. |
| `test_sessionSpendLimit_zeroMeansUnlimited` | ② control — pins `spendLimit == 0` = unlimited (`CawProfileLedger.sol:726`, gated at `CawActions.sol:1380`). 15000 spent, `sessionSpent` stays 0. |
| `test_transfer_invalidatesTokenScopedSession` | ④a — `tokenSessionEpoch[tokenId]++`. Positive control asserts the session is live **and** bound to TOKEN_A before transfer. |
| `test_transfer_invalidatesWalletScopedSession_CL4` | ④b — `ownerSessionEpoch[prev]++`. Submits a **successful** action for TOKEN_B before transferring TOKEN_A, then asserts the same key is dead for TOKEN_B (still owned) both by storage read and end-to-end `SessionExpired()`. |

**`docs/SESSION_KEY_GUARANTEES.md`** — the bundle item 8 specifies: every bound
with test file, assertion line, and enforcing contract line, plus an honest
inventory of the four catch-all assertions in the Truffle suite.

No new harness. `SessionProfileScopingTest.setUp` already deploys
`MockLayerZeroEndpoint` + ledger + actions and passes `_cawProfile = address(this)`,
so the test contract is the L1 CawProfile and `onlyOnMainnet` helpers are
directly callable. Funding uses `ledger.deposit(..., address(0))`, which skips
`_setOwnerOf` (`:650`) and leaves ownership/epochs untouched.

④ drives the transfer through `setOwnerOf` (`:664`) rather than the L1
`transferAndSync` + LZ mock round trip. The bound *is* the epoch bump in
`_setOwnerOf` (`:691-692`); the round trip isn't needed to prove it. **The Truffle
originals should stay** — they cover the real L1→LZ→L2 path this deliberately
shortcuts, and should be re-cited in the doc once #195 is resolved.

## Result

```
forge test --match-path 'test-foundry/Session*.t.sol'

SessionMessageParser.t.sol    12 passed
SessionProfileScoping.t.sol    7 passed   (was 3)
SessionRegisterFuzz.t.sol      6 passed
                              25 passed, 0 failed, 0 skipped
```

5/5 bounds now provable on foundry.

## Not in this PR

Found while assembling the bundle, left out deliberately — they need sequencing
decisions rather than review:

- **`CawActions.sol:1635`** is the only legacy `revert("…")` in a contract with 68
  custom-error reverts. Its M-1 twin at `:1578` uses `SessionExpired()`. One-line
  change, independent of everything here.
- **The four catch-all assertions** (`batched-actions-test.js:608/674`,
  `session-tip-batched-test.js:740`, `zk-actions-test.js:710`) are
  `A || B || includes('revert')` and pass on any revert. Tightening them requires
  the line above first, and they can't run until #195 anyway.
- **`validSession`'s docstring** (`CawProfileLedger.sol:171-172`) claims it zeroes
  expired sessions; the body only compares epochs. Harmless today — every caller
  gates independently (`:1568`, `:1630`, `:569`) — but the fix isn't a one-liner,
  since zeroing on expiry would erase the M-1 distinction at `:1578`/`:1636`.

Details in the accompanying write-up.

## Verification note

`.github/` doesn't exist, so there's no CI to confirm this. My run used solc
0.8.30 sourced from the `ethereum/solidity` GitHub release
(`0.8.30+commit.73712a01.Linux.g++`) via `forge --use`, because
`binaries.soliditylang.org` was unreachable from my machine. Same commit hash as
the normal fetch, and everything compiled clean — but **please confirm 25/25 on
your toolchain before anyone cites this bundle.**

Also worth noting: `forge test` doesn't work on a fresh clone. There's no
`.gitmodules` and no `solidity/lib/`, so it fails at parse with
`Source "lib/forge-std/src/Test.sol" not found` until you run
`forge install foundry-rs/forge-std`. The doc records this as a prerequisite, but
vendoring forge-std or adding a `.gitmodules` would be better — right now the only
runner these guarantees are provable on only works for someone who already knows
that, which is awkward for something meant to be citable by outside reviewers.
