### PR TITLE
fix(deploy): --dry-run now honors CONTRACTS condition predicates

### DIFF
--- a/solidity/scripts/deploy.js
+++ b/solidity/scripts/deploy.js
@@ -2650,7 +2650,8 @@ After deployment, ABIs are automatically regenerated for the frontend.
     console.log('\nContracts to deploy:');
     for (const phase of [1, 2, 3, 4, 5]) {
       const phaseContracts = Object.entries(CONTRACTS)
-        .filter(([key, c]) => c.phase === phase && !deployer.state.addresses[key]);
+        .filter(([key, c]) => c.phase === phase && !deployer.state.addresses[key])
+        .filter(([_, c]) => !c.condition || c.condition(deployer.state, deployer, deployer.env));
       if (phaseContracts.length > 0) {
         console.log(`  Phase ${phase}: ${phaseContracts.map(([k]) => k).join(', ')}`);
       }


### PR DESCRIPTION
`--dry-run` lists what would be deployed, but the filter only checks `phase` and whether the contract is already in state — it does not evaluate the `condition` predicate. Contracts that would be skipped are therefore listed as "to deploy".

From an empty state, `--env mainnet`:

| | before | after |
|---|---|---|
| Phase 1 | 16 | 13 |
| Phase 2 | 19 | 16 |
| Phase 4 | 4 | 4 |
| total | **39** | **33** |

The six that disappear are all gated:

- `MockSP1Verifier_L1` / `_L2` / `_L2b`, `MockSwapRouter` — `env === 'dev'`
- `CivicKycVerifier` — `CIVIC_GATEWAY_ADDRESS`
- `CawL1PriceReader` — `CAW_WETH_PAIR`

On testnet the first five are absent from `.deploy-state.json` entirely, yet `--dry-run` lists them. (`CawL1PriceReader` is the exception — it is present in state.)

`deployPhase()` already applies the same predicate (`deploy.js` ~2032):

```js
.filter(([_, config]) => !config.condition || config.condition(this.state, this, this.env))
```

This mirrors it in the dry-run listing.

Checked against `--env testnet`, `--env dev` and `--env mainnet`. Under `dev` the four `env === 'dev'` contracts correctly remain listed.