### PR TITLE
docs(session-guarantees): ship solidity/.npmrc; document ERESOLVE + v…

### DIFF
--- a/docs/SESSION_KEY_GUARANTEES.md
+++ b/docs/SESSION_KEY_GUARANTEES.md
@@ -34,7 +34,17 @@ Expected: **25 passed, 0 failed.**
 - `forge-std` is not vendored and there is no `.gitmodules`, so `forge test`
   fails at parse on a fresh clone until `forge install foundry-rs/forge-std` is
   run.
-- `npm install` requires `--legacy-peer-deps` (LayerZero peer conflict).
+- `npm install` needs `--legacy-peer-deps` (LayerZero adapter packages pull in
+  `@eth-optimism/contracts@0.6.0`, which declares `ethers@^5` as a required
+  peer, while this project is on ethers v6 — npm >= 7 treats the conflict as a
+  hard `ERESOLVE` error). A `solidity/.npmrc` carrying `legacy-peer-deps=true`
+  is shipped, so a bare `npm install` also completes cleanly on a fresh clone.
+  The skipped package (`@eth-optimism/contracts`) is imported by nothing in
+  `contracts/` or `test-foundry/`, so this has no effect on compilation or the
+  25/25 result. (`overrides` does not work here — silencing the ethers peer
+  surfaces the next LayerZero peer conflict; the flag is the practical fix.)
+- `via-IR` compilation can exceed ~2 GB RSS. On runners below ~4 GB RAM add a
+  temporary swap file, or `forge test` may be OOM-killed.
 
 ### Truffle counterparts
 

--- a/solidity/.npmrc
+++ b/solidity/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Follow-up to #32. Makes the Foundry bundle it added actually reproducible on a fresh clone.

`SESSION_KEY_GUARANTEES.md` positions `test-foundry/` as citable by outside reviewers, but a fresh clone can't get there in one step: bare `npm install` in `solidity/` fails, and the doc only mentioned the flag in prose. @tencawffee flagged this during independent verification of #32 and proposed shipping an `.npmrc`; this PR does that and documents the exact cause.

## What's in it

- **`solidity/.npmrc`** — one line, `legacy-peer-deps=true`.
- **`docs/SESSION_KEY_GUARANTEES.md` § Prerequisites** — expands the one-line npm note into the exact peer chain, and adds the via-IR / low-memory swap note.

## Why `npm install` fails without it

On a fresh clone, plain `npm install` in `solidity/` fails `ERESOLVE` on npm ≥ 7:

- root project is on `ethers@6.16.0`
- `@eth-optimism/contracts@0.6.0` declares `peer ethers@"^5"`, pulled in via `@layerzerolabs/lz-evm-messagelib-v2@3.0.168` (and again via `@layerzerolabs/oapp-evm@0.4.1`)
- npm ≥ 7 treats the v5/v6 conflict as a hard error

`overrides` doesn't cleanly fix it — silencing the ethers peer just surfaces the next LayerZero peer conflict. `legacy-peer-deps=true` skips only `@eth-optimism/contracts`, which nothing in `contracts/` or `test-foundry/` imports, so it has no effect on compilation or tests. Root cause sits upstream in the LayerZero packages' peer declarations and isn't fixable from this repo.

## Verification (independent of #32's environments)

Fresh clone, Hetzner / Ubuntu 24.04 / 24 GB, npm 10.x, forge-std v1.16.2, solc 0.8.30:

1. bare `npm install` → `ERESOLVE`, same peer chain @tencawffee reported
2. add `solidity/.npmrc` (+ clear `node_modules`/`package-lock.json`) → `added 1165 packages`, no error
3. `forge test --match-path 'test-foundry/Session*.t.sol'` → **25 passed, 0 failed, 0 skipped**

Deterministic gas matches @tencawffee to the digit on this third machine (cumulative 332481, walletScoped_CL4 278781, crossOwner 339808), so the `.npmrc` demonstrably has zero effect on the result.

This implements @tencawffee's permanent fix; credit to them for the independent verification and the `.npmrc` proposal.
