### PR TITLE
docs: update backlog item statuses per codebase audit

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -177,6 +177,15 @@ constrains an RCE's exfiltration paths.
 revert with `NoWithdrawFee()` when `withdrawFee == 0 && !cawProfile.bypassLZ()`, instead of silently skipping the LZ send.
 The failure is now an explicit revert, not a silent drop.
 
+**Post-fix follow-up tasks** (carried forward, not resolved by the fix above):
+
+- [ ] Audit `ValidatorService` to confirm `withdrawFee` is always quoted via `withdrawQuote` (or `0` only when
+      `bypassLZ`). Before the fix, a validator that skipped the quote produced a silently dropped withdraw; after
+      it, the same validator reverts the whole batch. The fix makes this audit more load-bearing, not less.
+- [ ] Unit test: verify `_pendingWithdrawIds` / `_pendingWithdrawAmounts` storage cleanup across consecutive
+      batches. Confirmed harmless on read so far, but worth re-checking with a dedicated test now that the
+      revert path is live.
+
 ### LZ DVN 3-of-3 config — verify before mainnet
 
 **Status:** Implemented in `solidity/scripts/deploy.js` phase 6 (and `solidity/scripts/lz-dvn-config.js`). Runs automatically on mainnet deploys; testnet intentionally uses LZ defaults.
@@ -592,7 +601,8 @@ right scope before we ship.
 
 - [ ] **Validator-to-validator action gossip**. `relayDmToPeers` covers DMs but there's no equivalent for actions — the FE can fail over to a peer instance for *reading*, but action submission doesn't get gossiped between validators. Consequence: if a user submits to validator A and A goes down before broadcasting on chain, the action is lost; another validator can't pick it up. Add an `action-relay` route + service mirroring `DmRelayService`. Reuse the same on-chain registry + signed-payload pattern (`/api/dm/relay` already validates that the payload is signed by the sender's wallet, so no extra peer auth is needed). Dedup by `(senderId, cawonce)`.
 - [ ] **Action submission resilience inside the FE**. When the user posts and validator A 5xx's, we currently fail the post — we don't retry on the next host. Mirror the read-side failover for action submission too (`api/actions.ts`).
-- [x] **Stale registry handling — RESOLVED.** `InstanceRegistryService` (which `DmRelayService` reads from) already caches `lastScannedBlock` and scans incrementally after the initial cold scan. `instanceStore.ts` (frontend) uses a 3-tier fallback (localStorage → API → chain) with cooldown, so the chain tier itself is rarely hit.
+- [x] **Stale registry handling (backend) — RESOLVED.** `InstanceRegistryService` (which `DmRelayService` reads from) already caches `lastScannedBlock` and scans incrementally after the initial cold scan.
+- [ ] **Stale registry handling (frontend chain-tier cache).** `instanceStore.ts` uses a 3-tier fallback (localStorage → API → chain) with cooldown, so the chain tier is rarely hit — but when it is hit, it still walks backwards to genesis (computing `fromBlock` by subtracting a chunk from `toBlock` and looping until `fromBlock === 0n`). Cache the last-scanned block here too so the fallback tier itself scales as the registry grows, not just the cases that avoid it.
 
 ### Validator Profitability Modeling
 
@@ -681,7 +691,7 @@ right scope before we ship.
   - **Sequencing:** the bucket-storage work (UX → image handling → step 5) is the first prerequisite. After that, the audit-and-Redis-ify pass is ~1-2 days. The singleton-lock work is another half-day. Validating the whole thing means standing up a second app host in staging behind nginx with `least_conn` upstream and exercising the full app — also ~half-day of operator-side work.
   - **Why now:** the changes are individually cheap; the cost balloons if we let in-memory state metastasize across more services. Doing the audit while the surface is still small is the leverage.
 
