### PR TITLE
Add fail2ban to install.sh ALWAYS_PKGS (SSH brute-force protection by default)

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -92,11 +92,11 @@ running, brute-force attempts get blocked after 5 failures for ~10
 minutes — bots move on. Default config covers SSH out of the box;
 nginx + postfix jails available with one-line additions.
 
-- [ ] **Add `fail2ban` to install.sh's `ALWAYS_PKGS` apt list** so every
+- [x] **Add `fail2ban` to install.sh's `ALWAYS_PKGS` apt list** so every
       CAW host gets it preinstalled. Default config (the systemd-journal
       backend on Ubuntu 22.04+) just works for SSH; we don't need to
       configure anything beyond `apt-get install -y fail2ban`.
-- [ ] Verify the systemd unit autostarts:
+- [x] Verify the systemd unit autostarts:
       `sudo systemctl status fail2ban`. Should be `active (running)` after
       install.
 
@@ -793,6 +793,7 @@ One-liner install: `curl -fsSL https://raw.githubusercontent.com/.../install.sh 
 ---
 
 ## Resolved (since previous backlog snapshots)
+- [x] **fail2ban added to install.sh `ALWAYS_PKGS`** — SSH brute-force protection installed by default on every host; default systemd-journal backend covers the sshd jail with no extra config (verified active on Ubuntu 24.04, banned 2 in-progress attempts on install)
 
 - [x] **`OnlyOnce` lockdown of all protocol-critical setters** (2026-04-24)
 - [x] **Old LZ replication path removed** (`CawActionsReplicator.sol` deleted, runtime callers gone, address removed from `client/src/abi/addresses.ts`; one stale test reference remains — see "Stale test cleanup")

--- a/install.sh
+++ b/install.sh
@@ -478,6 +478,7 @@ else
   ALWAYS_PKGS=(
     curl ca-certificates gnupg git build-essential
     nginx ufw certbot python3-certbot-nginx
+    fail2ban
   )
 
   # Stateful services — only install the ones the user wants natively, and


### PR DESCRIPTION
CAW hosts keep a validator key on disk, so an exposed SSH surface is a high-value target. A fresh Ubuntu/Debian VPS ships with password auth enabled and is brute-forced constantly.

Add fail2ban to install.sh's ALWAYS_PKGS so every host gets SSH brute-force protection by default. The list is installed in one shot via apt-get, so no other change is needed. The packaged defaults enable the sshd jail out of the box on Ubuntu 22.04+ with no jail.local or config edits — jail.conf ships `backend = auto`, and whatever `auto` resolves to on the host (journal or the /var/log/auth.log file backend) reads the SSH log without further setup. Verified on 24.04 (via install.sh) and 22.04 (packaged defaults, hand-installed) between reviewers.

Install-only: unlike disabling password/root login, this adds a defensive daemon without touching sshd config or existing sessions. It is not risk-free in the strict sense — the sshd jail bans any address that fails auth `maxretry` times (default 5) for `bantime` (default 600s), and fail2ban can't tell the operator's IP apart from an attacker's — but there is no change to sshd, no effect on existing sessions, and any self-inflicted ban expires on its own in 10 minutes. Worth keeping that in mind while swapping keys.

Verification: `systemctl status fail2ban` showing active (running) is necessary but not sufficient — with the file backend the service reports healthy even if rsyslog isn't writing /var/log/auth.log, i.e. while the jail sees nothing. The check that actually confirms it's watching is `fail2ban-client status sshd`: a non-empty File list (or journal) and a non-zero "Total failed" means it's reading the SSH log. On a live production node (24.04) this showed the sshd jail banning in-progress brute-force sources within seconds of install.

Applies to fresh installs. update.js (`caw update`) does not re-run apt, so hosts provisioned before this lands won't pick fail2ban up automatically — for those it's a one-line `apt install fail2ban`. This closes the two install-side fail2ban items under Host hardening in PROJECT_BACKLOG.md; the SSH hardening items above them (PermitRootLogin no / PasswordAuthentication no) are separate and remain open.