### PR TITLE
fix(rpc-proxy): allowlist Multicall3 contract address to prevent FE breakage in strict mode

### DIFF
--- a/client/src/api/routes/rpc-proxy.ts
+++ b/client/src/api/routes/rpc-proxy.ts
@@ -54,6 +54,8 @@ const KNOWN_CONTRACTS: Set<string> = (() => {
   }
   // Uniswap V2 router (mainnet price reads) — not in addresses.ts as an *_ADDRESS.
   s.add('0x7a250d5630b4cf539739df2c5dacb4c659f2488d')
+  // Multicall3 (standard batching contract across EVM chains used by viem/wagmi)
+  s.add('0xca11bde05977b3631167028862be2a173976ca11')
   for (const raw of (process.env.RPC_PROXY_EXTRA_CONTRACTS || '').split(',')) {
     const a = raw.trim().toLowerCase()
     if (/^0x[0-9a-fA-F]{40}$/.test(a)) s.add(a)


### PR DESCRIPTION
Summary

Adds the standard Multicall3 contract address (0xca11bde05977b3631167028862be2a173976ca11) to KNOWN_CONTRACTS in client/src/api/routes/rpc-proxy.ts.

Background & Motivation

In production logs, rpc-proxy frequently outputs non-allowlisted target warnings for Multicall3 queries (49+ occurrences in the current log file alone, on cawnest.com):

[rpc-proxy] eth_call → non-allowlisted target 0xca11bde05977b3631167028862be2a173976ca11 (allowed; set RPC_PROXY_STRICT=1 to block)

Multicall3 is a standard EVM contract used by frontend libraries (viem, wagmi, rainbowkit) to aggregate multiple eth_call reads into a single request.

While non-allowlisted targets are permitted when RPC_PROXY_STRICT=0, enabling RPC_PROXY_STRICT=1 in production would immediately block all frontend batch reads through the RPC proxy, breaking contract state/balance reads across the app.

Changes

Added s.add('0xca11bde05977b3631167028862be2a173976ca11') to KNOWN_CONTRACTS in client/src/api/routes/rpc-proxy.ts, following the existing pattern used for the Uniswap V2 Router.

Diff
```diff
--- a/client/src/api/routes/rpc-proxy.ts
+++ b/client/src/api/routes/rpc-proxy.ts
@@ -55,4 +55,6 @@ const KNOWN_CONTRACTS: Set<string> = (() => {
   // Uniswap V2 router (mainnet price reads) — not in addresses.ts as an *_ADDRESS.
   s.add('0x7a250d5630b4cf539739df2c5dacb4c659f2488d')
+  // Multicall3 (standard batching contract across EVM chains used by viem/wagmi)
+  s.add('0xca11bde05977b3631167028862be2a173976ca11')
   for (const raw of (process.env.RPC_PROXY_EXTRA_CONTRACTS || '').split(',')) {
```
```