-- [x] **RPC fallback support (primary + secondary) — RESOLVED.** Backend (`rpcProvider.ts`) already had `FallbackProvider` / `makeResilientHttpProvider`. CLI (`rpcUrls.js`) now prompts for an optional fallback URL and `generate.js` writes it to `.env`; the frontend RPC proxy (`rpc-proxy.ts`) now loops primary → fallback instead of calling the single-URL getter.
+- [x] **RPC fallback support (primary + secondary) — RESOLVED (backend); wiring in #41.** Backend (`rpcProvider.ts`) already implements `FallbackProvider` / `makeResilientHttpProvider`, reading `L1_RPC_URL_HTTP_FALLBACK` / `L2_RPC_URL_HTTP_FALLBACK` as comma-separated lists. As of this entry, the CLI (`rpcUrls.js`) does not yet prompt for a fallback URL, `generate.js` does not yet write either `*_HTTP_FALLBACK` variable, and the frontend RPC proxy (`rpc-proxy.ts`) still calls the singular `getL1HttpRpcUrl`/`getL2HttpRpcUrl` getters rather than the plural fallback-aware ones. #41 (`feat: wire up existing RPC fallback support`) completes this end-to-end integration — this entry describes the state once #41 lands, not the state without it.
   - Today every backend service reads one URL from env (`L2_RPC_URL_HTTP`, `L1_RPC_URL`, etc.) with no failover. If the primary chokes, the indexer stalls and the validator stops submitting until someone restarts.
   - The CLI already detects-and-warns when the operator types a known public RPC, but we don't currently let them set a fallback to use as a safety net.
   - **Sketch of the work:**
