### PR TITLE
fix(boot): refuse an unstamped DB that still holds rows from the old contracts

### DIFF
--- a/client/src/utils/contractEpochGuard.ts
+++ b/client/src/utils/contractEpochGuard.ts
@@ -23,6 +23,8 @@
  *                 Stamping that would mark stale data as current, and every later
  *                 boot would report OK: the guard disarms itself for that database.
  *                 So: no stamp + prior rows → treat as a mismatch.
+ *                 And if that look at the data cannot be taken, refuse as well —
+ *                 "could not check" must not leave here as "checked and fine".
  *   - matches   → proceed normally.
  *   - MISMATCH  → the code points at NEW contracts but the DB is for OLD ones →
  *                 throw a loud, explicit error telling the dev to reset the DB.
@@ -30,7 +32,8 @@
  * Bypass (only if you REALLY know the DB is compatible): set
  * ALLOW_CONTRACT_EPOCH_MISMATCH=1 — logs a warning and proceeds. This also covers
  * the one benign unstamped case: a DB that was already rebuilt for the current
- * contracts before this guard shipped. One boot with the flag stamps it for good.
+ * contracts before this guard shipped. One boot with the flag stamps it for good —
+ * and it has to be taken out again afterwards, or this guard stays off permanently.
  */
 
 import { PrismaClient } from '@prisma/client'
@@ -39,19 +42,48 @@ import { logger } from './logger'
 
 const EPOCH_KEY = 'deployed-contract-epoch'
 
+/** Both bypass paths say this, and so does the error text — a flag with no exit is how
+ *  a guard disarms itself, which is the failure this guard exists to prevent. */
+const REMOVE_FLAG_NOTE =
+  'Remove ALLOW_CONTRACT_EPOCH_MISMATCH once this boot has stamped the DB — left in ' +
+  '.env (ecosystem.config.cjs preloads it) this guard stays off for good, including ' +
+  'the next redeploy.'
+
 /** The epoch this code is wired to = the current deployed CawProfile address. */
 function currentEpoch(): string {
   return (process.env.CAW_NAMES_ADDRESS || CAW_NAMES_ADDRESS).toLowerCase()
 }
 
