### PR TITLE
fix(install): run the StakeLedger reseed as the app user, not root

### DIFF
--- a/cli/src/steps/install.js
+++ b/cli/src/steps/install.js
@@ -1,4 +1,5 @@
 import { execSync, exec, spawn } from 'child_process'
+import crypto from 'crypto'
 import fs from 'fs'
 import path from 'path'
 import ora from 'ora'
@@ -278,7 +279,11 @@ export async function startServices(nodeType, installDir) {
   // Chown the install dir to caw:caw so the running services have access.
   // Skip when not running as root (dev / non-sudo invocation).
   const runAsUser = process.env.SUDO_USER
-  if (runAsUser && process.getuid && process.getuid() === 0) {
+  // Non-null only when this install actually hands installDir to an
+  // unprivileged user. Anything root runs out of that tree afterwards has to
+  // drop to this user, or the boundary the chown creates isn't real.
+  const treeOwner = runAsUser && process.getuid && process.getuid() === 0 ? runAsUser : null
+  if (treeOwner) {
     const spinner0 = ora(`Chowning ${installDir} to ${runAsUser}...`).start()
     try {
       execSync(`chown -R ${runAsUser}:${runAsUser} ${installDir}`, { stdio: 'pipe' })
@@ -323,7 +328,7 @@ export async function startServices(nodeType, installDir) {
   // the Activity charts go flat. Frontend-only nodes don't run the
   // snapshotter, so skip there.
   if (nodeType !== 'frontend-only') {
-    setupStakeLedgerCron(installDir)
+    setupStakeLedgerCron(installDir, treeOwner)
   }
 
   console.log()
@@ -344,21 +349,36 @@ export async function startServices(nodeType, installDir) {
 
 /**
  * Install the StakeLedger drift-protection cron. Writes a wrapper script
- * into ${installDir}/scripts/ that re-anchors the snapshotter state from
+ * into /usr/local/lib/caw/ that re-anchors the snapshotter state from
  * chain, then adds a 3-hourly entry to root's crontab. Idempotent: a
  * second invocation overwrites the wrapper and replaces only the matching
  * crontab line (other entries are preserved).
  *
- * The wrapper is parameterized on installDir so multiple installs (e.g.
+ * The wrapper lives outside installDir because it runs from root's crontab,
+ * and the `chown -R` in startServices hands installDir to the unprivileged
+ * app user — a root-run script must not sit in a tree that user can write
+ * to. Its filename is still keyed on installDir so multiple installs (e.g.
  * staging + prod on the same VM) each manage their own cursor without
- * stomping each other.
+ * stomping each other, same as the old in-tree path.
+ *
+ * `treeOwner` is the user installDir was chowned to, or null if it stayed
+ * root-owned. Only `pm2 restart` needs root here; the seed step does not,
+ * and it executes code out of the chowned tree, so it drops to treeOwner.
  */
-function setupStakeLedgerCron(installDir) {
+function setupStakeLedgerCron(installDir, treeOwner) {
   const spinner = ora('Installing StakeLedger drift-protection cron...').start()
   try {
-    const scriptsDir = path.join(installDir, 'scripts')
-    fs.mkdirSync(scriptsDir, { recursive: true })
-    const scriptPath = path.join(scriptsDir, 'reseed-stake-ledger.sh')
+    const scriptsDir = '/usr/local/lib/caw'
+    fs.mkdirSync(scriptsDir, { recursive: true, mode: 0o755 })
+    // Keyed on installDir, like the old in-tree path was. The hash
+    // disambiguates paths that differ only in punctuation (/var/www/a.b and
+    // /var/www/a-b slug to the same string).
+    const slug = installDir.replace(/[^A-Za-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+    const tag = crypto.createHash('sha256').update(installDir).digest('hex').slice(0, 8)
+    const scriptPath = path.join(scriptsDir, `reseed-stake-ledger-${slug}-${tag}.sh`)
+    // Pre-move location. Dropped from the crontab and unlinked below so an
+    // upgrade doesn't leave two entries reseeding the same install.
+    const legacyPath = path.join(installDir, 'scripts', 'reseed-stake-ledger.sh')
 
     // Resolve the pm2 app name from the ecosystem file that generate.js
     // wrote earlier in this same install. Falls back to 'all' so the
@@ -372,6 +392,22 @@ function setupStakeLedgerCron(installDir) {
       const m = eco.match(/"name":\s*"(caw-server-[^"]+)"/)
       if (m) pm2Name = m[1]
     } catch {}
+
+    // Only `pm2 restart` needs root here: the pm2 daemon is root-owned
+    // because `pm2 start` ran under sudo earlier in this install. The seed
+    // step does not, and the code it runs (scripts/seed-stake-ledger.ts and
+    // the tsx it resolves from client/node_modules/) is owned by treeOwner
+    // after the chown — so drop to that user for it. runuser sets HOME,
+    // leaves npx/node resolvable, and inherits cwd, so the `cd` below still
+    // applies. Absolute path because root crontabs run with
+    // PATH=/usr/bin:/bin and runuser sits in /usr/sbin on Debian-derived
+    // distros; if it can't be resolved, `set -e` fails the run loudly rather
+    // than silently falling back to running the seed as root.
+    const runuserBin = ['/usr/sbin/runuser', '/sbin/runuser', '/usr/bin/runuser']
+      .find(p => fs.existsSync(p))
+    const seedCmd = treeOwner
+      ? `${runuserBin || 'runuser'} -u ${treeOwner} -- /usr/bin/env npx tsx scripts/seed-stake-ledger.ts`
+      : `/usr/bin/env npx tsx scripts/seed-stake-ledger.ts`
 
     const wrapper = `#!/usr/bin/env bash
 # Cron-driven StakeLedger re-anchor. Runs every 3h; reseeds chain state
@@ -392,16 +428,19 @@ mkdir -p "$LOG_DIR"
 LOG="$LOG_DIR/reseed-stake-ledger.log"
 {
   echo "==== $(date -u +%Y-%m-%dT%H:%M:%SZ) reseed start ===="
-  /usr/bin/env npx tsx scripts/seed-stake-ledger.ts
+  ${seedCmd}
   echo "-- restarting pm2 process: ${pm2Name}"
   /usr/bin/pm2 restart ${pm2Name}
   echo "==== $(date -u +%Y-%m-%dT%H:%M:%SZ) reseed done ===="
 } >> "$LOG" 2>&1
 `
     fs.writeFileSync(scriptPath, wrapper, { mode: 0o755 })
+    // The pre-move wrapper is no longer referenced by anything.
+    try { fs.unlinkSync(legacyPath) } catch {}
 
-    // Crontab: read existing lines (or empty), drop any prior entry for
-    // this exact script path (idempotent reinstall), append the new line.
+    // Crontab: read existing lines (or empty), drop any prior entry for this
+    // install — both the current script path and the pre-move one, so an
+    // upgrade doesn't leave two — then append the new line.
     let existing = ''
     try {
       existing = execSync('crontab -l 2>/dev/null', { stdio: ['pipe', 'pipe', 'pipe'] }).toString()
@@ -411,16 +450,19 @@ LOG="$LOG_DIR/reseed-stake-ledger.log"
     }
     const filtered = existing
       .split('\n')
-      .filter(line => !line.includes(scriptPath))
+      .filter(line => !line.includes(scriptPath) && !line.includes(legacyPath))
       .filter(line => line.length > 0)
     filtered.push(`0 */3 * * * ${scriptPath}`)
     const newCron = filtered.join('\n') + '\n'
     execSync('crontab -', { input: newCron, stdio: ['pipe', 'pipe', 'pipe'] })
 
     spinner.succeed(`Drift-protection cron installed (${scriptPath}, every 3h)`)
+    if (treeOwner && !runuserBin) {
+      spinner.warn(`  runuser not found — install util-linux, or this cron fails on its first run`)
+    }
   } catch (e) {
     spinner.warn(`Could not install StakeLedger cron — Activity charts may freeze on drift: ${e.message}`)
-    spinner.warn(`  To install manually later: see ${path.join(installDir, 'scripts', 'reseed-stake-ledger.sh')}`)
+    spinner.warn(`  To install manually later: see /usr/local/lib/caw/`)
   }
 }
 


### PR DESCRIPTION
### What the installer does today

`cli/src/steps/install.js` does two things about 45 lines apart. On `master`
(`e2074718`), lines 274–284:

```js
// pm2 launches the apps as the caw user (via the ecosystem's `user:`
// directive), and those apps need to write to logs/ and read from .env.
const runAsUser = process.env.SUDO_USER
if (runAsUser && process.getuid && process.getuid() === 0) {
    execSync(`chown -R ${runAsUser}:${runAsUser} ${installDir}`, ...)
```

Then line 326 calls `setupStakeLedgerCron(installDir)`, which writes its
wrapper to `${installDir}/scripts/reseed-stake-ledger.sh` (line 361) and
registers it in **root's** crontab (lines 405–418):

```
0 */3 * * * /var/www/<site>/scripts/reseed-stake-ledger.sh
```

The wrapper's body is, in effect:

```bash
cd ${installDir}/client
/usr/bin/env npx tsx scripts/seed-stake-ledger.ts   # does not need root
/usr/bin/pm2 restart ${pm2Name}                     # does need root
```

Because of the `chown -R`, everything root then executes on that schedule is
owned by the app user by construction: the wrapper's directory, the seed
script, and the `tsx` binary resolved out of `client/node_modules/`. Write
access as the app user therefore becomes root execution on the next tick —
within three hours, with nothing further required. That is precisely the
boundary the `chown` and its comment exist to establish.

It isn't only that one comment. `cli/src/steps/generate.js:701-703` states the
same intent for the same install:

```js
// If `pm2 startup` is wired to systemd, pm2 boots as root and launches each
// app. Set the per-app `user` so workloads drop privileges.
```

and line 740 applies it — `...(runAsUser ? { user: runAsUser } : {})`. So two
files declare that workloads run unprivileged, and the reseed cron is the one
thing that doesn't follow.

The same code is on `v2` (lines 401 / 447 / 477 / 539), so it carries forward.

### Why both halves of the fix are needed

Moving the wrapper out of the tree isn't sufficient on its own: a root-owned
wrapper would still execute `seed-stake-ledger.ts` and `tsx` from inside
`installDir`.

Dropping privilege isn't sufficient on its own either: the wrapper itself
sits in a directory the app user can write to.

Only `pm2 restart` genuinely needs root here — the pm2 daemon is root-owned
because `pm2 start` ran under sudo earlier in this same install. The seed step
does not. This patch splits the wrapper along that line, which is also why it
needs no `sudoers` rule.

### Where this does not apply

If `caw install` is run directly as root without `sudo`, `SUDO_USER` is unset,
the `chown -R` is skipped, and `installDir` stays root-owned. pm2 still drops
the app to `caw` (generate.js falls back to `'caw'` at that point), but
nothing under `installDir` is writable by it, so the root cron has nothing to
inherit. The patch keeps today's behaviour in that case, gated on the same
condition as the `chown`.

### What changed

- The wrapper moves to `/usr/local/lib/caw/`, root-owned. Its filename is
  still keyed on `installDir` — the property the in-tree path had — with a
  short hash so two paths differing only in punctuation can't collide.
- The seed step runs as the chowned-to user via `runuser`. `pm2 restart`
  stays root.
- The pre-move crontab line is dropped and the old wrapper unlinked, so a
  reinstall doesn't leave two entries reseeding the same install.
- If `runuser` can't be resolved, install warns, and `set -e` makes the run
  fail loudly rather than silently reverting to running the seed as root.

No strong opinion on `/usr/local/lib/caw/` — happy to move it wherever you
prefer. What matters is only that it isn't inside the tree `chown -R` hands
over.

### Testing

Ubuntu 24.04, on a node running this installer's output since 2026-07-29.

Environment facts the patch depends on:

- `runuser` resolves at `/usr/sbin/runuser` and `/sbin/runuser`; there is no
  `/usr/bin/runuser`. Hence the absolute path, since root crontabs run with
  `PATH=/usr/bin:/bin`.
- `runuser -u <appuser> --` sets `HOME` to that user's home, leaves `npx` and
  `node` resolvable, and inherits cwd, so the `cd` above it still applies.
- The relocated wrapper's directory is not writable by the app user. The
  in-tree one is (`drwxrwxr-x appuser appuser`), as are the seed script
  (`-rw-rw-r--`) and the real `tsx` target (`-rwxr-xr-x`) — all owned by the
  app user via the `chown -R`.

End-to-end run of the generated command sequence, on a production node with
~4.6k tokenIds (2026-08-01):

- Process tree during the run: root down to `runuser`, then `npm exec tsx` →
  `sh -c tsx` → `node ... seed-stake-ledger.ts`, all as the app user
  (uid 1000). `auth.log` recorded
  `runuser: pam_unix(runuser:session): session opened for user <appuser>(uid=1000) by root(uid=0)`.
- Seed completed: `StakeLedgerState` upserted, `CawOwnershipCurrent`
  populated with 4592 non-zero rows, `lastBlock` seeded to the L2 head.
- `pm2 restart` then succeeded as root; the app came back under pm2 as the
  app user and served 200 on the local API 49s later.
- 11m38s wall clock, exit 0 — same duration as the privilege-dropped reseed
  we already run in production.

`node --check` passes on the modified file.

### For you to decide

- Base is `master`. `v2` carries the same code if you want it there too.
- If this cron is on its way out — i.e. once the snapshotter no longer needs
  the `halted` flag cleared out-of-band — feel free to close this. It's only
  worth landing while the cron exists.
- Deliberately not in this diff: the wrapper has no concurrency guard, so a
  run that overruns 3h overlaps itself, writing the same state twice and
  restarting pm2 twice. Separate concern — happy to send a `flock` patch if
  you want one.

### Disclosure

We operate `cawobservatory.net` (V1 registry, instanceId 1015) and
`v2.cawobservatory.net` (V2 registry, instance 28), and publish an observation
dashboard about CAW — so we're both a participant in the network and an
observer of it. Everything above was measured on those two nodes.
