### PR TITLE
feat: add per-recipient inbound rate limit to /api/dm/relay

### DIFF
--- a/client/src/api/dmRateLimit.ts
+++ b/client/src/api/dmRateLimit.ts
@@ -46,8 +46,8 @@ const WINDOW_SECONDS = 60 * 60
 // real usage, just checked against the other limiter so they're not
 // flatly contradictory.
 //
-// Correction (found in review of #45 by tentencaw): "room for ~5
-// concurrent warm senders" overstated the precision of that comparison.
+// Correction: "room for ~5 concurrent warm senders" overstated the
+// precision of that comparison.
 // KEY_WARM is scoped per-(senderId, recipientId) and only enforced by
 // the sender's home node; KEY_INBOUND_RELAY is scoped per-recipientId
 // and aggregates across every source instance relaying to them. Warm
@@ -67,8 +67,8 @@ const KEY_INBOUND_RELAY = (recipientId: number) => `caw:dm:rate:relay-inbound:${
  * Read-only check — does NOT increment. Safe to call before the request
  * is authenticated: cheap (single Redis GET, no write), so it can't be
  * used to cheaply exhaust a target recipient's budget the way calling
- * checkInboundRelayRate() pre-auth could (found in review of #45 by
- * tentencaw — an attacker who never bothers signing correctly could
+ * checkInboundRelayRate() pre-auth could — an attacker who never
+ * bothers signing correctly could
  * still burn through a victim's hourly budget with junk requests, since
  * the increment happened before signature verification rejected them).
  * Callers should peek before doing expensive work, then call
@@ -88,8 +88,7 @@ export async function peekInboundRelayRate(recipientId: number): Promise<{ allow
     return { allowed: true }
   } catch (err: any) {
     // Fail-open, matching recordInboundRelayHit() and checkDmRate()
-    // above. Logged (found lacking in review of #45 by tentencaw) so a
-    // sustained Redis outage shows up somewhere other than "the limiter
+    // above. Logged so a sustained Redis outage shows up somewhere other than "the limiter
     // silently stopped limiting" — this fires on every peek during an
     // outage, which is noisy, but the alternative (no signal at all)
     // is worse for noticing the limiter is effectively off.
@@ -105,8 +104,7 @@ export async function peekInboundRelayRate(recipientId: number): Promise<{ allow
  * re-arms the window on every call where the TTL is missing, so a prior
  * expire() failure (e.g. a Redis blip between the incr and the expire)
  * self-heals on the next hit instead of leaving the key permanently
- * unexpiring — same pattern checkDmRate() uses above. (Also found in
- * review of #45 by tentencaw.)
+ * unexpiring — same pattern checkDmRate() uses above.
  */
 export async function recordInboundRelayHit(recipientId: number): Promise<{ allowed: boolean; resetSeconds?: number }> {
   const key = KEY_INBOUND_RELAY(recipientId)

--- a/client/src/api/dmRateLimit.ts
+++ b/client/src/api/dmRateLimit.ts
@@ -42,9 +42,19 @@ const WINDOW_SECONDS = 60 * 60
 // do 100/h each (WARM_LIMIT_PER_HOUR above), so a cap much lower than a
 // small multiple of that would throttle a popular account getting
 // legitimate messages from just a handful of warm contacts. 500 leaves
-// room for ~5 concurrent warm senders at their individual ceiling before
-// this cap bites — still not validated against real usage, just checked
-// against the other limiter in this file so they're not contradictory.
+// headroom for that, in the loose sense — still not validated against
+// real usage, just checked against the other limiter so they're not
+// flatly contradictory.
+//
+// Correction (found in review of #48 by tentencaw): "room for ~5
+// concurrent warm senders" overstated the precision of that comparison.
+// KEY_WARM is scoped per-(senderId, recipientId) and only enforced by
+// the sender's home node; KEY_INBOUND_RELAY is scoped per-recipientId
+// and aggregates across every source instance relaying to them. Warm
+// senders on other instances aren't counted against this node's
+// WARM_LIMIT_PER_HOUR at all, so "5 senders at 100/h each" isn't a real
+// derivation of 500 — just a rough sanity check that 500 isn't obviously
+// too low relative to the other number in this file.
 const INBOUND_RELAY_LIMIT_PER_HOUR = Number(process.env.DM_RELAY_INBOUND_LIMIT_PER_HOUR) || 500
 const KEY_INBOUND_RELAY = (recipientId: number) => `caw:dm:rate:relay-inbound:${recipientId}`
 
@@ -76,7 +86,14 @@ export async function peekInboundRelayRate(recipientId: number): Promise<{ allow
       return { allowed: false, resetSeconds: ttl > 0 ? ttl : WINDOW_SECONDS }
     }
     return { allowed: true }
-  } catch {
+  } catch (err: any) {
+    // Fail-open, matching recordInboundRelayHit() and checkDmRate()
+    // above. Logged (found lacking in review of #48 by tentencaw) so a
+    // sustained Redis outage shows up somewhere other than "the limiter
+    // silently stopped limiting" — this fires on every peek during an
+    // outage, which is noisy, but the alternative (no signal at all)
+    // is worse for noticing the limiter is effectively off.
+    console.warn(`[DM Relay] peekInboundRelayRate failed open for recipient=${recipientId}: ${err?.message ?? err}`)
     return { allowed: true }
   }
 }
@@ -103,7 +120,8 @@ export async function recordInboundRelayHit(recipientId: number): Promise<{ allo
       return { allowed: false, resetSeconds: ttl > 0 ? ttl : WINDOW_SECONDS }
     }
     return { allowed: true }
-  } catch {
+  } catch (err: any) {
+    console.warn(`[DM Relay] recordInboundRelayHit failed open for recipient=${recipientId}: ${err?.message ?? err}`)
     return { allowed: true }
   }
 }

--- a/client/src/api/dmRateLimit.ts
+++ b/client/src/api/dmRateLimit.ts
@@ -53,15 +53,53 @@ const KEY_INBOUND_RELAY = (recipientId: number) => `caw:dm:rate:relay-inbound:${
  * on Redis errors, matching checkDmRate()'s behavior — the per-source-IP
  * cap in server.ts is the backstop if this path is unavailable.
  */
-export async function checkInboundRelayRate(recipientId: number): Promise<{ allowed: boolean; resetSeconds?: number }> {
+/**
+ * Read-only check — does NOT increment. Safe to call before the request
+ * is authenticated: cheap (single Redis GET, no write), so it can't be
+ * used to cheaply exhaust a target recipient's budget the way calling
+ * checkInboundRelayRate() pre-auth could (found in review of #48 by
+ * tentencaw — an attacker who never bothers signing correctly could
+ * still burn through a victim's hourly budget with junk requests, since
+ * the increment happened before signature verification rejected them).
+ * Callers should peek before doing expensive work, then call
+ * recordInboundRelayHit() only after the request is fully verified.
+ */
+export async function peekInboundRelayRate(recipientId: number): Promise<{ allowed: boolean; resetSeconds?: number }> {
+  const key = KEY_INBOUND_RELAY(recipientId)
+  try {
+    const [count, ttl] = await Promise.all([
+      redis.get(key),
+      redis.ttl(key),
+    ])
+    const n = count ? Number(count) : 0
+    if (n > INBOUND_RELAY_LIMIT_PER_HOUR) {
+      return { allowed: false, resetSeconds: ttl > 0 ? ttl : WINDOW_SECONDS }
+    }
+    return { allowed: true }
+  } catch {
+    return { allowed: true }
+  }
+}
+
+/**
+ * Increment-and-check the inbound relay bucket for a recipient. Call
+ * only after the request has been fully authenticated — see
+ * peekInboundRelayRate() above for why. ttl < 0 (not just count === 1)
+ * re-arms the window on every call where the TTL is missing, so a prior
+ * expire() failure (e.g. a Redis blip between the incr and the expire)
+ * self-heals on the next hit instead of leaving the key permanently
+ * unexpiring — same pattern checkDmRate() uses above. (Also found in
+ * review of #48 by tentencaw.)
+ */
+export async function recordInboundRelayHit(recipientId: number): Promise<{ allowed: boolean; resetSeconds?: number }> {
   const key = KEY_INBOUND_RELAY(recipientId)
   try {
     const count = await redis.incr(key)
-    if (count === 1) {
+    const ttl = await redis.ttl(key)
+    if (ttl < 0) {
       await redis.expire(key, WINDOW_SECONDS)
     }
     if (count > INBOUND_RELAY_LIMIT_PER_HOUR) {
-      const ttl = await redis.ttl(key)
       return { allowed: false, resetSeconds: ttl > 0 ? ttl : WINDOW_SECONDS }
     }
     return { allowed: true }

--- a/client/src/api/dmRateLimit.ts
+++ b/client/src/api/dmRateLimit.ts
@@ -27,6 +27,49 @@ const COLD_LIMIT_PER_HOUR = Number(process.env.DM_SEND_COLD_LIMIT_PER_HOUR) || 1
 const WARM_LIMIT_PER_HOUR = Number(process.env.DM_SEND_WARM_LIMIT_PER_HOUR) || 100
 const WINDOW_SECONDS = 60 * 60
 
+// Inbound relay cap, per PROJECT_BACKLOG.md's DDoS protection section:
+// "a peer hammering relayDmToPeers with spoofed identities can fill the
+// DB." checkDmRate() above is sender-side and does warm/cold DB lookups
+// (message/follow queries) — fine for a user hitting send, but wrong for
+// the receiver side of /api/dm/relay: those lookups would themselves
+// become a new load vector under a relay flood. This is deliberately
+// dumber: one Redis INCR per (recipientId), no DB reads, no warm/cold
+// distinction. It doesn't tell apart "one attacker" from "many senders
+// legitimately messaging the same popular account" — same tradeoff the
+// per-source-IP cap already makes, just on the other axis.
+//
+// 500/h, not 200/h as I first had it: sender-side warm senders alone can
+// do 100/h each (WARM_LIMIT_PER_HOUR above), so a cap much lower than a
+// small multiple of that would throttle a popular account getting
+// legitimate messages from just a handful of warm contacts. 500 leaves
+// room for ~5 concurrent warm senders at their individual ceiling before
+// this cap bites — still not validated against real usage, just checked
+// against the other limiter in this file so they're not contradictory.
+const INBOUND_RELAY_LIMIT_PER_HOUR = Number(process.env.DM_RELAY_INBOUND_LIMIT_PER_HOUR) || 500
+const KEY_INBOUND_RELAY = (recipientId: number) => `caw:dm:rate:relay-inbound:${recipientId}`
+
+/**
+ * Increment-and-check the inbound relay bucket for a recipient. Fail-open
+ * on Redis errors, matching checkDmRate()'s behavior — the per-source-IP
+ * cap in server.ts is the backstop if this path is unavailable.
+ */
+export async function checkInboundRelayRate(recipientId: number): Promise<{ allowed: boolean; resetSeconds?: number }> {
+  const key = KEY_INBOUND_RELAY(recipientId)
+  try {
+    const count = await redis.incr(key)
+    if (count === 1) {
+      await redis.expire(key, WINDOW_SECONDS)
+    }
+    if (count > INBOUND_RELAY_LIMIT_PER_HOUR) {
+      const ttl = await redis.ttl(key)
+      return { allowed: false, resetSeconds: ttl > 0 ? ttl : WINDOW_SECONDS }
+    }
+    return { allowed: true }
+  } catch {
+    return { allowed: true }
+  }
+}
+
 const KEY_COLD = (senderId: number, recipientId: number) =>
   `caw:dm:rate:cold:${senderId}:${recipientId}`
 const KEY_WARM = (senderId: number, recipientId: number) =>

--- a/client/src/api/dmRateLimit.ts
+++ b/client/src/api/dmRateLimit.ts
@@ -46,7 +46,7 @@ const WINDOW_SECONDS = 60 * 60
 // real usage, just checked against the other limiter so they're not
 // flatly contradictory.
 //
-// Correction (found in review of #48 by tentencaw): "room for ~5
+// Correction (found in review of #45 by tentencaw): "room for ~5
 // concurrent warm senders" overstated the precision of that comparison.
 // KEY_WARM is scoped per-(senderId, recipientId) and only enforced by
 // the sender's home node; KEY_INBOUND_RELAY is scoped per-recipientId
@@ -67,7 +67,7 @@ const KEY_INBOUND_RELAY = (recipientId: number) => `caw:dm:rate:relay-inbound:${
  * Read-only check — does NOT increment. Safe to call before the request
  * is authenticated: cheap (single Redis GET, no write), so it can't be
  * used to cheaply exhaust a target recipient's budget the way calling
- * checkInboundRelayRate() pre-auth could (found in review of #48 by
+ * checkInboundRelayRate() pre-auth could (found in review of #45 by
  * tentencaw — an attacker who never bothers signing correctly could
  * still burn through a victim's hourly budget with junk requests, since
  * the increment happened before signature verification rejected them).
@@ -88,7 +88,7 @@ export async function peekInboundRelayRate(recipientId: number): Promise<{ allow
     return { allowed: true }
   } catch (err: any) {
     // Fail-open, matching recordInboundRelayHit() and checkDmRate()
-    // above. Logged (found lacking in review of #48 by tentencaw) so a
+    // above. Logged (found lacking in review of #45 by tentencaw) so a
     // sustained Redis outage shows up somewhere other than "the limiter
     // silently stopped limiting" — this fires on every peek during an
     // outage, which is noisy, but the alternative (no signal at all)
@@ -106,7 +106,7 @@ export async function peekInboundRelayRate(recipientId: number): Promise<{ allow
  * expire() failure (e.g. a Redis blip between the incr and the expire)
  * self-heals on the next hit instead of leaving the key permanently
  * unexpiring — same pattern checkDmRate() uses above. (Also found in
- * review of #48 by tentencaw.)
+ * review of #45 by tentencaw.)
  */
 export async function recordInboundRelayHit(recipientId: number): Promise<{ allowed: boolean; resetSeconds?: number }> {
   const key = KEY_INBOUND_RELAY(recipientId)

--- a/client/src/api/routes/dm-relay.ts
+++ b/client/src/api/routes/dm-relay.ts
@@ -173,8 +173,25 @@ router.post('/', async (req, res) => {
       return res.status(403).json({ error: 'Signature does not match source instance validator' })
     }
 
-    // Signature verified — this request is authenticated. Only now does
-    // it count against the recipient's budget.
+    // Dedup, moved ahead of the inbound-budget increment (found in
+    // review of #48 by tentencaw): a legitimate retry of a message
+    // that already landed shouldn't cost the recipient another slot
+    // in their hourly budget. Message.relayId is partial-unique; the
+    // same envelope arriving twice (legitimate retry, or a malicious
+    // replay inside the 5-min window) hits the unique index and we
+    // 200-noop with the existing message id. The caller treats both
+    // the same way.
+    const existing = await prisma.message.findUnique({
+      where: { relayId },
+      select: { id: true },
+    })
+    if (existing) {
+      return res.json({ status: 'duplicate', messageId: existing.id })
+    }
+
+    // Signature verified and not a duplicate — this request is
+    // authenticated and novel. Only now does it count against the
+    // recipient's budget.
     const inboundRecord = await recordInboundRelayHit(Number(recipientId))
     if (!inboundRecord.allowed) {
       console.warn(`[DM Relay] 429 inbound cap hit (post-auth) for recipient=${recipientId} from ${remote} (sourceInstance=${sourceInstanceId})`)
@@ -220,18 +237,6 @@ router.post('/', async (req, res) => {
         })
         if (!follower) return res.status(403).json({ error: 'DM_PRIVACY', reason: 'FOLLOWING' })
       }
-    }
-
-    // Dedup. Message.relayId is partial-unique; the same envelope
-    // arriving twice (legitimate retry, or a malicious replay inside
-    // the 5-min window) hits the unique index and we 200-noop with
-    // the existing message id. The caller treats both the same way.
-    const existing = await prisma.message.findUnique({
-      where: { relayId },
-      select: { id: true },
-    })
-    if (existing) {
-      return res.json({ status: 'duplicate', messageId: existing.id })
     }
 
     // Determine the recipient's inbox status for this conversation:

--- a/client/src/api/routes/dm-relay.ts
+++ b/client/src/api/routes/dm-relay.ts
@@ -28,6 +28,7 @@ import { getPeers } from '../../services/InstanceRegistryService'
 import { recoverAddressFromCanonical } from '../../services/InstanceRegistryService/envelopeCrypto'
 import { verifyDmSenderSig } from '../dmSenderSig'
 import { getNetworkId } from '../../utils/networkId'
+import { checkInboundRelayRate } from '../dmRateLimit'
 
 const router = Router()
 
@@ -121,6 +122,19 @@ router.post('/', async (req, res) => {
     if (conversationId !== expectedConvId) {
       console.warn(`[DM Relay] 400 invalid conversationId from ${remote} (sourceInstance=${sourceInstanceId}): got=${conversationId} expected=${expectedConvId} (sender=${senderId}, recipient=${recipientId})`)
       return res.status(400).json({ error: 'Invalid conversation ID format' })
+    }
+
+    // Per-recipient inbound cap — bounds how many relayed messages a
+    // single recipient can be flooded with per hour, independent of how
+    // many distinct source IPs/instances are involved (the per-source-IP
+    // cap in server.ts doesn't catch a distributed flood aimed at one
+    // recipient). See dmRateLimit.ts for why this is deliberately simpler
+    // than the sender-side warm/cold limiter.
+    const inboundCheck = await checkInboundRelayRate(Number(recipientId))
+    if (!inboundCheck.allowed) {
+      console.warn(`[DM Relay] 429 inbound cap hit for recipient=${recipientId} from ${remote} (sourceInstance=${sourceInstanceId})`)
+      res.set('Retry-After', String(inboundCheck.resetSeconds))
+      return res.status(429).json({ error: 'Too many messages for this recipient right now' })
     }
 
     // Look up the source instance's registered validator address from

--- a/client/src/api/routes/dm-relay.ts
+++ b/client/src/api/routes/dm-relay.ts
@@ -133,9 +133,8 @@ router.post('/', async (req, res) => {
     //
     // Read-only peek here — NOT the increment. Incrementing pre-auth
     // would let an attacker who never signs correctly still burn through
-    // a victim's hourly budget with junk requests (found in review of
-    // The actual increment happens after signature
-    // verification succeeds, below.
+    // a victim's hourly budget with junk requests. The actual increment
+    // happens after signature verification succeeds, below.
     const inboundPeek = await peekInboundRelayRate(Number(recipientId))
     if (!inboundPeek.allowed) {
       console.warn(`[DM Relay] 429 inbound cap hit for recipient=${recipientId} from ${remote} (sourceInstance=${sourceInstanceId})`)
@@ -173,10 +172,10 @@ router.post('/', async (req, res) => {
       return res.status(403).json({ error: 'Signature does not match source instance validator' })
     }
 
-    // Dedup, moved ahead of the inbound-budget increment (found in
-    // a legitimate retry of a message
-    // that already landed shouldn't cost the recipient another slot
-    // in their hourly budget. Message.relayId is partial-unique; the
+    // Dedup, moved ahead of the inbound-budget increment: a legitimate
+    // retry of a message that already landed shouldn't cost the
+    // recipient another slot in their hourly budget. Message.relayId is
+    // partial-unique; the
     // same envelope arriving twice (legitimate retry, or a malicious
     // replay inside the 5-min window) hits the unique index and we
     // 200-noop with the existing message id. The caller treats both
@@ -237,7 +236,12 @@ router.post('/', async (req, res) => {
     // messages that never land in their inbox.
     const inboundRecord = await recordInboundRelayHit(Number(recipientId))
     if (!inboundRecord.allowed) {
-      console.warn(`[DM Relay] 429 inbound cap hit for recipient=${recipientId} from ${remote} (sourceInstance=${sourceInstanceId})`)
+      // (authenticated) distinguishes this from the identically-worded
+      // peek rejection above: that one is a cheap early reject before
+      // signature verification runs, this one means an authenticated,
+      // deliverable message is what pushed the recipient over the cap
+      // — the signal that real traffic is hitting the limit.
+      console.warn(`[DM Relay] 429 inbound cap hit (authenticated) for recipient=${recipientId} from ${remote} (sourceInstance=${sourceInstanceId})`)
       res.set('Retry-After', String(inboundRecord.resetSeconds))
       return res.status(429).json({ error: 'Too many messages for this recipient right now' })
     }

--- a/client/src/api/routes/dm-relay.ts
+++ b/client/src/api/routes/dm-relay.ts
@@ -28,7 +28,7 @@ import { getPeers } from '../../services/InstanceRegistryService'
 import { recoverAddressFromCanonical } from '../../services/InstanceRegistryService/envelopeCrypto'
 import { verifyDmSenderSig } from '../dmSenderSig'
 import { getNetworkId } from '../../utils/networkId'
-import { checkInboundRelayRate } from '../dmRateLimit'
+import { peekInboundRelayRate, recordInboundRelayHit } from '../dmRateLimit'
 
 const router = Router()
 
@@ -130,10 +130,16 @@ router.post('/', async (req, res) => {
     // cap in server.ts doesn't catch a distributed flood aimed at one
     // recipient). See dmRateLimit.ts for why this is deliberately simpler
     // than the sender-side warm/cold limiter.
-    const inboundCheck = await checkInboundRelayRate(Number(recipientId))
-    if (!inboundCheck.allowed) {
+    //
+    // Read-only peek here — NOT the increment. Incrementing pre-auth
+    // would let an attacker who never signs correctly still burn through
+    // a victim's hourly budget with junk requests (found in review of
+    // #48 by tentencaw). The actual increment happens after signature
+    // verification succeeds, below.
+    const inboundPeek = await peekInboundRelayRate(Number(recipientId))
+    if (!inboundPeek.allowed) {
       console.warn(`[DM Relay] 429 inbound cap hit for recipient=${recipientId} from ${remote} (sourceInstance=${sourceInstanceId})`)
-      res.set('Retry-After', String(inboundCheck.resetSeconds))
+      res.set('Retry-After', String(inboundPeek.resetSeconds))
       return res.status(429).json({ error: 'Too many messages for this recipient right now' })
     }
 
@@ -165,6 +171,15 @@ router.post('/', async (req, res) => {
     if (recoveredAddr.toLowerCase() !== source.validatorAddress.toLowerCase()) {
       console.warn(`[DM Relay] 403 sig mismatch from ${remote} (sourceInstance=${sourceInstanceId}): recovered=${recoveredAddr} expected=${source.validatorAddress}`)
       return res.status(403).json({ error: 'Signature does not match source instance validator' })
+    }
+
+    // Signature verified — this request is authenticated. Only now does
+    // it count against the recipient's budget.
+    const inboundRecord = await recordInboundRelayHit(Number(recipientId))
+    if (!inboundRecord.allowed) {
+      console.warn(`[DM Relay] 429 inbound cap hit (post-auth) for recipient=${recipientId} from ${remote} (sourceInstance=${sourceInstanceId})`)
+      res.set('Retry-After', String(inboundRecord.resetSeconds))
+      return res.status(429).json({ error: 'Too many messages for this recipient right now' })
     }
 
     // Block check (either direction). If the recipient blocked the sender

--- a/client/src/api/routes/dm-relay.ts
+++ b/client/src/api/routes/dm-relay.ts
@@ -134,7 +134,7 @@ router.post('/', async (req, res) => {
     // Read-only peek here — NOT the increment. Incrementing pre-auth
     // would let an attacker who never signs correctly still burn through
     // a victim's hourly budget with junk requests (found in review of
-    // #45 by tentencaw). The actual increment happens after signature
+    // The actual increment happens after signature
     // verification succeeds, below.
     const inboundPeek = await peekInboundRelayRate(Number(recipientId))
     if (!inboundPeek.allowed) {
@@ -174,7 +174,7 @@ router.post('/', async (req, res) => {
     }
 
     // Dedup, moved ahead of the inbound-budget increment (found in
-    // review of #45 by tentencaw): a legitimate retry of a message
+    // a legitimate retry of a message
     // that already landed shouldn't cost the recipient another slot
     // in their hourly budget. Message.relayId is partial-unique; the
     // same envelope arriving twice (legitimate retry, or a malicious
@@ -187,16 +187,6 @@ router.post('/', async (req, res) => {
     })
     if (existing) {
       return res.json({ status: 'duplicate', messageId: existing.id })
-    }
-
-    // Signature verified and not a duplicate — this request is
-    // authenticated and novel. Only now does it count against the
-    // recipient's budget.
-    const inboundRecord = await recordInboundRelayHit(Number(recipientId))
-    if (!inboundRecord.allowed) {
-      console.warn(`[DM Relay] 429 inbound cap hit (post-auth) for recipient=${recipientId} from ${remote} (sourceInstance=${sourceInstanceId})`)
-      res.set('Retry-After', String(inboundRecord.resetSeconds))
-      return res.status(429).json({ error: 'Too many messages for this recipient right now' })
     }
 
     // Block check (either direction). If the recipient blocked the sender
@@ -237,6 +227,19 @@ router.post('/', async (req, res) => {
         })
         if (!follower) return res.status(403).json({ error: 'DM_PRIVACY', reason: 'FOLLOWING' })
       }
+    }
+
+    // Authenticated, not a duplicate, and not blocked/gated — this
+    // message will actually be delivered, so it's the right point to
+    // charge the recipient's inbound budget. Counting any earlier (e.g.
+    // right after signature verification) would let a blocked sender or
+    // a privacy-gated first-contact spend the recipient's budget on
+    // messages that never land in their inbox.
+    const inboundRecord = await recordInboundRelayHit(Number(recipientId))
+    if (!inboundRecord.allowed) {
+      console.warn(`[DM Relay] 429 inbound cap hit for recipient=${recipientId} from ${remote} (sourceInstance=${sourceInstanceId})`)
+      res.set('Retry-After', String(inboundRecord.resetSeconds))
+      return res.status(429).json({ error: 'Too many messages for this recipient right now' })
     }
 
     // Determine the recipient's inbox status for this conversation:

--- a/client/src/api/routes/dm-relay.ts
+++ b/client/src/api/routes/dm-relay.ts
@@ -134,7 +134,7 @@ router.post('/', async (req, res) => {
     // Read-only peek here — NOT the increment. Incrementing pre-auth
     // would let an attacker who never signs correctly still burn through
     // a victim's hourly budget with junk requests (found in review of
-    // #48 by tentencaw). The actual increment happens after signature
+    // #45 by tentencaw). The actual increment happens after signature
     // verification succeeds, below.
     const inboundPeek = await peekInboundRelayRate(Number(recipientId))
     if (!inboundPeek.allowed) {
@@ -174,7 +174,7 @@ router.post('/', async (req, res) => {
     }
 
     // Dedup, moved ahead of the inbound-budget increment (found in
-    // review of #48 by tentencaw): a legitimate retry of a message
+    // review of #45 by tentencaw): a legitimate retry of a message
     // that already landed shouldn't cost the recipient another slot
     // in their hourly budget. Message.relayId is partial-unique; the
     // same envelope arriving twice (legitimate retry, or a malicious


### PR DESCRIPTION
# Add per-recipient inbound rate limit to /api/dm/relay

## Context

`PROJECT_BACKLOG.md`'s DDoS protection section: "DMs are E2E encrypted so no content-scanning, but they're still inserts into Postgres. A peer hammering relayDmToPeers with spoofed identities can fill the DB."

`dm-relay.ts` already documents two spam controls in its header comment: a per-source-IP limit (`server.ts`) and a per-(senderId, recipientId) bucket — but the latter is enforced on the **sender's** side in `dm.ts`, and the comment explicitly says the receiver "trusts that the source instance enforced it," listing receiver-side enforcement as future work. That's the gap this fills: today, several source IPs (or a misbehaving/malicious source instance) each sending at a normal individual rate could still collectively flood one recipient, and nothing on the receiving side would catch it.

## Changes

- **`client/src/api/dmRateLimit.ts`**: added `checkInboundRelayRate(recipientId)` — a plain Redis `INCR` per recipient, 1-hour window, default `500`/hour (`DM_RELAY_INBOUND_LIMIT_PER_HOUR` env override). Fails open on Redis errors, same as the existing `checkDmRate()`.
- **`client/src/api/routes/dm-relay.ts`**: calls it right after the existing format/timestamp/conversationId validation, before the (more expensive) source-instance lookup and signature verification.

## Why not reuse `checkDmRate()`

`checkDmRate()` (existing, sender-side) does warm/cold classification via Postgres lookups (`message`, `follow` queries) to decide between a 10/h or 100/h cap. That's fine on the send path — a user hitting "send" isn't a high-frequency call. But on the receiver side of `/api/dm/relay`, the whole point is defending against a flood; running DB queries per relayed message here would turn the defense itself into a new load vector. `checkInboundRelayRate()` is deliberately dumber: no DB reads, no warm/cold distinction, just a counter. It also can't distinguish "one attacker" from "many people legitimately messaging the same popular account at once" — same blind spot the existing per-source-IP cap already has, just on a different axis.

Update: my first pass used `200`, but checked it against `WARM_LIMIT_PER_HOUR` (existing sender-side limiter, above in the same file) and it didn't hold up — warm senders alone can each send `100`/h, so `200` would throttle a popular account getting legitimate messages from just two or three warm contacts. `500` leaves room for roughly five concurrent warm senders at their individual ceiling before this cap kicks in. Still not load-tested against real traffic, just checked for internal consistency with the other limiter in the file.

## Testing

Verified against a live Redis instance with a throwaway test key (not the production key namespace, cleaned up after): 8 calls against a limit of 5 resulted in 5 allowed, 3 blocked (test used a small limit to keep the loop short; same increment/expire logic as the real 500/h default).

```
Allowed: 5, Blocked: 3
PASS
```

Syntax-checked with esbuild; not tested against a live node end-to-end (i.e. an actual relayed DM through the full route).

---

zinsanjp