+/** Prisma errors are multi-line with the human summary last; the box wants one line.
+ *  The full text still goes to the log, so nothing is lost. */
+function lastLine(msg: string | undefined): string {
+  const lines = (msg ?? '').split('\n').map((l) => l.trim()).filter(Boolean)
+  return lines.length ? lines[lines.length - 1] : 'unknown error'
+}
+
 export class ContractEpochMismatchError extends Error {
-  /** dbEpoch === null → the DB has no stamp but does hold rows from a prior deployment. */
-  constructor(public readonly dbEpoch: string | null, public readonly codeEpoch: string) {
+  /**
+   * dbEpoch === null → the DB has no stamp. Either it holds rows from a prior
+   * deployment, or — when probeError is set — that could not be determined.
+   */
+  constructor(
+    public readonly dbEpoch: string | null,
+    public readonly codeEpoch: string,
+    public readonly probeError?: string,
+  ) {
     const dbLine = dbEpoch
       ? `    DB was built for CawProfile: ${dbEpoch}\n`
-      : '    DB has NO epoch stamp, but already holds rows from a previous\n' +
-        '    deployment — it predates this guard, so it was built for the OLD\n' +
-        '    contracts. (A fresh or just-reset DB is empty.)\n'
+      : probeError
+        ? '    DB has NO epoch stamp, and this guard could not read the tables it\n' +
+          '    needs to tell a fresh database from one carried over from an older\n' +
+          '    build:\n' +
+          `      ${probeError}\n` +
+          '    The epoch lookup just before it succeeded, so the database IS\n' +
+          '    reachable — this is its schema or its permissions, not the\n' +
+          '    connection. Refusing rather than guessing.\n'
+        : '    DB has NO epoch stamp, but already holds rows from a previous\n' +
+          '    deployment — it predates this guard, so it was built for the OLD\n' +
+          '    contracts. (A fresh or just-reset DB is empty.)\n'
     super(
       '\n\n' +
       '════════════════════════════════════════════════════════════════════\n' +
@@ -67,6 +99,8 @@ export class ContractEpochMismatchError extends Error {
       '     (= prisma db push --force-reset — this WIPES all data.)\n\n' +
       '  If you are CERTAIN the DB is already compatible, bypass with:\n' +
       '        ALLOW_CONTRACT_EPOCH_MISMATCH=1\n' +
+      '     Then REMOVE it. Left in .env — ecosystem.config.cjs preloads it —\n' +
+      '     this guard stays off for good, including the next redeploy.\n' +
       '════════════════════════════════════════════════════════════════════\n',
     )
     this.name = 'ContractEpochMismatchError'
@@ -82,6 +116,10 @@ export class ContractEpochMismatchError extends Error {
  * The two cases are only distinguishable by looking at the data.
  *
  * Existence probes, not counts: this runs on every boot and must stay cheap.
+ *
+ * Throws are the caller's problem to classify, and the caller can: by the time this
+ * runs, the epoch lookup has already reached the database, so a failure here is not
+ * the unreachable-DB case the boot path tolerates.
  */
 async function hasPriorDeploymentState(prisma: PrismaClient): Promise<boolean> {
   const [user, action] = await Promise.all([
@@ -106,20 +144,38 @@ export async function assertContractEpoch(): Promise<void> {
     const dbEpoch = row ? String((row.value as unknown) ?? '').toLowerCase() : null
 
     if (!dbEpoch) {
-      // No stamp. Two cases, and they must not be confused:
+      // No stamp. Three outcomes, and they must not be confused:
       //   - a genuinely fresh / just-reset DB → nothing to invalidate → stamp, proceed.
       //   - a DB carried over from a build that predates this guard → it still holds
       //     rows keyed to the OLD contracts. Stamping it would mark stale data as
       //     current and make every later boot report OK — the guard would disarm
       //     itself for that database, which is worse than not having caught it once.
-      if (await hasPriorDeploymentState(prisma)) {
+      //   - the look at the data itself fails → the two are indistinguishable, so
+      //     refuse. The caller turns anything that is not a mismatch into a warning
+      //     and boots, which would make a check that could not run look like a check
+      //     that passed. The query above already reached the DB, so this is not the
+      //     dev-without-a-database case that leniency exists for.
+      let priorState: boolean
+      try {
+        priorState = await hasPriorDeploymentState(prisma)
+      } catch (err) {
+        const msg = (err as Error)?.message
+        logger.error(`[contractEpoch] could not classify an unstamped DB: ${msg}`)
+        if (!bypass) throw new ContractEpochMismatchError(null, codeEpoch, lastLine(msg))
+        priorState = true
+      }
+
+      if (priorState) {
         if (!bypass) throw new ContractEpochMismatchError(null, codeEpoch)
         logger.warn(
-          '[contractEpoch] unstamped DB with rows from a previous deployment, bypassed ' +
-          '(ALLOW_CONTRACT_EPOCH_MISMATCH=1). Proceeding — you asserted the DB is compatible.',
+          '[contractEpoch] unstamped DB that is not provably fresh, bypassed ' +
+          '(ALLOW_CONTRACT_EPOCH_MISMATCH=1). Proceeding — you asserted the DB is ' +
+          `compatible. ${REMOVE_FLAG_NOTE}`,
         )
       }
-      // Fresh or just-reset DB — stamp it and proceed.
+
+      // Either a genuinely fresh / just-reset DB, or one of the cases above that the
+      // operator bypassed. Stamp it so the next boot doesn't ask again.
       await prisma.chainData.upsert({
         where: { key: EPOCH_KEY },
         create: { key: EPOCH_KEY, value: codeEpoch },
@@ -138,7 +194,8 @@ export async function assertContractEpoch(): Promise<void> {
     if (bypass) {
       logger.warn(
         `[contractEpoch] MISMATCH bypassed (ALLOW_CONTRACT_EPOCH_MISMATCH=1): ` +
-        `db=${dbEpoch} code=${codeEpoch}. Proceeding — you asserted the DB is compatible.`,
+        `db=${dbEpoch} code=${codeEpoch}. Proceeding — you asserted the DB is ` +
+        `compatible. ${REMOVE_FLAG_NOTE}`,
       )
       // Re-stamp so subsequent boots don't keep warning.
       await prisma.chainData.update({ where: { key: EPOCH_KEY }, data: { value: codeEpoch } })

--- a/client/src/utils/contractEpochGuard.ts
+++ b/client/src/utils/contractEpochGuard.ts
@@ -16,12 +16,21 @@
  * the first time we see a DB, and on every boot compare the stamp to the current
  * code's address:
  *   - no stamp  → fresh / just-reset DB → stamp it, proceed.
+ *                 EXCEPT when the DB already holds rows from a previous deployment.
+ *                 The stamp was introduced with this guard, so every database
+ *                 carried over from an older build has no stamp while still being
+ *                 keyed to the OLD contracts — the exact case this guard exists for.
+ *                 Stamping that would mark stale data as current, and every later
+ *                 boot would report OK: the guard disarms itself for that database.
+ *                 So: no stamp + prior rows → treat as a mismatch.
  *   - matches   → proceed normally.
  *   - MISMATCH  → the code points at NEW contracts but the DB is for OLD ones →
  *                 throw a loud, explicit error telling the dev to reset the DB.
  *
  * Bypass (only if you REALLY know the DB is compatible): set
- * ALLOW_CONTRACT_EPOCH_MISMATCH=1 — logs a warning and proceeds.
+ * ALLOW_CONTRACT_EPOCH_MISMATCH=1 — logs a warning and proceeds. This also covers
+ * the one benign unstamped case: a DB that was already rebuilt for the current
+ * contracts before this guard shipped. One boot with the flag stamps it for good.
  */
 
 import { PrismaClient } from '@prisma/client'
@@ -36,7 +45,13 @@ function currentEpoch(): string {
 }
 
 export class ContractEpochMismatchError extends Error {
-  constructor(public readonly dbEpoch: string, public readonly codeEpoch: string) {
+  /** dbEpoch === null → the DB has no stamp but does hold rows from a prior deployment. */
+  constructor(public readonly dbEpoch: string | null, public readonly codeEpoch: string) {
+    const dbLine = dbEpoch
+      ? `    DB was built for CawProfile: ${dbEpoch}\n`
+      : '    DB has NO epoch stamp, but already holds rows from a previous\n' +
+        '    deployment — it predates this guard, so it was built for the OLD\n' +
+        '    contracts. (A fresh or just-reset DB is empty.)\n'
     super(
       '\n\n' +
       '════════════════════════════════════════════════════════════════════\n' +
@@ -45,7 +60,7 @@ export class ContractEpochMismatchError extends Error {
       '  This code is wired to a DIFFERENT set of contracts than the data in\n' +
       '  the database was built for. The contracts were redeployed (tokenIds\n' +
       '  reassigned), so the existing DB rows are STALE and would misbehave.\n\n' +
-      `    DB was built for CawProfile: ${dbEpoch}\n` +
+      dbLine +
       `    Code now points at CawProfile: ${codeEpoch}\n\n` +
       '  ➜  Reset the database to use the new contracts:\n' +
       '        cd client && npm run prisma:reset\n' +
@@ -59,6 +74,24 @@ export class ContractEpochMismatchError extends Error {
 }
 
 /**
+ * True if this DB already holds rows keyed to a contract deployment.
+ *
+ * A database created by `prisma db push --force-reset` (the documented remedy) is
+ * empty. A database carried over from an older build is not — and it has no epoch
+ * stamp either, so "no stamp" on its own cannot mean "fresh" for anyone upgrading.
+ * The two cases are only distinguishable by looking at the data.
+ *
+ * Existence probes, not counts: this runs on every boot and must stay cheap.
+ */
+async function hasPriorDeploymentState(prisma: PrismaClient): Promise<boolean> {
+  const [user, action] = await Promise.all([
+    prisma.user.findFirst({ select: { id: true } }),
+    prisma.action.findFirst({ select: { id: true } }),
+  ])
+  return !!(user || action)
+}
+
+/**
  * Verify the DB's contract epoch matches this code, or throw
  * ContractEpochMismatchError. Stamps a fresh/reset DB with the current epoch.
  * Call ONCE at boot, before starting any service. Uses its own short-lived
@@ -66,12 +99,26 @@ export class ContractEpochMismatchError extends Error {
  */
 export async function assertContractEpoch(): Promise<void> {
   const codeEpoch = currentEpoch()
+  const bypass = process.env.ALLOW_CONTRACT_EPOCH_MISMATCH === '1'
   const prisma = new PrismaClient()
   try {
     const row = await prisma.chainData.findUnique({ where: { key: EPOCH_KEY } })
     const dbEpoch = row ? String((row.value as unknown) ?? '').toLowerCase() : null
 
     if (!dbEpoch) {
+      // No stamp. Two cases, and they must not be confused:
+      //   - a genuinely fresh / just-reset DB → nothing to invalidate → stamp, proceed.
+      //   - a DB carried over from a build that predates this guard → it still holds
+      //     rows keyed to the OLD contracts. Stamping it would mark stale data as
+      //     current and make every later boot report OK — the guard would disarm
+      //     itself for that database, which is worse than not having caught it once.
+      if (await hasPriorDeploymentState(prisma)) {
+        if (!bypass) throw new ContractEpochMismatchError(null, codeEpoch)
+        logger.warn(
+          '[contractEpoch] unstamped DB with rows from a previous deployment, bypassed ' +
+          '(ALLOW_CONTRACT_EPOCH_MISMATCH=1). Proceeding — you asserted the DB is compatible.',
+        )
+      }
       // Fresh or just-reset DB — stamp it and proceed.
       await prisma.chainData.upsert({
         where: { key: EPOCH_KEY },
@@ -88,7 +135,7 @@ export async function assertContractEpoch(): Promise<void> {
     }
 
     // Mismatch.
-    if (process.env.ALLOW_CONTRACT_EPOCH_MISMATCH === '1') {
+    if (bypass) {
       logger.warn(
         `[contractEpoch] MISMATCH bypassed (ALLOW_CONTRACT_EPOCH_MISMATCH=1): ` +
         `db=${dbEpoch} code=${codeEpoch}. Proceeding — you asserted the DB is compatible.`,


### PR DESCRIPTION
`assertContractEpoch()` treats "no epoch stamp" as "fresh DB" and stamps it. But the stamp was introduced *with* this guard (b85d2d2, 2026-07-26), so every database carried over from an older build has no stamp while still holding rows keyed to the **old** contracts — the exact population the guard exists to protect.

This is the server-side twin of the browser bug fixed today in d7a0e05:

> every browser coming from a build that predates the guard has NO epoch key at all — the guard treated that null as a first-ever visit, stamped the new epoch, and skipped the wipe

Same null, same wrong conclusion.

**And it compounds.** Stamping the stale DB makes every later boot log `[contractEpoch] OK`, so the guard permanently disarms itself for that database — worse than failing to catch it once, because the operator never gets a second chance to notice.

## Reproduced on a real database

Not a synthetic fixture. Our node `v2.cawobservatory.net` was still on `672f5ee` (2026-07-22) until tonight — it had missed the 2026-07-24 redeploy entirely. I took a dump of its database before running `prisma:reset`, so the pre-upgrade state is preserved: **no `deployed-contract-epoch` key in `ChainData`, and `User` 102 / `Caw` 528 / `Action` 1085 rows with tokenId 1..102, all keyed to the 2026-06-14 CawProfile (`0x4F853523…`).**

Restored that dump into a scratch database and ran the guard from current `v2` HEAD against it:

```
[contractEpoch] stamped DB epoch = 0x61c07717210988df782e779cac8ac67633ed2a2e
→ boot allowed; User/Caw/Action still 102 / 528 / 1085, untouched
```

Second run against the same database:

```
[contractEpoch] OK (0x61c07717210988df782e779cac8ac67633ed2a2e)
```

I also checked that `contractEpochGuard` is the only DB/contract consistency check in the tree, and that it runs before `runServices(config)` — nothing downstream catches this.

## Why it matters right now

Today's heads-up to node operators says the server "refuses to start against a stale DB and tells you exactly what to do, so you can't silently run on mismatched data." That holds for a DB stamped by an earlier deploy. It does not hold for the upgrade path — which is who the note is addressed to.

## The fix

Mirror `hasPriorDeploymentState()` from d7a0e05 on the server side. An unstamped DB with rows in `User` or `Action` is a pre-guard database, not a fresh one, so it is treated as a mismatch. Existence probes rather than counts, since this runs on every boot.

Verified against a live Postgres, all four paths:

| DB state | before | after |
|---|---|---|
| pre-guard, old-contract rows, unstamped | boots (stamps) | **refuses** |
| fresh / just after `prisma:reset` | boots (stamps) | boots (stamps) |
| same pre-guard DB, `ALLOW_CONTRACT_EPOCH_MISMATCH=1` | boots | boots, warns, stamps |
| already stamped, matching | `OK` | `OK` |

What an operator sees on the refusal:

```
════════════════════════════════════════════════════════════════════
  ⛔  DATABASE / CONTRACT MISMATCH — server refusing to start
════════════════════════════════════════════════════════════════════
  This code is wired to a DIFFERENT set of contracts than the data in
  the database was built for. The contracts were redeployed (tokenIds
  reassigned), so the existing DB rows are STALE and would misbehave.

    DB has NO epoch stamp, but already holds rows from a previous
    deployment — it predates this guard, so it was built for the OLD
    contracts. (A fresh or just-reset DB is empty.)
    Code now points at CawProfile: 0x61c07717210988df782e779cac8ac67633ed2a2e

  ➜  Reset the database to use the new contracts:
        cd client && npm run prisma:reset
     (= prisma db push --force-reset — this WIPES all data.)

  If you are CERTAIN the DB is already compatible, bypass with:
        ALLOW_CONTRACT_EPOCH_MISMATCH=1
════════════════════════════════════════════════════════════════════
```

## Trade-off, stated plainly

There is one benign unstamped case this now refuses. An operator who reset their DB in the ~58 hours between the redeploy (d38f9b36, 2026-07-24 03:41Z) and this guard landing (b85d2d2, 2026-07-26 13:28Z) has a *correct* database with no stamp, and would be told to wipe good data.

I kept the refusal and routed that case through the existing bypass rather than weakening the check, because the guard's whole premise is to fail loudly rather than silently misbehave, and the error text already names the flag — one boot with `ALLOW_CONTRACT_EPOCH_MISMATCH=1` stamps it for good. If you would rather have that case pass silently, say the word and I will invert it; it is a two-line change.

Independent of #38 (`master`, installer cron privileges) — different file, different branch, no overlap.
