### PR TITLE
fix(marketplace-indexer): hold checkpoint when a PayoutWithdrawn fails to record

### DIFF
--- a/client/prisma/migrations/20260817000000_marketplace_payout_partial_unique/migration.sql
+++ b/client/prisma/migrations/20260817000000_marketplace_payout_partial_unique/migration.sql
@@ -1,0 +1,17 @@
+-- Fix: MarketplaceIndexerService creates a MarketplacePayout row per PayoutQueued
+-- event. queuedTxHash alone is NOT unique (one tx can queue multiple sellers), so
+-- block resync/replay duplicated pending payout rows; the catch only logged and
+-- continued. e24c207 adds queuedLogIndex (ethers v6 ev.index) and treats a P2002
+-- on replay as an idempotent no-op -- but that dedup only works if the matching
+-- partial UNIQUE index exists. Prisma @@unique cannot express a partial
+-- (WHERE ... IS NOT NULL) index, so it is created here in raw SQL.
+--
+-- queuedLogIndex is nullable: pre-existing rows stay NULL and are excluded from
+-- the partial index (no backfill, no collision). prod caw_v2 MarketplacePayout
+-- was verified at 0 rows, so no existing-duplicate merge step is needed.
+--
+-- The index name and predicate MUST stay in sync with the runtime P2002 path in
+-- MarketplaceIndexerService/index.ts.
+CREATE UNIQUE INDEX IF NOT EXISTS "MarketplacePayout_queuedTxHash_queuedLogIndex_key"
+  ON "MarketplacePayout" ("queuedTxHash", "queuedLogIndex")
+  WHERE "queuedLogIndex" IS NOT NULL;

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -1038,6 +1038,7 @@ model MarketplacePayout {
   status          String    @default("pending")
   queuedAt        DateTime  @default(now())
   queuedTxHash    String
+  queuedLogIndex  Int?
   withdrawnAt     DateTime?
   withdrawnTxHash String?
   recipient       String?

--- a/client/src/services/MarketplaceIndexerService/index.ts
+++ b/client/src/services/MarketplaceIndexerService/index.ts
@@ -693,6 +693,14 @@ export const marketplaceIndexerService: Service = {
           // Process PayoutWithdrawn events (V2 H-15 pull-pattern)
           // Mark all pending rows for this seller as withdrawn. If the event
           // amount doesn't match the sum of pending rows, log a discrepancy.
+          //
+          // PayoutWithdrawn has no backfill path (unlike Deposited's manual
+          // backfill script or NftTransfer's auto-rescan), so a swallowed
+          // failure here strands the seller's pending payout rows as 'pending'
+          // permanently. Track failures and hold the checkpoint below so the
+          // range re-runs on the next poll — the same don't-advance-on-error
+          // behaviour the outer poll catch already relies on.
+          let payoutWithdrawnFailed = false
           for (const event of payoutsWithdrawn) {
             const ev = event as ethers.EventLog
             const seller    = String(ev.args[0]).toLowerCase()
@@ -731,12 +739,20 @@ export const marketplaceIndexerService: Service = {
                 console.warn(`[MarketplaceIndexer] PayoutWithdrawn: no pending rows found for seller=${seller.slice(0, 10)}... (bootstrapped past PayoutQueued?) tx=${ev.transactionHash.slice(0, 10)}...`)
               }
             } catch (err: any) {
+              payoutWithdrawnFailed = true
               console.error(`[MarketplaceIndexer] PayoutWithdrawn processing error for seller=${seller}:`, err.message?.slice(0, 200))
             }
           }
 
-          lastBlock = toBlock
-          await saveLastProcessedBlock(toBlock)
+          if (payoutWithdrawnFailed) {
+            console.warn(
+              `[MarketplaceIndexer] Holding checkpoint at block ${lastBlock} (not advancing to ${toBlock}): ` +
+              `one or more PayoutWithdrawn events failed to record; blocks ${fromBlock}..${toBlock} will be retried next poll.`
+            )
+          } else {
+            lastBlock = toBlock
+            await saveLastProcessedBlock(toBlock)
+          }
 
         } catch (err) {
           console.error('[MarketplaceIndexer] Poll error:', err)

--- a/client/src/services/MarketplaceIndexerService/index.ts
+++ b/client/src/services/MarketplaceIndexerService/index.ts
@@ -672,6 +672,10 @@ export const marketplaceIndexerService: Service = {
             const ev = event as ethers.EventLog
             const seller = String(ev.args[0]).toLowerCase()
             const amount = BigInt(ev.args[1].toString())
+            // ethers v6 exposes the block-level log index as `index` (v5 was `logIndex`).
+            // Use null (not 0) as the "unknown" sentinel: 0 is a real index, and the
+            // partial unique on (queuedTxHash, queuedLogIndex) only covers non-null rows.
+            const queuedLogIndex = (ev as any).index ?? (ev as any).logIndex ?? null
             try {
               await prisma.marketplacePayout.create({
                 data: {
@@ -679,14 +683,22 @@ export const marketplaceIndexerService: Service = {
                   amount,
                   status: 'pending',
                   queuedTxHash: ev.transactionHash,
+                  queuedLogIndex,
                 },
               })
               console.log(`[MarketplaceIndexer] PayoutQueued: seller=${seller.slice(0, 10)}... amount=${amount.toString()} tx=${ev.transactionHash.slice(0, 10)}...`)
             } catch (err: any) {
-              // Idempotency: duplicate tx on re-index will hit unique-ish constraint.
-              // We don't have a unique constraint on queuedTxHash alone (one tx can
-              // queue multiple sellers), so log and continue rather than throw.
-              console.warn(`[MarketplaceIndexer] PayoutQueued insert error (may be re-index):`, err.message?.slice(0, 100))
+              // A single tx can queue multiple sellers, so queuedTxHash alone is not
+              // unique. Dedup is enforced by a partial unique index on
+              // (queuedTxHash, queuedLogIndex) WHERE queuedLogIndex IS NOT NULL, created
+              // out-of-band (db-push cannot express partial indexes). On block
+              // resync/replay Postgres raises unique_violation -> Prisma P2002; that is
+              // the expected idempotent no-op, not an error.
+              if (err?.code === 'P2002') {
+                console.debug(`[MarketplaceIndexer] PayoutQueued replay no-op tx=${ev.transactionHash.slice(0, 10)}... logIndex=${queuedLogIndex}`)
+              } else {
+                console.warn(`[MarketplaceIndexer] PayoutQueued insert error:`, err.message?.slice(0, 100))
+              }
             }
           }
 


### PR DESCRIPTION
Follow-up to #50. #50 held the DepositWatcher checkpoint when `recordDeposit` fails; this applies the same fix to `MarketplaceIndexer`'s `PayoutWithdrawn` handler — the one marketplace handler where a dropped event has **no recovery path**.

### The bug

In the poll loop, `PayoutWithdrawn` events are processed in a `try/catch` that logs and swallows on failure:

```ts
} catch (err: any) {
  console.error(`[MarketplaceIndexer] PayoutWithdrawn processing error for seller=${seller}:`, ...)
}
```

After the loop, the poll advances the checkpoint unconditionally:

```ts
lastBlock = toBlock
await saveLastProcessedBlock(toBlock)
```

So if `updateMany` (or `findMany`) throws for a seller, the checkpoint moves past that block and the event is never revisited.

### Why this one, and why now

The catch-sweep classified the marketplace handlers by recovery path. `PayoutWithdrawn` is the severe case: there is **no backfill mechanism** for it, unlike `Deposited` (manual backfill script) or `NftTransfer` (auto-rescan). A single swallowed `PayoutWithdrawn` leaves the seller's `MarketplacePayout` rows in `status: 'pending'` permanently — the ledger treats those funds as still owed, with no path to reconcile. That's a persistent state divergence from one dropped event.

### The fix

Track whether any `PayoutWithdrawn` in the poll failed, and hold the checkpoint if so:

```ts
let payoutWithdrawnFailed = false
for (const event of payoutsWithdrawn) {
  try { /* ... */ }
  catch (err: any) {
    payoutWithdrawnFailed = true
    console.error(...)
  }
}

if (payoutWithdrawnFailed) {
  console.warn(`[MarketplaceIndexer] Holding checkpoint at block ${lastBlock} ... blocks ${fromBlock}..${toBlock} will be retried next poll.`)
} else {
  lastBlock = toBlock
  await saveLastProcessedBlock(toBlock)
}
```

**This does not add new re-run semantics.** `lastBlock = toBlock` is the *only* checkpoint advance, reached only on the happy path of the inner try; any thrown error already causes the outer poll catch to leave `lastBlock` untouched and re-run the whole range next poll. This change simply routes a currently-swallowed `PayoutWithdrawn` failure into that same existing hold-and-retry path. Re-processing the range is a property the indexer already documents and relies on (see the `Idempotency: if the indexer's lastBlock ever regresses ...` note on the Sale handler).

### Scope (deliberately narrow)

- **In scope:** the `PayoutWithdrawn` swallow-then-advance only.
- **Out of scope — left untouched on purpose:**
  - the amount-mismatch `"...pending rows withdrawn anyway"` branch (that's a separate correctness call, not a checkpoint issue);
  - the other swallow-then-continue handlers (`sales`, `bids`, `settled`, `payoutsQueued`, …) — those are the separate catch-sweep track. A `PayoutWithdrawn`-triggered hold *will* re-run those handlers, which relies on their existing re-run safety; making them individually fail-loud is tracked separately.

### Deferred: backoff

#50 also bundled a backoff. The marketplace poll re-schedules at a fixed `pollIntervalMs` (no 250ms fast-catchup path like DepositWatcher), so a held range retries at most once per interval — no tight loop. I've kept this PR to the checkpoint hold only rather than guess a backoff shape; if we want #50's backoff ported for consistency (e.g. to stop a *permanently*-failing range from re-scanning a 2000-block `getLogs` every interval indefinitely), that can layer on as a small follow-up.

### Verification

- Static: confirmed against v2 base `672f5ee` — `PayoutWithdrawn` is the sole handler with no backfill path; `lastBlock = toBlock` is the only checkpoint advance; the outer poll catch already leaves `lastBlock` unadvanced on any thrown error.
- Diff is two hunks, no other handler or the "anyway" branch touched.
- Runtime (forcing a `PayoutWithdrawn` failure and confirming the checkpoint holds + retries) is production-dependent — deferring to node testing.