### PR TITLE
feat: add rate limiting to /api/actions

### DIFF
--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -363,6 +363,21 @@ export function createApp() {
   // covered automatically. Audit fix 2026-05-23 (fe-headers H-3).
   app.use('/api/auth', (_req, res, next) => { res.set('Cache-Control', 'no-store'); next() })
   app.use('/api/auth', authRouter)
+  // Actions: per-IP rate limit to stop rapid-fire signature-flooding.
+  // /api/actions has no session/auth gate (auth is per-request EIP-712
+  // signature verification downstream), so hasValidSession-style skip
+  // logic (used on /api/upload) doesn't apply here — everything is
+  // treated the same and rate-limited per IP.
+  // Default is a rough first line of defense; tune via
+  // ACTIONS_RATE_LIMIT_PER_MIN once there's real traffic data — this
+  // has not been load-tested against production throughput.
+  app.use('/api/actions', rateLimit({
+    windowMs: 60 * 1000,
+    max: parseInt(process.env.ACTIONS_RATE_LIMIT_PER_MIN || '60', 10),
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many action submissions. Please slow down.' },
+  }))
   app.use('/api/actions', actionsRouter)
   app.use('/api/caws', cawRouter)
   app.use('/api/txs',  txRouter)

--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -371,6 +371,14 @@ export function createApp() {
   // Default is a rough first line of defense; tune via
   // ACTIONS_RATE_LIMIT_PER_MIN once there's real traffic data — this
   // has not been load-tested against production throughput.
+  //
+  // This counts REQUESTS, not actions. /api/actions/batch (below,
+  // actions.ts ~L1715) accepts up to 64 actions per call, so the
+  // effective ceiling on submitted actions is ACTIONS_RATE_LIMIT_PER_MIN
+  // * 64 — ~3,840/min at the default, not 60/min. An operator planning
+  // around a specific actions/min figure should account for this
+  // multiplier; a single-action request and a 64-action batch request
+  // cost the limiter the same.
   app.use('/api/actions', rateLimit({
     windowMs: 60 * 1000,
     max: parseInt(process.env.ACTIONS_RATE_LIMIT_PER_MIN || '60', 10),


### PR DESCRIPTION
# Add rate limiting to /api/actions

## Context

`PROJECT_BACKLOG.md`'s DDoS protection section flags `/api/actions` as the hottest unprotected surface — every accepted action costs the validator gas, and unlike `unlike`/`unfollow` (covered by `checkFreeActionRate`), paid actions (`caw`, `like`, `recaw`, `follow`) have no per-request rate limit at the route level. This adds one.

## Changes

- **`client/src/api/server.ts`**: added an `express-rate-limit` middleware on `/api/actions`, mounted before `actionsRouter`.

`/api/actions` has no session/auth gate of its own (auth happens per-request via EIP-712 signature verification downstream), so the `hasValidSession`-based skip logic used on `/api/upload` doesn't apply here — every request is rate-limited per IP the same way.

Default is `60` requests/minute, overridable via `ACTIONS_RATE_LIMIT_PER_MIN` in `.env` — no code change needed to tune it once there's real traffic data to work from.

**I haven't validated 60/min against actual production throughput or infra headroom** — I don't have visibility into validator processing capacity or current DB/Redis load margins, so I can't say whether that's the right number. Treat it as a starting point; happy to adjust or make it more granular (e.g. per-`senderId`, tiered by stake — noted as a stretch goal in the backlog) if useful.

One thing worth flagging: this limits per-IP, so any legitimate high-frequency automated actor sharing one IP (a seeding script, a future bot service relaying multiple users' posts, etc.) would also get capped. `ACTIONS_RATE_LIMIT_PER_MIN` covers that without a code change if it comes up.

## Testing

Verified with a standalone Express app hitting the exact same middleware config: 65 requests in a tight loop against `/api/actions` returned 60× `200` and 5× `429`, matching the configured limit exactly.

```
Success: 60, Blocked (429): 5
PASS
```

Syntax-checked with esbuild; not tested against a live node.

---

zinsanjp
