### PR TITLE
fix(compose): JA/CJK IME on Blink — commit composition text instead of freezing the controlled textarea

### DIFF
--- a/client/src/services/FrontEnd/src/components/HighlightedTextarea.tsx
+++ b/client/src/services/FrontEnd/src/components/HighlightedTextarea.tsx
@@ -71,10 +71,17 @@ interface HighlightedTextareaProps {
 // Firefox (real Gecko) is the ONLY engine that aborts an IME composition when
 // React re-applies the controlled `value` mid-composition — there we drop the
 // textarea to uncontrolled for the duration of a composition. WebKit/Blink
-// (iOS Safari & Chrome, desktop Chrome) keep the controlled value fine, and
-// going uncontrolled there BREAKS their IME, so we must gate this to Gecko.
+// keep the controlled value applied, but ONLY as long as the parent commits
+// every mid-composition onChange to state (see PostForm.handleTextChange):
+// if the parent skips those events instead, React's controlled-state restore
+// resets textarea.value back to the frozen prop after EVERY composition
+// keystroke on Blink — wiping the 変換中 text and killing the IME session,
+// which made Japanese input impossible on Chrome/Edge (measured on the live
+// bundle, 2026-07-30). Going uncontrolled on WebKit/Blink breaks their IME,
+// so the Gecko gate itself stays — exported because PostForm gates its
+// composition-freeze to Gecko with the same test.
 // Firefox-for-iOS ("FxiOS") is WebKit, not Gecko, and correctly does NOT match.
-const IS_GECKO =
+export const IS_GECKO =
   typeof navigator !== 'undefined' && /firefox/i.test(navigator.userAgent)
 
 const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -89,7 +89,7 @@ function gifSearchQuery(text: string): string {
     .filter(w => w.length > 1 && !stopWords.has(w))
   return words.slice(-5).join(' ')
 }
-import HighlightedTextarea from './HighlightedTextarea'
+import HighlightedTextarea, { IS_GECKO } from './HighlightedTextarea'
 import { useT } from '~/i18n/I18nProvider'
 import { acquireScrollLock, releaseScrollLock } from '~/utils/scrollLock'
 
@@ -855,7 +855,20 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
     // we received a real compositionstart, so plain Latin typing in those
     // browsers (no compositionstart → ref is false) commits immediately while
     // genuine CJK sessions (compositionstart fired → ref is true) still defer.
-    if (isComposingRef.current) {
+    // The freeze is GECKO-ONLY. On Blink (Chrome/Edge/Brave/Android Chrome)
+    // skipping these events while the textarea stays controlled makes React's
+    // controlled-state restore reset textarea.value to the frozen prop after
+    // EVERY composition keystroke — the 変換中 text is wiped synchronously and
+    // the IME session dies, so Japanese input was impossible on Blink
+    // (measured on the live bundle, 2026-07-30). Committing each interim
+    // value is the standard React IME pattern: prop === DOM value after the
+    // re-render, so React writes nothing to the node and the candidate
+    // window survives. Same gate as the fix zinsanjp/nyaromesama field-
+    // verified on v2.nyaromesama.com (deployed 2026-07-25). On Gecko the
+    // freeze stays: there the textarea goes uncontrolled during composition
+    // (see IS_GECKO in HighlightedTextarea) and a mid-composition re-render
+    // aborts the IME instead.
+    if (isComposingRef.current && IS_GECKO) {
       // Capture the correct value+caret from this mid-composition input event
       // so handleCompositionEnd can commit it even if the browser (Firefox)
       // reports an empty ta.value at compositionend. Still return without
@@ -944,6 +957,15 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
   // remains the authoritative final commit + cursor placement everywhere
   // compositionend DOES fire normally.
   const handleCompositionUpdate = (e: React.CompositionEvent<HTMLTextAreaElement>) => {
+    // Gecko keeps the composition-freeze (handleTextChange skips commits
+    // there), so committing interim text here would re-render the controlled
+    // textarea mid-composition and abort the IME — the exact failure this
+    // handler's Firefox-lag guard below also protects against. Bail early
+    // and let compositionend do the single commit. On Blink handleTextChange
+    // now commits every interim value anyway; on iOS WebKit (the engine this
+    // live commit exists for, since compositionend can be dropped there) the
+    // path below still runs.
+    if (IS_GECKO) return
     const ta = e.currentTarget
     // The live commit here exists only for iOS WebKit, which may not fire
     // compositionend, and which DOES reflect the composing text in ta.value at
@@ -2754,7 +2776,10 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                         value={slice}
                         composedValueRef={lastComposedRef}
                         onChange={(e) => {
-                          if (isComposingRef.current) {
+                          // Gecko-only freeze — same reasoning as
+                          // handleTextChange (Blink wipes the composing
+                          // text via controlled-state restore if skipped).
+                          if (isComposingRef.current && IS_GECKO) {
                             lastComposedRef.current = { value: e.target.value, caret: e.target.selectionStart ?? e.target.value.length }
                             return
                           }
@@ -3366,7 +3391,10 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                     value={slice}
                     composedValueRef={lastComposedRef}
                     onChange={(e) => {
-                      if (isComposingRef.current) {
+                      // Gecko-only freeze — same reasoning as
+                      // handleTextChange (Blink wipes the composing
+                      // text via controlled-state restore if skipped).
+                      if (isComposingRef.current && IS_GECKO) {
                         lastComposedRef.current = { value: e.target.value, caret: e.target.selectionStart ?? e.target.value.length }
                         return
                       }


### PR DESCRIPTION
## What

Japanese/CJK IME input is currently impossible in the post composer on every Blink browser (desktop & Android Chrome, Edge, Brave): each composition keystroke is synchronously reverted, so the composing (変換中) text never survives and the IME session dies. This PR makes the composer commit interim composition text to state on non-Gecko engines instead of freezing it — the standard React controlled-input IME pattern. Two files, no behavior change on Gecko or on the iOS-WebKit paths.

## Root cause

Three existing pieces interact:

1. `PostForm.handleTextChange` skips onChange entirely while `isComposingRef` is set (the #322 fix).
2. `HighlightedTextarea` stays **controlled** during composition everywhere except Gecko (`value={isComposing && IS_GECKO ? undefined : value}`).
3. React's controlled-component **state restore**: when an `input` event fires on a controlled textarea and the handler does not commit the new value, React resets `textarea.value` back to the (frozen) prop. Blink fires `input` for every mid-composition keystroke, so the composing text is wiped synchronously after each keystroke.

Measured on a live production bundle (v2 @ 672f5ee, Chrome on Windows): replaying Chrome's composition sequence (`compositionstart` → native value write "あ" → `input` with `inputType: insertCompositionText`) shows `textarea.value` reverting to `""` within the same task as the input event, while plain `insertText` input is untouched. Firefox escapes because React suppresses onChange during composition on Gecko **and** the textarea goes uncontrolled there.

## Fix

- Gate the composition-freeze in `handleTextChange` (and the two chunk-mode inline onChange handlers) to Gecko only. On Blink/WebKit every interim composition value is committed: after the re-render `prop === DOM value`, so React writes the same value back to the node — a harmless no-op (the setter still fires on every `input`, with an identical value; measured on-device by tencawffee) — and the native candidate window is unaffected.
- `handleCompositionUpdate` (the iOS-WebKit live-commit that exists because compositionend can be dropped there) now bails out on Gecko explicitly, where a mid-composition re-render aborts the IME.
- `IS_GECKO` is exported from `HighlightedTextarea` so both files share one definition.

## Verification

- **Synthetic**: replayed the Chrome composition event sequence against the rebuilt bundle — composing values now survive every keystroke ("あ" → "あい" → commit), and plain input still commits normally.
- **Real device**: Windows Chrome with the Japanese IME on a production node (v2.cawobservatory.net) — Japanese conversion, commit, and posting all work.

## Prior art & credits

@Zinsanjp and @nyaromesama diagnosed and field-fixed the JA IME breakage ahead of this PR: v2.nyaromesama.com has been running an equivalent gate (`/firefox/i`-scoped composition freeze) since 2026-07-25, verified on real devices together with @tencaw1000. Their deployed workaround additionally avoids the single→thread textarea swap while editing on non-Gecko engines and visualizes chunk boundaries inside one textarea instead — the visual half of that is already submitted as PR #33. This PR contributes the mechanism identification (React's controlled-state restore) and a minimal upstreamable diff; the credit for first making Japanese typeable on CAW v2 belongs to them.

## Known remaining edge

Crossing the on-chain byte limit mid-composition still swaps the single textarea into thread mode and interrupts the IME at that boundary (the original #322 trigger). On Blink this is a single interruption with no data loss — committed state is preserved. On iOS-WebKit it is worse: the swap fully remounts the textareas and orphans the open composition, after which `compositionstart` re-fires on every keystroke and characters duplicate in the draft, with no self-recovery — measured on a real device by tencawffee ([details](https://github.com/GilgameshCaw/Caw/pull/36#issuecomment-5143707692)). nyaromesama's deployed approach (stay in one textarea while editing + PR #33's boundary visuals) closes this edge — verified on iOS in the same report — and would compose well on top of this fix.

