### PR TITLE
feat: wire up existing RPC fallback support (CLI + rpc-proxy)

### DIFF
--- a/cli/src/steps/generate.js
+++ b/cli/src/steps/generate.js
@@ -480,6 +480,14 @@ function buildEnvVars(nodeType, config) {
   // Optional fallback RPC URLs — routed through FallbackProvider
   // (client/src/utils/rpcProvider.ts) when set. HTTP-only: the fallback
   // exists for read/poll resilience, not for WSS event subscription.
+  //
+  // Only written here, at install time — an operator on an existing box
+  // doesn't get this from caw update; they'd add
+  // L1_RPC_URL_HTTP_FALLBACK / L2_RPC_URL_HTTP_FALLBACK to .env by hand.
+  // Less of a gap than the same shape elsewhere, since the variable
+  // names are documented here and the reading side (rpc-proxy.ts) has
+  // always been there — but worth knowing this isn't retrofitted onto
+  // existing installs automatically.
   if (config.l1RpcUrlHttpFallback) env.L1_RPC_URL_HTTP_FALLBACK = config.l1RpcUrlHttpFallback
   if (config.l2RpcUrlHttpFallback) env.L2_RPC_URL_HTTP_FALLBACK = config.l2RpcUrlHttpFallback
   if (config.ethMainnetRpcUrl) env.ETH_MAINNET_RPC_URL = config.ethMainnetRpcUrl

--- a/cli/src/steps/generate.js
+++ b/cli/src/steps/generate.js
@@ -477,6 +477,11 @@ function buildEnvVars(nodeType, config) {
   if (config.l2RpcUrlHttp) env.L2_RPC_URL_HTTP = config.l2RpcUrlHttp
   if (config.l1RpcUrl) env.L1_RPC_URL = config.l1RpcUrl
   if (config.l1RpcUrlHttp) env.L1_RPC_URL_HTTP = config.l1RpcUrlHttp
+  // Optional fallback RPC URLs — routed through FallbackProvider
+  // (client/src/utils/rpcProvider.ts) when set. HTTP-only: the fallback
+  // exists for read/poll resilience, not for WSS event subscription.
+  if (config.l1RpcUrlHttpFallback) env.L1_RPC_URL_HTTP_FALLBACK = config.l1RpcUrlHttpFallback
+  if (config.l2RpcUrlHttpFallback) env.L2_RPC_URL_HTTP_FALLBACK = config.l2RpcUrlHttpFallback
   if (config.ethMainnetRpcUrl) env.ETH_MAINNET_RPC_URL = config.ethMainnetRpcUrl
   // Optional Infura-style API Key Secrets. Backend-only — embedded as
   // Basic Auth in the URL by rpcProvider.ts withSecret() so the same

--- a/cli/src/steps/rpcUrls.js
+++ b/cli/src/steps/rpcUrls.js
@@ -211,6 +211,42 @@ async function collectRpcPair(label, required, expectedChainId) {
     console.log()
   }
 
+  // Optional fallback URL. If the primary RPC goes down or gets rate-limited,
+  // the backend's FallbackProvider (client/src/utils/rpcProvider.ts) routes
+  // around it automatically — but only if L1_RPC_URL_HTTP_FALLBACK /
+  // L2_RPC_URL_HTTP_FALLBACK is set. We don't force this on every operator
+  // (a paid primary rarely needs it), but we do offer it, and default to
+  // "yes" when the primary itself looked like a public RPC (isPublicRpc
+  // above) since that's exactly the case the resilience machinery exists for.
+  let httpFallback = ''
+  const { addFallback } = await inquirer.prompt([{
+    type: 'confirm',
+    name: 'addFallback',
+    message: `Add a fallback ${label} RPC URL? ${dim('(automatic switch-over if the primary goes down or hits a rate limit)')}`,
+    default: isPublicRpc(http),
+  }])
+  if (addFallback) {
+    const { fallbackInput } = await inquirer.prompt([{
+      type: 'input',
+      name: 'fallbackInput',
+      message: `${label} Fallback HTTP RPC URL (https://):`,
+      validate: (input) => {
+        if (!input.trim()) return true // optional — Enter to skip
+        if (!input.startsWith('https://') && !input.startsWith('http://')) {
+          return 'URL must start with https:// or http://'
+        }
+        if (input.trim() === http) {
+          return 'Fallback URL is identical to the primary — pick a different provider'
+        }
+        return true
+      },
+    }])
+    httpFallback = fallbackInput.trim()
+    if (httpFallback && isPublicRpc(httpFallback)) {
+      console.log(dim(`  (Fallback is also a public RPC — fine as a second line of defense, but consider a paid provider for at least one of the two.)`))
+    }
+  }
+
   // Step 2: WSS URL (optional). When the HTTP URL is Infura, offer the
   // auto-derived WSS as a default; otherwise leave blank — most providers
   // either give you a separate WSS URL or don't expose one at all.
@@ -257,7 +293,7 @@ async function collectRpcPair(label, required, expectedChainId) {
   // override. We don't surface that as a prompt because for a normal node
   // install it's the wrong choice (leaks the key into the bundle and
   // bypasses the proxy's caching + origin gate).
-  return { wss: wss.trim(), http, secret, frontendHttp: '' }
+  return { wss: wss.trim(), http, secret, frontendHttp: '', httpFallback }
 }
 
 /**
@@ -436,6 +472,7 @@ export async function collectL1Rpc(nodeType, network = 'testnet') {
     // Optional separate URL for the browser bundle. Falls back to
     // l1RpcUrlHttp at write time when blank.
     l1RpcUrlHttpFrontend: l1.frontendHttp || '',
+    l1RpcUrlHttpFallback: l1.httpFallback || '',
   }
 
   // Mainnet price feeds — only validators need this (CAW/ETH price for tip
@@ -599,6 +636,7 @@ export async function collectL2Rpc(nodeType, storageChainLabel, network = 'testn
     l2RpcUrlHttp: l2.http,
     l2RpcSecret: l2.secret || '',
     l2RpcUrlHttpFrontend: l2.frontendHttp || '',
+    l2RpcUrlHttpFallback: l2.httpFallback || '',
   }
 }
 

--- a/client/src/api/routes/rpc-proxy.ts
+++ b/client/src/api/routes/rpc-proxy.ts
@@ -367,10 +367,22 @@ async function forwardToOneUpstream(url: string, auth: string | null, body: any)
  * (L1_RPC_URL_HTTP_FALLBACK / L2_RPC_URL_HTTP_FALLBACK — see rpcProvider.ts
  * getL1HttpRpcUrls/getL2HttpRpcUrls). Tries each upstream in order (primary
  * first); each already gets its own one-shot retry via
- * forwardToOneUpstream(), so a single flaky upstream costs at most one
- * extra ~200ms round trip before we move to the next one. Only the LAST
- * upstream's error is returned if all of them fail — earlier failures are
- * logged so an operator can see which upstream is degrading.
+ * forwardToOneUpstream(). Only the LAST upstream's error is returned if
+ * all of them fail — earlier failures are logged so an operator can see
+ * which upstream is degrading.
+ *
+ * Cost of moving to the next upstream depends on how the current one
+ * failed. For a fast failure (401/429, where forwardToOneUpstream's
+ * retry returns immediately) the extra cost is ~200ms — the one-shot
+ * retry's delay, and that's the whole story. It does NOT hold for a
+ * hang: UPSTREAM_TIMEOUT_MS is 8000ms and the retry runs a second full
+ * attempt, so a hanging upstream costs ~8000ms + 200ms + 8000ms ≈ 16.2s
+ * before the loop advances. With one fallback configured, a browser
+ * request can wait ~32.4s total instead of ~16.2s. Hanging is also one
+ * of the shapes a rate-limited or overloaded provider takes — not a
+ * corner case unrelated to why this exists — so this slow path isn't
+ * rare. A shorter per-upstream timeout may be worth revisiting once
+ * more than one fallback is common.
  */
 async function forwardUpstream(chain: Chain, body: any): Promise<any> {
   const upstreams = getUpstreams(chain)
@@ -382,7 +394,29 @@ async function forwardUpstream(chain: Chain, body: any): Promise<any> {
   for (let i = 0; i < upstreams.length; i++) {
     const { url, auth } = upstreams[i]
     lastResult = await forwardToOneUpstream(url, auth, body)
-    if (!lastResult?.error) return lastResult
+    // Only advance on transport-layer failure, not on a legitimate
+    // JSON-RPC error the upstream answered correctly. forwardToOneUpstream
+    // returns res.json() verbatim on res.ok, so an upstream that responds
+    // HTTP 200 with a JSON-RPC error body (execution reverted, invalid
+    // params, "query returned more than 10000 results", ...) comes back
+    // with .error set too — that's the call failing, not the upstream.
+    // eth_call reverts aren't rare here; it's most of what this proxy
+    // carries, and Multicall3 batching means one browser action can
+    // bundle several. Without this check, each of those got re-sent to
+    // every configured upstream for an identical answer.
+    //
+    // Every error forwardToOneUpstream produces itself uses code -32603
+    // (Upstream HTTP ..., Upstream timeout ..., Upstream fetch failed:
+    // ..., Upstream exhausted, RPC upstream not configured) — gating on
+    // that narrows "every error" down to "errors that look like ours."
+    // Not airtight: an upstream can legitimately return -32603 itself
+    // (it's the JSON-RPC spec's own "Internal error"), in which case this
+    // would still fall through to the fallback for a same-shaped
+    // application error. Signalling transport failure out of band instead
+    // of encoding it as a JSON-RPC error would close that gap, at the
+    // cost of a larger change.
+    const isTransportError = lastResult?.error?.code === -32603
+    if (!lastResult?.error || !isTransportError) return lastResult
     if (i < upstreams.length - 1) {
       console.warn(`[rpc-proxy] ${chain} upstream ${i + 1}/${upstreams.length} failed (${lastResult.error?.message || 'unknown'}), trying fallback`)
     }
@@ -487,7 +521,11 @@ router.post('/l1', gate, proxyRateLimit, makeHandler('l1'))
 router.post('/l2', gate, proxyRateLimit, makeHandler('l2'))
 
 // Light health probe — confirms the proxy is wired without exposing
-// upstream URLs.
+// upstream URLs. Reports whether upstreams are CONFIGURED, not whether
+// they're actually REACHABLE — this was true before fallback support
+// too (!!getL1HttpRpcUrl() and this length check mean the same thing),
+// noting it here so it isn't mistaken for a liveness check now that
+// there's more than one upstream in play.
 router.get('/health', (_req, res) => {
   const l1 = getUpstreams('l1').length > 0
   const l2 = getUpstreams('l2').length > 0

--- a/client/src/api/routes/rpc-proxy.ts
+++ b/client/src/api/routes/rpc-proxy.ts
@@ -1,8 +1,8 @@
 import { Router, Request, Response } from 'express'
 import { rateLimit } from 'express-rate-limit'
 import {
-  getL1HttpRpcUrl,
-  getL2HttpRpcUrl,
+  getL1HttpRpcUrls,
+  getL2HttpRpcUrls,
 } from '../../utils/rpcProvider'
 import { originGate } from '../middleware/originGate'
 import * as ADDR from '../../abi/addresses'
@@ -232,8 +232,7 @@ function pickTtlMs(method: string, params: unknown): number | null {
 // Upstream forwarder
 // ─────────────────────────────────────────────────────────────────
 
-function getUpstream(chain: Chain): { url: string; auth: string | null } {
-  const raw = chain === 'l1' ? getL1HttpRpcUrl() : getL2HttpRpcUrl()
+function parseUpstreamUrl(raw: string): { url: string; auth: string | null } {
   if (!raw) return { url: '', auth: null }
   // raw is like https://:SECRET@base-sepolia.infura.io/v3/PROJECTID
   // Pull the secret out and use Authorization: Basic instead.
@@ -254,6 +253,17 @@ function getUpstream(chain: Chain): { url: string; auth: string | null } {
   } catch {
     return { url: raw, auth: null }
   }
+}
+
+/**
+ * Primary + any operator-configured fallback URLs (L1_RPC_URL_HTTP_FALLBACK /
+ * L2_RPC_URL_HTTP_FALLBACK, comma-separated — see rpcProvider.ts). Always
+ * returns at least one entry when a primary is configured, possibly empty
+ * when it isn't (existing "RPC upstream not configured" behaviour).
+ */
+function getUpstreams(chain: Chain): { url: string; auth: string | null }[] {
+  const raws = chain === 'l1' ? getL1HttpRpcUrls() : getL2HttpRpcUrls()
+  return raws.map(parseUpstreamUrl).filter(u => u.url)
 }
 
 /**
@@ -293,11 +303,14 @@ function jsonRpcError(id: any, code: number, message: string): any {
   return { jsonrpc: '2.0', id: id ?? null, error: { code, message } }
 }
 
-async function forwardUpstream(chain: Chain, body: any): Promise<any> {
-  const { url, auth } = getUpstream(chain)
-  if (!url) {
-    return jsonRpcError((body as any)?.id, -32603, 'RPC upstream not configured')
-  }
+/**
+ * Single-upstream forward with a one-shot retry on transient failures
+ * (timeout / network error / 5xx / burst-throttle 401/429). Unchanged from
+ * the original single-URL implementation — just parameterized on which
+ * upstream to hit, so forwardUpstream() (below) can loop it across
+ * primary + fallback.
+ */
+async function forwardToOneUpstream(url: string, auth: string | null, body: any): Promise<any> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (auth) headers.Authorization = auth
 
@@ -346,7 +359,35 @@ async function forwardUpstream(chain: Chain, body: any): Promise<any> {
     }
   }
   // Unreachable, but TS wants a return.
-  return jsonRpcError((body as any)?.id, -32603, 'RPC upstream exhausted')
+  return jsonRpcError((body as any)?.id, -32603, 'Upstream exhausted')
+}
+
+/**
+ * Forward across primary + any configured fallback upstreams
+ * (L1_RPC_URL_HTTP_FALLBACK / L2_RPC_URL_HTTP_FALLBACK — see rpcProvider.ts
+ * getL1HttpRpcUrls/getL2HttpRpcUrls). Tries each upstream in order (primary
+ * first); each already gets its own one-shot retry via
+ * forwardToOneUpstream(), so a single flaky upstream costs at most one
+ * extra ~200ms round trip before we move to the next one. Only the LAST
+ * upstream's error is returned if all of them fail — earlier failures are
+ * logged so an operator can see which upstream is degrading.
+ */
+async function forwardUpstream(chain: Chain, body: any): Promise<any> {
+  const upstreams = getUpstreams(chain)
+  if (upstreams.length === 0) {
+    return jsonRpcError((body as any)?.id, -32603, 'RPC upstream not configured')
+  }
+
+  let lastResult: any = null
+  for (let i = 0; i < upstreams.length; i++) {
+    const { url, auth } = upstreams[i]
+    lastResult = await forwardToOneUpstream(url, auth, body)
+    if (!lastResult?.error) return lastResult
+    if (i < upstreams.length - 1) {
+      console.warn(`[rpc-proxy] ${chain} upstream ${i + 1}/${upstreams.length} failed (${lastResult.error?.message || 'unknown'}), trying fallback`)
+    }
+  }
+  return lastResult
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -448,8 +489,8 @@ router.post('/l2', gate, proxyRateLimit, makeHandler('l2'))
 // Light health probe — confirms the proxy is wired without exposing
 // upstream URLs.
 router.get('/health', (_req, res) => {
-  const l1 = !!getL1HttpRpcUrl()
-  const l2 = !!getL2HttpRpcUrl()
+  const l1 = getUpstreams('l1').length > 0
+  const l2 = getUpstreams('l2').length > 0
   res.json({ l1: l1 ? 'configured' : 'missing', l2: l2 ? 'configured' : 'missing' })
 })
 


### PR DESCRIPTION
# RPC Fallback Support — wire up the existing FallbackProvider (CLI + rpc-proxy)

## Context

`PROJECT_BACKLOG.md` lists **"RPC fallback support (primary + secondary)"** as an open item, describing backend services as reading a single URL from env with no failover.

While looking into this, I found that `client/src/utils/rpcProvider.ts` already has this built:

- `makeFallbackJsonRpcProvider()` — ethers `FallbackProvider`, quorum 1
- `getL1HttpRpcUrls()` / `getL2HttpRpcUrls()` — reads `L1_RPC_URL_HTTP_FALLBACK` / `L2_RPC_URL_HTTP_FALLBACK`
- `makeResilientHttpProvider()` — verify-before-promote self-healing (per the 2026-07-11 audit comment)

The backlog description appears to predate that work.

**What's actually missing is the wiring to reach it:**

1. The CLI (`cli/src/steps/rpcUrls.js`) only ever asks for one URL — no prompt exists for a fallback.
2. The frontend's RPC proxy (`client/src/api/routes/rpc-proxy.ts`), which serves all browser-side reads via `/api/rpc/l1` + `/api/rpc/l2`, calls the single-URL `getL1HttpRpcUrl()` / `getL2HttpRpcUrl()` — it doesn't touch the fallback machinery at all, even when an operator has set the env vars by hand.

This PR wires both up. **No changes to `rpcProvider.ts` itself** — the existing implementation is used as-is.

## Changes

- **`cli/src/steps/rpcUrls.js`**
  After the existing public-RPC warning, offers an optional fallback URL prompt (defaults to "yes" when the primary itself looked like a public RPC — that's exactly the case the resilience machinery exists for). Returns `httpFallback` alongside the existing fields.

- **`cli/src/steps/generate.js`**
  Writes `L1_RPC_URL_HTTP_FALLBACK` / `L2_RPC_URL_HTTP_FALLBACK` to `.env` when the operator provided one, following the same pattern as the existing `L1_RPC_URL_HTTP` write.

- **`client/src/api/routes/rpc-proxy.ts`**
  `getUpstream()` → `getUpstreams()` (reads the plural `getL1HttpRpcUrls()` / `getL2HttpRpcUrls()`). `forwardUpstream()` now loops primary → fallback → ..., trying each in order; the existing per-URL timeout + one-shot-retry logic (`forwardToOneUpstream`) is unchanged. `/health` reports based on the resolved upstream list.

## Effect

If the primary RPC goes down or hits a rate limit, both the backend services (already covered by existing `rpcProvider.ts` callers) and the frontend proxy now fail over to the configured fallback automatically, instead of the frontend proxy failing every read until the primary recovers.

Nothing changes for operators who don't set a fallback URL — it's opt-in, and the existing single-URL behavior is the default.

## Testing

**1. Live network test** (primary pointed at a dead port, fallback set to a real public RPC):

```
[test] upstream 1/2 failed (Upstream fetch failed: fetch failed), trying fallback
Result: { jsonrpc: '2.0', result: '0xaa36a7', id: 1 }
PASS: fallback worked, got correct chainId
```

**2. End-to-end CLI prompt test** (`collectL1Rpc()` with mocked `inquirer` answers), confirming the new prompt fires correctly and the fallback URL makes it all the way through to the returned config object:

```
[mock prompt] addFallback (type=confirm) -> true
[mock prompt] fallbackInput (type=input) -> "https://1rpc.io/sepolia"
  (Fallback is also a public RPC — fine as a second line of defense, but consider a paid provider for at least one of the two.)
...
l1RpcUrlHttpFallback: https://1rpc.io/sepolia
PASS: fallback correctly captured in result
```

**3. Confirmed `generate.js`'s env-writing logic** produces the expected `L1_RPC_URL_HTTP_FALLBACK` / `L2_RPC_URL_HTTP_FALLBACK` entries from that config.

`getL1HttpRpcUrls()` / `getL2HttpRpcUrls()` correctly return `[primary, fallback]` when the env var is set, `[primary]` when it isn't (unchanged behavior).

All three changed files pass syntax checks; testing was done against a fork checkout, not against a live node — happy to test further if useful.

---

zinsanjp
