### PR TITLE
fix(deploy): abort when a critical linking assertion fails

### DIFF
--- a/solidity/scripts/deploy.js
+++ b/solidity/scripts/deploy.js
@@ -1038,6 +1038,7 @@ const LINKING_STEPS = [
     // wrong and the cap mechanism would be silently dead. Fail fast here so a
     // broken deploy is caught before it reaches the finalization phase.
     name: 'Assert CawCapOracle_L1.cawActions == CawActions_L1 (nonce-prediction check)',
+    critical: true,
     chain: 'L1',
     phase: 2,
     custom: async (state, deployer) => {
@@ -1215,6 +1216,7 @@ for (const L of L2_CHAIN_KEYS) {
   // aborts instead of shipping.
   LINKING_STEPS.push({
     name: `Assert CawProfileLedger_${L}.cawActions == CawActions_${L} (nonce-prediction check)`,
+    critical: true,
     chain: L,
     phase: 1,
     custom: async (state, deployer) => {
@@ -1406,6 +1408,7 @@ for (const L of L2_CHAIN_KEYS) {
   // L2 side: CawProfileLedger_<L>.peers(L1_eid) must be the NEW L1 CawProfile.
   LINKING_STEPS.push({
     name: `Assert CawProfileLedger_${L}.peers(L1) == CawProfile (cross-chain peer read-back)`,
+    critical: true,
     chain: L,
     phase: 7,
     condition: (state) => state.addresses[`CawProfileLedger_${L}`] && state.addresses.CawProfile,
@@ -1431,6 +1434,7 @@ for (const L of L2_CHAIN_KEYS) {
   // L1 side (reverse): CawProfile.peers(L_eid) must be THIS L2's ledger.
   LINKING_STEPS.push({
     name: `Assert CawProfile.peers(${L}) == CawProfileLedger_${L} (cross-chain peer read-back)`,
+    critical: true,
     chain: 'L1',
     phase: 7,
     condition: (state) => state.addresses.CawProfile && state.addresses[`CawProfileLedger_${L}`],
@@ -2246,18 +2250,25 @@ class MultiChainDeployer {
       }
 
       // Run each chain's steps sequentially, but all chains in parallel
-      await Promise.allSettled(
+      const linkResults = await Promise.allSettled(
         Object.entries(linksByChain).map(async ([chain, steps]) => {
           for (const step of steps) {
             try {
               await this.executeLink(step);
             } catch (e) {
               console.error(`Failed: ${step.name} - ${e.message}`);
-              // Continue with other steps on this chain
+              // Assertions marked `critical` abort the deploy instead of just logging.
+              if (step.critical) throw e;
+              // Otherwise continue with other steps on this chain
             }
           }
         })
       );
+      // Mirror the deploy path above: a rejected chain means a critical
+      // assertion threw. Surface it instead of shipping a broken cascade.
+      for (const r of linkResults) {
+        if (r.status === 'rejected') throw r.reason;
+      }
     }
   }
 

--- a/solidity/scripts/deploy.js
+++ b/solidity/scripts/deploy.js
@@ -2266,6 +2266,10 @@ class MultiChainDeployer {
       );
       // Mirror the deploy path above: a rejected chain means a critical
       // assertion threw. Surface it instead of shipping a broken cascade.
+      // This aborts AFTER every chain settles, not the moment one throws:
+      // allSettled is deliberate so assertions from every chain reach the
+      // log before the deploy stops. The reason surfaced is the first
+      // rejected chain in Object.entries order, not the earliest in time.
       for (const r of linkResults) {
         if (r.status === 'rejected') throw r.reason;
       }


### PR DESCRIPTION
### The problem

796ed99 added three assertions whose error text says "abort and redeploy the full cascade — do not resume/patch". All three are `LINKING_STEPS`, so their `throw` lands here:

```js
      await Promise.allSettled(
        Object.entries(linksByChain).map(async ([chain, steps]) => {
          for (const step of steps) {
            try {
              await this.executeLink(step);
            } catch (e) {
              console.error(`Failed: ${step.name} - ${e.message}`);
              // Continue with other steps on this chain
            }
          }
        })
      );
```

The catch logs and continues, and `Promise.allSettled` then discards the rejection. So the deploy completes with exit 0 regardless of how many assertions fired — the message says abort, but nothing aborts.

The deploy path in the same method already handles this correctly:

```js
      const results = await Promise.allSettled(
        batch.map(key => this.deploy(key))
      );
      for (let i = 0; i < batch.length; i++) {
        if (results[i].status === 'rejected') {
          console.error(`Failed to deploy ${batch[i]}: ${results[i].reason.message}`);
          throw results[i].reason;
        }
```

This brings the linking path in line with it.

### Reproduction

I replayed the 2026-08-04 partial redeploy on forks of all three testnets — `--contract CawProfile` with the pre-08-04 `.deploy-state.json` as input, anvil forking Sepolia / Base Sepolia / Arbitrum Sepolia at fixed blocks, `testnet` env with the RPC env vars pointed at localhost.

**Against 796ed99:**

```
Failed: Assert CawProfileLedger_L2b.peers(L1) == CawProfile - CROSS-CHAIN PEER MISMATCH: peers(L1 eid 40161)=0x…4f853523… but the L1 CawProfile deployed at 0x16BBa978… ABORT and redeploy the FULL L1+L2 cascade together — do not resume/patch.
Failed: Assert CawProfileLedger_L2.peers(L1) == CawProfile  - (same)
Failed: Assert CawProfile.peers(L2) == CawProfileLedger_L2  - peers(L2 eid 40245)=0x00…00
Failed: Assert CawProfile.peers(L2b) == CawProfileLedger_L2b - 0x00…00
```

680 log lines, 4 failed assertions, last one at line 593, then 87 more lines to `Deployment complete!`, `exit=0`.

**With this change, same forks, same input, same deployer:**

```
297 log lines, 1 failed assertion, Deployment failed, exit=1
```

and the error propagates through exactly the path this patch touches:

```
Deployment failed: Error: NONCE PREDICTION MISMATCH: …
    at Object.custom (solidity/scripts/deploy.js:1268:19)
    at async MultiChainDeployer.executeLink (solidity/scripts/deploy.js:2142:7)
    at async solidity/scripts/deploy.js:2257:15
    at async Promise.allSettled (index 0)
    at async MultiChainDeployer.deployPhase (solidity/scripts/deploy.js:2253:27)
```

One caveat on reading those two runs: the assertion that fires differs between them — the first aborted on the phase-7 peer read-back, the second on the phase-1 nonce check. Nonce behaviour isn't stable across runs on anvil: with ethers' default `cacheTimeout: 250` I measured 23 of 30 sequential sends failing on nonce against a plain anvil, and 0 of 30 with the cache disabled. So which immutable ends up mis-wired can differ run to run. What the pair demonstrates is the control flow — a critical assertion now stops the deploy — not which assertion fires.

Other chains in the same phase still finish their steps before the abort: `allSettled` is kept, so L2b's assertions are reported alongside L2's rather than being cut off mid-phase. The deploy stops before the next phase begins.

### Changes

- `critical: true` on the four assertion steps (the pre-existing `CawCapOracle_L1` check plus the three added in 796ed99)
- rethrow from the catch when `step.critical` — `console.error` is unchanged, so non-critical failures behave exactly as before
- capture the `allSettled` results and surface any rejection

13 insertions, 2 deletions, one file. `node -c` clean.

### Reproducing it

```
git checkout <this branch>
cp solidity/.deploy-state.json /tmp/deploy-state.bak
git show 672f5ee:solidity/.deploy-state.json > solidity/.deploy-state.json
anvil --fork-url <sepolia>  --fork-block-number <N1> --port 8545 &
anvil --fork-url <base-sep> --fork-block-number <N2> --port 8546 &
anvil --fork-url <arb-sep>  --fork-block-number <N3> --port 8547 &
# point EXPECTED_DEPLOYER at anvil account 0
L1_RPC_URL=http://127.0.0.1:8545 L2_RPC_URL=http://127.0.0.1:8546 \
L2B_RPC_URL=http://127.0.0.1:8547 PRIVATE_KEYS=<anvil key 0> \
  node solidity/scripts/deploy.js --contract CawProfile; echo "exit=$?"
```

`--fork-block-number` is required — without it anvil panics on Arbitrum Sepolia with `historical state is not available`. `solidity` needs `npm ci --legacy-peer-deps` and `npx hardhat compile` first.

Running the same scenario against 796ed99 unmodified reproduces the `exit=0` behaviour — that's the first run above.