### PR TITLE
fix(deposit-watcher): hold checkpoint when a deposit fails to record

### DIFF
--- a/client/src/services/DepositWatcher/index.ts
+++ b/client/src/services/DepositWatcher/index.ts
@@ -122,6 +122,15 @@ export const depositWatcherService: Service = {
       }
 
       let behindAfterPoll = false
+      // Consecutive record-failure count. Drives an exponential backoff on the
+      // retry cadence (see the anyFailed branch and the setTimeout in finally):
+      // a permanently-failing deposit must not hot-loop queryFilter+getBlock+
+      // findFirst at the catch-up rate. Reset to 0 on any fully-successful poll.
+      let consecutiveFailures = 0
+      // Cap for that backoff (15 min). Transient failures recover in 1-2 polls
+      // (60s → 2m), while a permanently-failing deposit settles to one retry
+      // per 15 min: 60s, 2m, 4m, 8m, 15m, 15m… — visible lag, not a hot loop.
+      const DEPOSIT_FAILURE_BACKOFF_CAP_MS = 15 * 60_000
 
       const poll = async () => {
         if (!alive) return
@@ -158,7 +167,11 @@ export const depositWatcherService: Service = {
             await Promise.all(uniqueBlocks.map(async bn => {
               try {
                 const block = await provider.getBlock(bn)
-                blockTsByNumber.set(bn, new Date(Number(block?.timestamp ?? 0) * 1000))
+                // getBlock can resolve to null (rather than throw) on some
+                // providers; Number(null?.timestamp ?? 0) * 1000 would silently
+                // stamp 1970-01-01 into the snapshot the activity chart reads.
+                // Treat null the same as the catch path below: approximate NOW.
+                blockTsByNumber.set(bn, block ? new Date(Number(block.timestamp) * 1000) : new Date())
               } catch {
                 // Provider hiccup → fall back to NOW; better an
                 // approximate timestamp than dropping the event.
@@ -202,10 +215,12 @@ export const depositWatcherService: Service = {
               // Hold the checkpoint so the failed block(s) are re-read next
               // poll. recordDeposit is idempotent (skips on existing
               // txHash+logIndex+reason), so already-recorded deposits in this
-              // range are no-ops on the retry. Poll again promptly rather than
-              // waiting the full interval.
-              behindAfterPoll = true
+              // range are no-ops on the retry. Count the failure so the retry
+              // cadence backs off (see finally) rather than hot-looping at the
+              // catch-up rate.
+              consecutiveFailures++
             } else {
+              consecutiveFailures = 0
               lastBlock = toBlock
               await redis.set(cpKey, String(lastBlock))
             }
@@ -216,10 +231,25 @@ export const depositWatcherService: Service = {
           rpc.reportError(err) // auto-heal on dead-connection errors
         } finally {
           if (!alive) return
-          // Same catch-up cadence as NftTransferWatcher: 250ms when
-          // we hit the per-poll cap (more blocks pending), full
-          // interval otherwise.
-          pollTimer = setTimeout(poll, behindAfterPoll ? 250 : cfg.pollIntervalMs)
+          // Poll cadence, in priority order:
+          //  1. a record failure held the checkpoint → back off exponentially
+          //     from the configured interval (capped) so a permanently-failing
+          //     deposit doesn't hot-loop and trip free-tier RPC rate limits.
+          //  2. hit the per-poll cap with more blocks pending → 250ms catch-up
+          //     (same as NftTransferWatcher).
+          //  3. otherwise → the full configured interval.
+          let nextPollMs: number
+          if (consecutiveFailures > 0) {
+            nextPollMs = Math.min(
+              cfg.pollIntervalMs * 2 ** (consecutiveFailures - 1),
+              DEPOSIT_FAILURE_BACKOFF_CAP_MS,
+            )
+          } else if (behindAfterPoll) {
+            nextPollMs = 250
+          } else {
+            nextPollMs = cfg.pollIntervalMs
+          }
+          pollTimer = setTimeout(poll, nextPollMs)
         }
       }
 

--- a/client/src/services/DepositWatcher/index.ts
+++ b/client/src/services/DepositWatcher/index.ts
@@ -166,6 +166,7 @@ export const depositWatcherService: Service = {
               }
             }))
 
+            let anyFailed = false
             for (const ev of events) {
               const args = (ev as ethers.EventLog).args
               if (!args) continue
@@ -188,12 +189,26 @@ export const depositWatcherService: Service = {
                   })
                 }, { timeout: 15_000 })
               } catch (err: any) {
+                // Swallow-and-advance was the bug: a failed deposit used to be
+                // warned and then lastBlock advanced past it, so the block was
+                // never re-read and the deposit was lost. Flag the failure so we
+                // hold the checkpoint and re-read this range next poll instead.
+                anyFailed = true
                 console.warn(`[DepositWatcher] Failed to record deposit tokenId=${tokenId} tx=${txHash}:`, err?.message)
               }
             }
 
