### PR TITLE
fix(scripts): unblock the seed/backfill scripts on v2

### DIFF
--- a/client/scripts/backfill-l1-deposits.ts
+++ b/client/scripts/backfill-l1-deposits.ts
@@ -26,6 +26,7 @@ import { prisma } from '../src/prismaClient'
 import { CAW_NAMES_ADDRESS } from '../src/abi/addresses'
 import { makeJsonRpcProvider, getL1HttpRpcUrl } from '../src/utils/rpcProvider'
 import { scanLogsForward, findContractDeployBlock } from '../src/utils/chunkedLogs'
+import { getNetworkId } from '../src/utils/networkId'
 
 const args = process.argv.slice(2)
 const argFrom = args.indexOf('--from') >= 0 ? Number(args[args.indexOf('--from') + 1]) : undefined
@@ -33,10 +34,10 @@ const argTo = args.indexOf('--to') >= 0 ? Number(args[args.indexOf('--to') + 1])
 const argChunk = args.indexOf('--chunk') >= 0 ? Number(args[args.indexOf('--chunk') + 1]) : undefined
 
 const CAW_CLIENT_ID = (() => {
-  const raw = process.env.CLIENT_ID
+  const raw = getNetworkId()
   const n = raw ? Number(raw) : NaN
   if (!Number.isFinite(n) || n <= 0) {
-    throw new Error('CLIENT_ID is required (set it in client/.env)')
+    throw new Error('NETWORK_ID (or legacy CLIENT_ID) is required (set it in client/.env)')
   }
   return n
 })()

--- a/client/scripts/backfill-stake-ledger.ts
+++ b/client/scripts/backfill-stake-ledger.ts
@@ -44,15 +44,16 @@ import { CAW_ACTIONS_ADDRESS } from '../src/abi/addresses'
 import { ACTION_TYPE_NUM_TO_NAME, ACTION_COST, type FixedCostActionType } from '../src/utils/cawActionCosts'
 import { PRECISION } from '../src/services/StakeLedger/contractMath'
 import { getCawProfileLedger } from '../src/services/StakeLedger/cawProfileLedger'
+import { getNetworkId } from '../src/utils/networkId'
 
 const args = new Set(process.argv.slice(2))
 const RESET = args.has('--reset')
 
 const CAW_CLIENT_ID = (() => {
-  const raw = process.env.CLIENT_ID
+  const raw = getNetworkId()
   const n = raw ? Number(raw) : NaN
   if (!Number.isFinite(n) || n <= 0) {
-    throw new Error('CLIENT_ID is required (set it in client/.env)')
+    throw new Error('NETWORK_ID (or legacy CLIENT_ID) is required (set it in client/.env)')
   }
   return n
 })()

--- a/client/scripts/seed-stake-ledger.ts
+++ b/client/scripts/seed-stake-ledger.ts
@@ -28,14 +28,15 @@
 import 'dotenv/config'
 import { Contract } from 'ethers'
 import { makeJsonRpcProvider, getL2HttpRpcUrl, getL1HttpRpcUrl } from '../src/utils/rpcProvider'
-import { cawProfileL2Abi, cawProfileAbi } from '../src/abi/generated'
+import { cawProfileLedgerAbi, cawProfileAbi } from '../src/abi/generated'
 import { CAW_NAMES_L2_ADDRESS, CAW_NAMES_ADDRESS } from '../src/abi/addresses'
 import { prisma } from '../src/prismaClient'
+import { getNetworkId } from '../src/utils/networkId'
 
 function requireClientId(): number {
-  const raw = process.env.CLIENT_ID
+  const raw = getNetworkId()
   const n = raw ? Number(raw) : NaN
-  if (!Number.isFinite(n) || n <= 0) throw new Error('CLIENT_ID required')
+  if (!Number.isFinite(n) || n <= 0) throw new Error('NETWORK_ID (or legacy CLIENT_ID) required')
   return n
 }
 