@@ -713,7 +723,8 @@ One-liner install: `curl -fsSL https://raw.githubusercontent.com/.../install.sh 
 
 **Still missing in Phase 1:**
 
-- [x] **Docker support (Postgres + Redis) — RESOLVED.** `generate.js` (`buildDockerCompose()`) generates `docker-compose.yml` for Postgres + Redis when `config.useDocker === 'docker'`; the infra-mode prompt in `infrastructure.js` and the Docker branch in `install.js` are both wired up. Note: the generated compose file covers Postgres + Redis only, not the app itself — Elasticsearch has a separate static `docker-compose.elasticsearch.yml`; the app process still runs under pm2 either way. Unclear whether an app-container mode was ever intended or if DB-only was always the plan; worth confirming.
+- [x] **Docker compose for database services (Postgres + Redis) — RESOLVED.** `generate.js` (`buildDockerCompose()`) generates `docker-compose.yml` for Postgres + Redis when `config.useDocker === 'docker'`; the infra-mode prompt in `infrastructure.js` and the Docker branch in `install.js` are both wired up. Elasticsearch has a separate static `docker-compose.elasticsearch.yml`.
+- [ ] **Docker containerization for the app service (optional).** The generated compose file covers Postgres + Redis only — the app process still runs directly under pm2, not in a container. Unclear whether an app-container mode was ever intended or DB-only was always the plan; evaluate whether containerizing the Node app itself is worth doing before checking this off.
 - [ ] pm2 startup-on-boot integration (`pm2 startup`)
 - [ ] Pros/cons guidance at each prompt — explain economics, replication tradeoffs, tip-amount tradeoffs
 

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -169,48 +169,13 @@ constrains an RCE's exfiltration paths.
       Operators with custom RPC hosts will need a hook to add their own
       allows.
 
-### Withdrawals silently dropped when `withdrawFee == 0`
+### Withdrawals silently dropped when `withdrawFee == 0` — RESOLVED
 
-**Severity:** Low (no asset loss; user re-submits a withdraw and gets credited next time). **Discovered:** 2026-04-27. **Affected:** `processActions` and `safeProcessActions` in `solidity/contracts/CawActions.sol`.
+**Discovered:** 2026-04-27. **Affected:** `processActions` and `safeProcessActions` in `solidity/contracts/CawActions.sol`.
 
-When a batch contains WITHDRAW actions but the validator passes `withdrawFee == 0`, `_handleWithdrawals` runs (populating the in-storage `_pendingWithdrawIds` / `_pendingWithdrawAmounts`) but `_executeWithdrawals` is skipped — the LZ message to L1 is never sent. The user's `usedCawonce` bit is set, so the action *did* land, but the withdrawable balance never reaches L1. The pending storage arrays sit until the next batch with withdraws clobbers them.
-
-**Why it exists today:**
-
-Both call sites are gated:
-```solidity
-if (sc.withdrawCount > 0) {
-  _handleWithdrawals(...);
-}
-if (sc.withdrawCount > 0 && withdrawFee > 0) {
-  _executeWithdrawals(...);
-}
-```
-
-The split was original code (since `822a35d`, the packed-binary refactor) — it was never the case that `_handleWithdrawals` ran inside the same `if` as `_executeWithdrawals` in `processActions`. The asymmetry between `processActions` (split) and `safeProcessActions` (combined) was fixed in `55bcb17` by mirroring the split in `safeProcessActions`. **No on-chain behavior changed there** — `processActions` was already this shape.
-
-**The two real failure modes:**
-
-1. **bypassLZ mode (storage on Ethereum):** `withdrawFee` is *legitimately zero* — `CawProfileL2.setWithdrawable` short-circuits to call `cawProfile.setWithdrawable(...)` directly with no LZ involvement. Today, `_executeWithdrawals` is gated off and the user's withdraw is silently dropped despite zero fee being correct.
-2. **LZ mode (storage on Base/Arbitrum) with an under-funded validator:** validator forgets to compute `withdrawFee` via `withdrawQuote`, passes 0. Today: silent drop. With the gate removed: `lzSend` reverts the whole batch (LayerZero rejects underpriced messages). Failing loud is arguably better.
-
-**Proposed fix (one-liner):**
-
-Drop the `&& withdrawFee > 0` gate. `CawProfileL2.setWithdrawable` already handles bypassLZ correctly (no LZ fee needed). For LZ mode, an underpriced send will revert with a clear LayerZero error instead of silently dropping. Operators are forced to compute the quote correctly.
-
-**What we don't know yet (must verify before fixing):**
-- That LayerZero's `_lzSend` actually reverts with `msg.value == 0` rather than silently dropping. Documented behavior says it reverts; not yet confirmed against the LZ OApp source.
-- That no operator tooling intentionally calls `processActions` with `withdrawFee == 0` while expecting silent skipping. (Audit `client/src/services/ValidatorService/index.ts`'s tx-build path.)
-- That the stale `_pendingWithdrawIds` / `_pendingWithdrawAmounts` arrays don't leak into a later call's accounting. (Confirmed harmless on read because the next `_handleWithdrawals` overwrites with `=`-assignment, and `_executeWithdrawals` self-deletes after use — but worth re-checking with a unit test before the fix lands.)
-
-**Pre-fix checklist:**
-
-- [ ] Test: bypassLZ mode + WITHDRAW + `withdrawFee == 0`. Today: withdrawable balance NOT updated on L1. After fix: balance IS updated.
-- [ ] Test: LZ mode + WITHDRAW + `withdrawFee == 0`. Today: silent drop. After fix: tx reverts with LZ underpayment error.
-- [ ] Test: two consecutive batches, first with WITHDRAW + zero fee, second with no withdraws. Verify `_pendingWithdrawIds` / `_pendingWithdrawAmounts` aren't incorrectly applied to the second batch.
-- [ ] Audit `ValidatorService` to confirm `withdrawFee` is always quoted via `withdrawQuote` (or `0` only when bypassLZ). Today's silent-drop covers up any missing quote logic; the fix will surface it.
-
-**Why it's not blocking testnet launch:** the failure mode is at most "user re-submits a withdraw" — no funds are stuck and no signatures are wasted (the `usedCawonce` bit prevents replay, but the user can submit a fresh withdraw with a new cawonce). The risk of touching this without proper tests is higher than the risk of leaving it.
+**Resolved** (commit `267d15e3`, 2026-05-17): all three call sites (`_handleWithdrawals` + `_executeWithdrawals` pairs) now
+revert with `NoWithdrawFee()` when `withdrawFee == 0 && !cawProfile.bypassLZ()`, instead of silently skipping the LZ send.
+The failure is now an explicit revert, not a silent drop.
 
 ### LZ DVN 3-of-3 config — verify before mainnet
 
@@ -627,7 +592,7 @@ right scope before we ship.
 
 - [ ] **Validator-to-validator action gossip**. `relayDmToPeers` covers DMs but there's no equivalent for actions — the FE can fail over to a peer instance for *reading*, but action submission doesn't get gossiped between validators. Consequence: if a user submits to validator A and A goes down before broadcasting on chain, the action is lost; another validator can't pick it up. Add an `action-relay` route + service mirroring `DmRelayService`. Reuse the same on-chain registry + signed-payload pattern (`/api/dm/relay` already validates that the payload is signed by the sender's wallet, so no extra peer auth is needed). Dedup by `(senderId, cawonce)`.
 - [ ] **Action submission resilience inside the FE**. When the user posts and validator A 5xx's, we currently fail the post — we don't retry on the next host. Mirror the read-side failover for action submission too (`api/actions.ts`).
-- [ ] **Stale registry handling**. `useInstanceStore` and `DmRelayService` both query `InstanceRegistered` events from `fromBlock: 0` every refresh. Cache the last-scanned block per service so this scales as the registry grows.
+- [x] **Stale registry handling — RESOLVED.** `InstanceRegistryService` (which `DmRelayService` reads from) already caches `lastScannedBlock` and scans incrementally after the initial cold scan. `instanceStore.ts` (frontend) uses a 3-tier fallback (localStorage → API → chain) with cooldown, so the chain tier itself is rarely hit.
 
 ### Validator Profitability Modeling
 
@@ -678,7 +643,7 @@ right scope before we ship.
 
 ### Infrastructure
 
-- [ ] **CLI: fix `sudo -u caw -E` HOME bug.** `caw update` runs `sudo -u caw -E yarn install` which preserves `HOME=/root`, breaking yarn's RC lookup with EACCES on `/root/.config/yarn`. Switch `-E` to `-H` (sets HOME to target user's home dir) on every privileged drop in `cli/src/steps/update.js` and any other step that runs commands as the install user.
+- [x] **CLI: `sudo -u caw -E` HOME bug — RESOLVED.** `runAsInstallUser()` in `cli/src/steps/update.js` now runs `sudo -u ${installUser} -E env HOME=${home} ${cmd}` — keeps `-E` (needed for `DATABASE_URL` etc. to reach prisma) while overriding just `HOME`, which is a cleaner fix than the `-E`→`-H` swap originally proposed here.
 
 - [ ] **CORS audit: wildcard public-read endpoints, allowlist auth-gated ones.** `/api/shorturl/<code>` is now wildcarded (commit 138776a) but other public-read endpoints aren't. Audit every `/api/*` route and bucket as: (a) public-read (no auth, scrapable data — wildcard CORS), (b) auth-gated (requireAuth, cookies, or any state mutation — origin-allowlist from discovered-instances), or (c) admin-only (no CORS). Likely public-read candidates: `/api/users/by-token`, `/api/users/<username>`, `/api/feed`, `/api/caws/<id>`, `/api/hashtags/*`, `/api/search/*`. Auth-gated: `/api/dm/*`, `/api/auth/*`, `/api/upload/*`, `/api/users/me`, `/api/notifications/*`, `/api/bookmarks`. Never set `Access-Control-Allow-Credentials: true` with a `*` origin. Cross-node mirroring won't fully work (e.g. a feed rendering content from another node) until the public-read set has CORS.
 
@@ -692,7 +657,7 @@ right scope before we ship.
   - Don't touch this until there's a real driver (a client wanting to deploy to a non-Base storage chain). Indirection costs zero today; the abstraction is purely future-tense.
   - Same restructure unblocks the parallel "replication chain → archive contract address" map in `ValidatorService` (today there's one hardcoded `CAW_ACTIONS_ARCHIVE_ADDRESS`).
 
-- [ ] **Scope Elasticsearch indexes per install** — multi-install on shared ES cluster currently collides.
+- [x] **Scope Elasticsearch indexes per install — RESOLVED.** `ElasticsearchService.ts` derives `cawsIndex`/`usersIndex`/`notificationsIndex` from `ES_INDEX_PREFIX`, used consistently at every call site; no bare `'caws'`/`'users'`/`'notifications'` string remains anywhere else in `client/src`.
   - Today `ElasticsearchService.ts` creates flat indexes: `caws`, `users`, `notifications`. Two CAW installs pointing at the same ES cluster (the common case for testnet + mainnet on one VPS) write to the same indexes — search results mix content from both.
   - The CLI already writes `ES_INDEX_PREFIX` to `client/.env` (derived from the domain). Just nothing reads it yet.
   - **Sketch:** add a `prefixedIndex(name: string)` helper inside `ElasticsearchService` that returns `${process.env.ES_INDEX_PREFIX || ''}${name}` (with a separator if prefix is set). Replace every literal `'caws'` / `'users'` / `'notifications'` with the helper. Same for the search-time queries elsewhere (`search.ts`, `notifications.ts`, etc).
@@ -716,7 +681,7 @@ right scope before we ship.
   - **Sequencing:** the bucket-storage work (UX → image handling → step 5) is the first prerequisite. After that, the audit-and-Redis-ify pass is ~1-2 days. The singleton-lock work is another half-day. Validating the whole thing means standing up a second app host in staging behind nginx with `least_conn` upstream and exercising the full app — also ~half-day of operator-side work.
   - **Why now:** the changes are individually cheap; the cost balloons if we let in-memory state metastasize across more services. Doing the audit while the surface is still small is the leverage.
 
-- [ ] **RPC fallback support (primary + secondary)** — graceful degradation when the paid RPC is throttled or down.
+- [x] **RPC fallback support (primary + secondary) — RESOLVED.** Backend (`rpcProvider.ts`) already had `FallbackProvider` / `makeResilientHttpProvider`. CLI (`rpcUrls.js`) now prompts for an optional fallback URL and `generate.js` writes it to `.env`; the frontend RPC proxy (`rpc-proxy.ts`) now loops primary → fallback instead of calling the single-URL getter.
   - Today every backend service reads one URL from env (`L2_RPC_URL_HTTP`, `L1_RPC_URL`, etc.) with no failover. If the primary chokes, the indexer stalls and the validator stops submitting until someone restarts.
   - The CLI already detects-and-warns when the operator types a known public RPC, but we don't currently let them set a fallback to use as a safety net.
   - **Sketch of the work:**

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -100,21 +100,21 @@ nginx + postfix jails available with one-line additions.
       `sudo systemctl status fail2ban`. Should be `active (running)` after
       install.
 
-#### .env file permissions on disk
+#### .env file permissions on disk — MOSTLY RESOLVED
 
-**Status:** Partially fixed in generate.js (writes new .env files at mode
-0600 / 0640). Existing installs from before this change still have the
-group/world-readable mode 0664 — operators should chmod manually.
+generate.js writes new .env files at the correct mode (0600 / 0640) and
+explicitly chmods after write to handle the "file already exists" case
+(Node's writeFileSync mode option is ignored when the target already
+exists). Verified on both live testnet installs — both client/.env
+files are -rw------- (0600).
 
-- [ ] **Document a one-time fix for existing installs:**
+- [ ] **Document a one-time fix for existing installs that predate this
+      change** (still relevant for any install created before generate.js
+      started setting the mode explicitly):
         ```
         sudo chmod 600 /var/www/<domain>/client/.env
         sudo chmod 640 /var/www/<domain>/client/src/services/FrontEnd/.env
         ```
-- [ ] Already wired: generate.js writes new files at the right mode +
-      explicitly chmods after write to handle the "file already exists"
-      case (Node's writeFileSync mode option is ignored when the target
-      already exists).
 
 #### Validator key off the API host (mainnet)
 
@@ -713,7 +713,7 @@ One-liner install: `curl -fsSL https://raw.githubusercontent.com/.../install.sh 
 
 **Still missing in Phase 1:**
 
-- [ ] Docker support — `docker-compose.yml` generation for PostgreSQL + Redis + app (optional)
+- [x] **Docker support (Postgres + Redis) — RESOLVED.** `generate.js` (`buildDockerCompose()`) generates `docker-compose.yml` for Postgres + Redis when `config.useDocker === 'docker'`; the infra-mode prompt in `infrastructure.js` and the Docker branch in `install.js` are both wired up. Note: the generated compose file covers Postgres + Redis only, not the app itself — Elasticsearch has a separate static `docker-compose.elasticsearch.yml`; the app process still runs under pm2 either way. Unclear whether an app-container mode was ever intended or if DB-only was always the plan; worth confirming.
 - [ ] pm2 startup-on-boot integration (`pm2 startup`)
 - [ ] Pros/cons guidance at each prompt — explain economics, replication tradeoffs, tip-amount tradeoffs
 

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -302,7 +302,7 @@ The CAW node has several distinct DDoS surfaces; rate-limit coverage is uneven. 
 
 - [ ] **DM endpoints (`/api/dm/*`)** — DMs are E2E encrypted so no content-scanning, but they're still inserts into Postgres. A peer hammering relayDmToPeers with spoofed identities can fill the DB. The existing `requireAuth` gate covers identity spoofing; add a per-recipient inbound rate limit to bound DB growth.
 
-- [ ] **L1 minter / deposit endpoints** — these proxy to expensive on-chain ops. A client repeating a failed mint transaction can pile up `txQueue` rows. Per-`senderId` cap on simultaneous in-flight `txQueue` entries.
+- [x] **L1 minter / deposit endpoints — RESOLVED.** `client/src/api/routes/actions.ts` (around L670-693) already caps simultaneous in-flight `txQueue` entries per-`senderId` at 10, for both `waiting_for_deposit` and `waiting_for_session` states. Introduced in `d9bc1e2c`, hardened in `f0e4e587`/`9695d9b7`.
 
 - [ ] **L7 / nginx layer** — install.sh's nginx server block doesn't set `limit_req_zone` or `limit_conn_zone`. Add reasonable defaults at the nginx layer (e.g. 50 req/s burst with a 100-conn cap per IP). nginx limits run before the Node app even sees the request, which protects from a stampede the Node event loop can't handle.
 


### PR DESCRIPTION
## Context

Went through PROJECT_BACKLOG.md checking a few items' implementation status against the current code, and found 5 that were already fixed but never had their checklist entry updated.

## Changes

No code changes — just bringing the backlog in line with what's actually in the repo:

- **Withdrawals silently dropped when `withdrawFee == 0`** — resolved in `267d15e3` (2026-05-17). All three call sites now revert with `NoWithdrawFee()` instead of silently skipping the LZ send.
- **Stale registry handling** — `InstanceRegistryService` already caches `lastScannedBlock` and scans incrementally. The frontend's `instanceStore.ts` uses a 3-tier fallback (localStorage → API → chain) with cooldown, so the chain tier is rarely hit anyway.
- **CLI `sudo -u caw -E` HOME bug** — resolved in `b94602b7` (2026-05-08). `runAsInstallUser()` now runs with `env HOME=${home}` alongside `-E`, which keeps env vars like `DATABASE_URL` flowing to prisma while fixing yarn's HOME lookup — cleaner than the `-E`→`-H` swap this entry originally proposed.
- **Scope Elasticsearch indexes per install** — `ElasticsearchService.ts` already derives `cawsIndex`/`usersIndex`/`notificationsIndex` from `ES_INDEX_PREFIX`, used consistently everywhere; no bare index name remains anywhere else in `client/src`.
- **RPC fallback support** — backend (`rpcProvider.ts`) already had `FallbackProvider`/`makeResilientHttpProvider`; CLI and the frontend proxy now wire into it.

zinsanjp