-            lastBlock = toBlock
-            await redis.set(cpKey, String(lastBlock))
+            if (anyFailed) {
+              // Hold the checkpoint so the failed block(s) are re-read next
+              // poll. recordDeposit is idempotent (skips on existing
+              // txHash+logIndex+reason), so already-recorded deposits in this
+              // range are no-ops on the retry. Poll again promptly rather than
+              // waiting the full interval.
+              behindAfterPoll = true
+            } else {
+              lastBlock = toBlock
+              await redis.set(cpKey, String(lastBlock))
+            }
           }
           ctx.heartbeat('poll')
         } catch (err: any) {


### PR DESCRIPTION
## What

`DepositWatcher` swallows per-event write failures and then advances its checkpoint unconditionally, so a deposit that fails to record is never re-read. On-chain the deposit happened, but the DB row is missing — a balance burn (financial).

## Root cause

In the poll loop (`src/services/DepositWatcher/index.ts`):

- `queryFilter(...)` at L143 has **no** `.catch(→[])`, so a fetch failure throws and lands in the outer catch (does not advance). Good.
- But each `recordDeposit` is wrapped in a per-event `try/catch` (L178-193) that **only** `console.warn`s, and then control falls through to:

```
lastBlock = toBlock            // L195
await redis.set(cpKey, ...)    // L196
```

The checkpoint advances even if one (or all) of the `recordDeposit` calls in that range failed. Those blocks are never scanned again → the failed deposit is lost.

Same anti-pattern family as the deploy.js §5/§7 and `NftTransferWatcher` swallows from the 2026-08-04 re-deploy investigation.

## Fix (flag approach)

- `let anyFailed = false` before the event loop.
- Set `anyFailed = true` inside the per-event catch.
- Gate the advance:
  - on failure → hold the checkpoint (`lastBlock` unchanged), set `behindAfterPoll = true` for a fast 250ms re-poll.
  - on success → `lastBlock = toBlock` + `redis.set` as before.

Failure → checkpoint held + hurried re-poll. Success → normal advance.

I deliberately did **not** use a side retry-queue (approach B): a parked-events queue is just a new place to silently swallow, which is exactly the pattern a review should reject. Holding the checkpoint keeps the chain as the single source of truth.

## Idempotency (measured)

Re-reading a range that partially succeeded is safe. `recordDeposit` (StakeLedger) early-returns when a `cawOwnershipSnapshot` with `(txHash, logIndex, reason='DEPOSIT')` already exists, so re-processing an already-recorded deposit is a no-op.

## Mitigation status — corrected

An earlier draft described the DepositWatcher swallow as mitigated by the manual `scripts/backfill-l1-deposits.ts`. Per ten's measurement on a v2-merged production tree, that script **does not run on v2**:

```
Error: CLIENT_ID is required (set it in client/.env)
    at scripts/backfill-l1-deposits.ts:39:11
```

It throws at module load (top-level IIFE reading `process.env.CLIENT_ID` directly at L35-42), before `main`. This is a v2 regression: the `CLIENT_ID → NETWORK_ID` rename added `src/utils/networkId.ts` (NETWORK_ID primary, CLIENT_ID fallback) and all of `src/` migrated, but the three `scripts/` entry points (`backfill-l1-deposits.ts`, `backfill-stake-ledger.ts`, `seed-stake-ledger.ts`) were left on the raw env read.

So the mitigation is effectively **zero**, not "manual script only". That makes this checkpoint fix the last line of defense for deposit accounting until the script is restored. The `CLIENT_ID` script fix is a separate, few-line change tracked by ten.

## SponsorRepayIndexer contrast — scoped

The PR previously cited `SponsorRepayIndexer` as the benign counter-example. That holds **only for its process layer**: `processEvents` is not wrapped in a per-call try, so a throw propagates to the outer catch and `lastBlock = to` / `saveCheckpoint` are never reached — the structure this fix borrows.

However, the shared poller's **fetch layer** has the same swallow this PR is about, at a different spot (per ten):

```
opts.contract.queryFilter(...)
  .catch((err) => { console.warn(...); return [] as ethers.EventLog[] })   // ~L236
```

A per-event-type fetch failure returns `[]`, `merged` is silently short, and the loop still advances. Same shape as the `scanLogsBackward` empty-array return from the 2026-08-04 investigation. Two call sites (L325 / L362) share one helper, so a single fix at the `.catch` covers both. **Not addressed here — flagged for separate handling** so "match SponsorRepay" doesn't accidentally import the fetch-layer swallow.

## Scope

This PR touches the `DepositWatcher` checkpoint only. The structurally identical `MarketplaceIndexerService` swallow (PayoutWithdrawn, L731-739) is a planned follow-up.

---

## Follow-up: retry backoff + null-timestamp (c07e9e9)

Two failure-path points from review (thanks @tentencaw, @Zinsanjp), fixed in `c07e9e9`:

- **Retry backoff.** The first cut reused `behindAfterPoll` for the failure path, so a deposit failing for a permanent reason (malformed data, a constraint violation) retried at the 250ms catch-up rate — a `queryFilter` + `getBlock` + `findFirst` hot loop four times a second, which can trip the free-tier RPC rate limits this watcher is tuned for. Split the two: catch-up keeps its 250ms; a record failure now drives a `consecutiveFailures` counter and an exponential backoff off `pollIntervalMs`, capped at 15 min (60s → 2m → 4m → 8m → 15m…). The "hold the checkpoint, don't advance" property is unchanged — only the re-poll delay grows. Counter resets to 0 on any fully-successful poll.
- **Null block timestamp.** In the timestamp prefetch, the `catch` path fell back to NOW but the success path did `Number(block?.timestamp ?? 0) * 1000` — `getBlock` resolving to `null` (rather than throwing) stamped `1970-01-01` into the snapshot the activity chart reads. Null now takes the same NOW fallback as the catch path.

## Adjacent gaps — not fixed here, tracked separately

Both live in `StakeLedger` and are design calls, not one-line fixes, so they're out of scope for this PR. Flagged so `anyFailed` isn't read as complete coverage of the deposit path:

- **`recordDeposit` halted-return** (`StakeLedger/index.ts`, before the dedup check). When the ledger is halted it records nothing and returns *normally* — no throw — so the `catch` never fires, `anyFailed` stays false, and the checkpoint advances. Every deposit in the range is lost, one layer below what this PR closes. `halted` is sticky (operator must reseed), and one of the paths that sets it is DIVERGENCE, which the code itself notes can fire spuriously under high load on a non-archive RPC. So an operator on a free-tier RPC can drop deposits silently while the checkpoint keeps moving. Turning that `return` into a `throw` touches every `recordDeposit` caller and is a call about what "halted" should mean — separate change.
- **In-memory mutation before DB commit** (`recordDeposit`). `s.totalCaw` / `s.ownership` are updated before the `$transaction` write commits. On a transient DB failure the transaction rolls back but the in-memory addition stays, and now that this PR holds the checkpoint and re-reads, the retry's dedup check (which reads the DB) passes and the same deposit is counted twice in memory. Moving the in-memory mutation after commit, or rolling it back on catch, closes it — a `StakeLedger` change, tracked separately.