@@ -46,7 +47,7 @@ async function main() {
   if (!rpcUrl) throw new Error('L2 RPC not configured (L2_RPC_URL_HTTP / L2_RPC_URL)')
 
   const l2Provider = makeJsonRpcProvider(rpcUrl, 84532)
-  const l2 = new Contract(CAW_NAMES_L2_ADDRESS, cawProfileL2Abi as any, l2Provider)
+  const l2 = new Contract(CAW_NAMES_L2_ADDRESS, cawProfileLedgerAbi as any, l2Provider)
 
   // L2's CawProfileL2 doesn't expose nextId/totalSupply (only L1 CawProfile
   // does — IDs are minted on L1, mirrored to L2). Read the count from L1.
@@ -141,9 +142,9 @@ async function main() {
   // double-count communal inflation. (Fresh installs: same cursor still
   // works, the indexer reads new events past the head as they arrive.)
   await prisma.stakeLedgerState.upsert({
-    where: { clientId },
+    where: { networkId: clientId },
     create: {
-      clientId,
+      networkId: clientId,
       multiplier: String(multiplier),
       totalCaw: String(totalCaw),
       lastBlock: BigInt(headBlock),

--- a/client/scripts/seed-stake-ledger.ts
+++ b/client/scripts/seed-stake-ledger.ts
@@ -23,7 +23,7 @@
 //   npx tsx scripts/seed-stake-ledger.ts          # run for real
 //   npx tsx scripts/seed-stake-ledger.ts --dry    # show what we'd write
 //
-// Reads CLIENT_ID + L2_RPC_URL_HTTP / L2_RPC_URL from .env.
+// Reads NETWORK_ID (or legacy CLIENT_ID) + L2_RPC_URL_HTTP / L2_RPC_URL from .env.
 
 import 'dotenv/config'
 import { Contract } from 'ethers'


### PR DESCRIPTION
### Context

v2 renamed `CLIENT_ID` to `NETWORK_ID` and added `src/utils/networkId.ts` — `getNetworkId()` reads `NETWORK_ID` first and falls back to `CLIENT_ID` for installs that predate the rename. Everything under `src/` moved over.

`scripts/` didn't. Three of them still read `process.env.CLIENT_ID` directly. And `grep -n "CLIENT_ID" cli/` returns only `X_OAUTH_CLIENT_ID` entries — the installer never writes a bare `CLIENT_ID` — so on a v2 install none of the three can start. On my node (v2 merged):

```
$ npx tsx scripts/seed-stake-ledger.ts --dry
Error: CLIENT_ID required
    at requireClientId (scripts/seed-stake-ledger.ts:38:44)
    at main (scripts/seed-stake-ledger.ts:44:20)

$ npx tsx scripts/backfill-l1-deposits.ts
Error: CLIENT_ID is required (set it in client/.env)
    at scripts/backfill-l1-deposits.ts:39:11
    at scripts/backfill-l1-deposits.ts:42:1
    at Object.<anonymous> (scripts/backfill-l1-deposits.ts:201:2)

$ npx tsx scripts/backfill-stake-ledger.ts
Error: CLIENT_ID is required (set it in client/.env)
    at scripts/backfill-stake-ledger.ts:55:11
    at scripts/backfill-stake-ledger.ts:58:1
    at Object.<anonymous> (scripts/backfill-stake-ledger.ts:385:2)
```

The two backfill scripts throw during module load — their reads are top-level. `seed-stake-ledger.ts` differs: `requireClientId()` is called from `main()`, so the module loads and it dies mid-run. Either way nothing is written on the way out, but the failure moment isn't the same for all three.

An install that has only `CLIENT_ID` set keeps working — `networkId.ts:8` returns `process.env.NETWORK_ID ?? process.env.CLIENT_ID ?? null`, so the fallback covers it. The env read just stops depending on which of the two names is present.

Two of these matter beyond the inconvenience.

**`seed-stake-ledger.ts` is on root's crontab every 3h**, via the reseed wrapper `caw install` generates. Its log on my node — `logs/reseed-stake-ledger.log` — runs from `==== 2026-07-26T18:00:01Z reseed start ====` to `==== 2026-08-13T12:00:01Z reseed start ====` and holds 145 `reseed start` markers against 145 `CLIENT_ID` error lines. Every run in it failed, and `StakeLedgerState` was empty.

**`backfill-l1-deposits.ts` is what `DepositWatcher` points at.** Its comment at L117-118 reads: *"Historical deposits are the backfill script's job (scripts/backfill-l1-deposits.ts) — it walks from contract…"*. That matters because the watcher's per-event write sits in a try/catch that warns and moves on (L178-191), with `lastBlock = toBlock` and the checkpoint write running unconditionally right after (L193-194) — so a deposit that fails to record isn't re-read. With the script unable to start on v2, the path the watcher names isn't available.

### `seed-stake-ledger.ts` had two more leftovers

`git diff master v2` is empty for that file — the migration never touched it.

**The ABI import.** It imports `cawProfileL2Abi`, which v2 removed from `generated.ts` in favour of `cawProfileLedgerAbi` (alongside `services/StakeLedger/cawProfileL2.ts` → `cawProfileLedger.ts`). Every other consumer moved; this one didn't. It's cast `as any`, so nothing catches it until runtime. Copying the pre-fix file aside and supplying `CLIENT_ID` by hand to get past the first failure:

```
$ CLIENT_ID=1 npx tsx scripts/_repro-seed.ts --dry
TypeError: Cannot read properties of undefined (reading 'formatJson')
    at Function.from (node_modules/ethers/src.ts/abi/interface.ts:1259:33)
    at new BaseContract (node_modules/ethers/src.ts/contract/contract.ts:690:33)
    at new Contract (node_modules/ethers/src.ts/contract/contract.ts:1120:1)
    at main (scripts/_repro-seed.ts:49:14)
```

(`_repro-seed.ts` is a throwaway copy of the unpatched file — L49 is the `new Contract` call.)

**The Prisma field.** It writes `StakeLedgerState` with `where: { clientId }` and `create: { clientId }`. `schema.prisma:1021` has `networkId Int @id` and no `clientId`. `backfill-stake-ledger.ts` had exactly these two call sites renamed in v2 — same table, same fields — while the env read three lines above it was left as-is. That's the shape of the whole thing: the rename went after `clientId`, and `CLIENT_ID` / `CAW_CLIENT_ID` are a different case.

### Why it survived

`client/tsconfig.json` has `"include": ["src"]`, so `scripts/` isn't type-checked. The Prisma field mismatch would otherwise be a compile error — the client types are generated from the schema. The ABI one is hidden by `as any` either way. And the cron's output only lands in a log file, so nothing surfaces in normal operation.

This is a point-in-time fix. `generated.ts` is regenerated from the contract ABIs, so a future rename can strand these scripts the same way — and with `scripts/` outside `tsconfig.json`, nothing will catch it then either.

### Changes

Minimal, per file:

- all three: `process.env.CLIENT_ID` → `getNetworkId()`, and the error message now names `NETWORK_ID`
- `seed-stake-ledger.ts`: `cawProfileL2Abi` → `cawProfileLedgerAbi` (import + `new Contract`), the two Prisma field sites `clientId` → `networkId`, and the header comment that told operators to set `CLIENT_ID`

`backfill-stake-ledger.ts` needed only the env read — its Prisma calls already use `networkId`.

Local variable names (`clientId`, `CAW_CLIENT_ID`) and log strings are left alone. Happy to rename those too, but it seemed like your call rather than part of the fix.

### Testing

Applied to my v2 node. First the dry run:

```
$ npx tsx scripts/seed-stake-ledger.ts --dry
[seed-stake-ledger] clientId=1 dryRun=true
[seed-stake-ledger] reading L2 state from 0xee2B2E2dE111942b8a1980836894aB1FDa765f24, L1 nextId from 0x61C07717210988df782E779cAc8AC67633Ed2a2e...
  rewardMultiplier (at scan start) = 1000000000000000000
  totalCaw         (at scan start) = 0
  nextId           = 10 (will read tokens 1..9)
  read 9/9 (0 non-zero owners so far)…
  sum(cawOwnership) = 0
[seed-stake-ledger] dry run — no DB writes.
```

`clientId=1` comes from `NETWORK_ID`; `CLIENT_ID` is still unset on that box. `rewardMultiplier` returning a value is the ABI fix landing — before it was `could not decode result data (value="0x", method="rewardMultiplier")`.

Then for real, which is what the cron had been trying to do all along:

```
$ npx tsx scripts/seed-stake-ledger.ts
[seed-stake-ledger] clientId=1 dryRun=false
...
  lastBlock seeded to L2 head 45429387
[seed-stake-ledger] StakeLedgerState upserted for clientId=1
[seed-stake-ledger] CawOwnershipCurrent populated with 0 non-zero rows
[seed-stake-ledger] Done. Restart pm2 so StakeLedger picks up the seeded state.
```

That covers the Prisma field — the upsert went through with `networkId`, and the table has its first row since the node was installed.

And `backfill-l1-deposits.ts` over a narrow window. Its only write is a per-event `create` inside the scan loop, guarded by a `findFirst` dedup on `(txHash, logIndex, reason)`, so an event-free range touches nothing:

```
$ npx tsx scripts/backfill-l1-deposits.ts --from 11479000 --to 11479100
[deposit-backfill] scanning L1 contract=0x61C07717210988df782E779cAc8AC67633Ed2a2e blocks=11479000..11479100 (head=11480481)
[deposit-backfill]   scanned blocks 11479000..11479100 (+0 logs, 0 total, 0.2s)
[deposit-backfill] found 0 Deposited event(s); writing rows…
[deposit-backfill] Done. wrote=0, skipped=0 (already-present), failed=0, of 0 candidates.
```

Not covered: `backfill-stake-ledger.ts` past its first line. It writes and takes no range arguments, so there's no safe way to exercise it here — I confirmed it stops failing at module load, and its change is the same one-line env read as the other two.

### Scope I didn't cover

The `clientId` → `networkId` rename in `schema.prisma` touched more than `StakeLedgerState` — the diff also has it on a model with `@@index([…, createdAt])` and one with `@@unique([…, tokenId])`. I checked the three scripts here against the schema and found nothing else, but since `scripts/` isn't type-checked I can't say the sweep is complete.

One spot I noticed and left alone: `scripts/recover-falsely-failed-txqueue.ts:112` compares `Number(ex?.clientId ?? -1) === Number(data.clientId ?? -1)`, where `ex` is `Action.data` and `data` is the TxQueue payload — both JSON blobs, so the schema rename doesn't reach them directly. But `git grep -n "clientId" -- client/src/` turns up nothing that writes that key into a payload: the hits are X OAuth (`X_OAUTH_CLIENT_ID`), comments, one log label in `DepositWatcher`, and `InstanceRegistryService`'s config schema, which keeps `clientId` deliberately as a pre-rename alias. The on-chain action payloads in my `RawEvent` rows carry `networkId`. If both sides come back `undefined`, that comparison is `-1 === -1` and the guard always passes. It's a write-only script with no dry mode, so I flagged it rather than changing it.

`tests/services/StakeLedger/verifyMultiplier.test.ts:9` also still sets `process.env.CLIENT_ID = '1'`. It passes, because `getNetworkId()` falls back — so it isn't broken, just the last place still using the old name.