### PR TITLE
fix(deploy): force-include the setter-wired CawProfile consumers

### DIFF
--- a/solidity/scripts/deploy.js
+++ b/solidity/scripts/deploy.js
@@ -2531,6 +2531,13 @@ class MultiChainDeployer {
           `CawActionsArchive_${L}`, `CawChallengeRelay_${L}`,
         ]),
         'CawProfileMinter', 'CawProfileQuoter', 'CawProfileLens', 'CawProfileMarketplace',
+        // Setter-wired rather than constructor-wired: CawProfile is injected into
+        // these two by one-shot linking steps (setCawProfile), and neither declares
+        // CawProfile in its dependencies, so neither the dependents closure nor the
+        // nonce-chain closure above reaches them. Left out of a CawProfile cascade
+        // on 2026-08-04, both kept pointing at the old CawProfile with no setter
+        // left to repair it.
+        'CawNetworkManager', 'CawBuyAndBurn',
       ];
       for (const key of forceInclude) {
         if (CONTRACTS[key]) toRedeploy.add(key);


### PR DESCRIPTION
### What's left after 796ed99

796ed99's `forceInclude` expansion closes most of what my 08-04 audit found holding stale references — `CawCapOracle_L1/L2/L2b`, `CawActionsERC1271_L1/L2/L2b`, and `CawChallengeRelay_L2b`. Two are still outside every closure:

| contract | stale getter(s) after 08-04 |
| --- | --- |
| `CawNetworkManager` | `cawProfile()`, `minter()` |
| `CawBuyAndBurn` | `cawProfile()` |

Neither takes `CawProfile` as a constructor argument:

```js
CawBuyAndBurn:     { dependencies: [],                constructorArgs: (state, chainKey) => [state.addresses.MintableCaw, state.addresses.MockSwapRouter || requireUniswapRouter(chainKey)] }
CawNetworkManager: { dependencies: ['CawBuyAndBurn'], constructorArgs: (state) => [state.addresses.CawBuyAndBurn] }
```

So neither declares it in `dependencies` and the transitive-dependents closure can't reach them. Neither appears anywhere in the nonce-prediction graph either — `grep -n "predictedSibling"` returns only `CawProfileMinter`, `CawCapOracle_L1/_<L>`, `CawActions_L1/_<L>` and `CawActionsERC1271_L1/_<L>` — so the flood-fill added in 796ed99 can't reach them either.

`CawProfile` goes in through one-shot linking steps (`setCawProfile` at deploy.js:993 and :1070), and those setters are consumed on the live testnet deployment — `CawBuyAndBurn.setCawProfile` returns "Already set" on my node.

### Before

Replaying the 08-04 partial redeploy on forks against 796ed99 unmodified — `--contract CawProfile` with the pre-08-04 `.deploy-state.json` as input:

```
  CawBuyAndBurn already deployed at 0x300F761743540f6583CD9227E03Aedc82C477FEF
  CawNetworkManager already deployed at 0x2Ce2d752675bf1Ee927D71090Fba50348B4BBB0e
  ...
  Skipping "Wire CawProfile into CawNetworkManager (setCawProfile)" - already done
  Skipping "Wire CawProfileMinter into CawNetworkManager (setMinter)" - already done
  ...
    CawBuyAndBurn: 0x300F761743540f6583CD9227E03Aedc82C477FEF
    CawNetworkManager: 0x2Ce2d752675bf1Ee927D71090Fba50348B4BBB0e
```

`CawProfile` redeploys, both of these keep their old addresses, and the re-wiring steps are skipped as already done. The stale reference survives the cascade intact.

### After

Same scenario, same input, with this change:

```
   Will redeploy: CawProfile, ..., CawChallengeRelay_L2b, CawNetworkManager, CawBuyAndBurn

Deploying CawBuyAndBurn to testnetL1...
Deploying CawNetworkManager to testnetL1...
   Deployed at: 0xd1fAbab961625d790342859f77886F77243Fb372        <- CawProfile
...
Wire CawProfile into CawNetworkManager (setCawProfile)...
   Calling CawNetworkManager.setCawProfile(0xd1fAbab961625d790342859f77886F77243Fb372)
Wire CawProfileMinter into CawNetworkManager (setMinter)...
   Calling CawNetworkManager.setMinter(0xB83fc34b93efA25B863E674a99f0C0A3CBC0Aa02)
   Calling CawBuyAndBurn.setCawProfile(0xd1fAbab961625d790342859f77886F77243Fb372)
...
    CawBuyAndBurn: 0xD351078d4677a063F8608cC27E4C58499CdB0210
    CawNetworkManager: 0x367571A4bb72DE563F7fc7E9e785eA2E9DE8488c
```

`exit=0`. The "Skipping ... already done" lines are gone: both contracts are rebuilt, and the setters — unconsumed on fresh contracts — inject the CawProfile that was deployed in this same run.

### Why forceInclude rather than dependencies

Declaring `CawProfile` in `CawNetworkManager.dependencies` would mean "deploy CawNetworkManager after CawProfile" — but `CawProfile` already lists `CawNetworkManager` in its own `dependencies`, so that's a cycle. The relationship isn't "deploys after", it's "must be rebuilt alongside", and `forceInclude` is the list for that. (@nyaromesama raised the dependencies option; this is why I went the other way.)

The ordering falls out of the existing declarations: `CawProfile` depends on both, so they deploy first and `CawProfile` takes their fresh addresses in its constructor; the linking steps then inject the new `CawProfile` back into them. Constructor direction and setter direction are both satisfied.

`redeploy()` already anticipates `CawNetworkManager` being rebuilt:

```js
// Only clear networkCreated if CawNetworkManager itself is being redeployed
if (toRedeploy.has('CawNetworkManager')) {
  this.state.linking = {};
}
```

and the run above confirms it — `createNetwork(Sepolia-Uruk, ...)`, `createNetwork(Sepolia-Babylon, ...)` and both `setFees` calls re-ran against the fresh contract. This change makes a case the script already handles actually occur, rather than introducing a new one.

### Scope

Seven lines: a comment and the two entries. `forceInclude` is applied after both closures (`for (const key of forceInclude) { if (CONTRACTS[key]) toRedeploy.add(key); }`), so nothing further expands from it. `node -c` clean.