### PR TITLE
fix(action-processor): prevent duplicate Tip rows on block resync/replay

### DIFF
--- a/client/prisma/migrations/20260815120000_add_tip_unique_constraint/migration.sql
+++ b/client/prisma/migrations/20260815120000_add_tip_unique_constraint/migration.sql
@@ -1,0 +1,24 @@
+-- Prevent duplicate Tip rows on block resync/replay.
+--
+-- handleCawAction/handleTipAction (ActionProcessor/actionHandlers.ts)
+-- looked up existing tips filtered on pending:true. Once a tip was
+-- confirmed (pending:false), a replayed/rescanned event no longer
+-- matched the lookup and fell through to create a fresh duplicate row.
+-- Confirmed on V1 production data: 12 duplicate rows, 347,312,728 CAW
+-- over-counted in tip totals (display-only impact — ValidatorService
+-- reward calculation does not read the Tip table).
+--
+-- This unique index is the DB-level backstop: even if the application
+-- logic is bypassed or two validators process the same event
+-- concurrently (TOCTOU on findFirst+create, verified independently),
+-- the second INSERT now fails with a unique-constraint violation
+-- instead of silently succeeding. actionHandlers.ts catches that
+-- violation (Prisma P2002) and treats it as a no-op.
+--
+-- Safe to apply on all currently-running V2 nodes: confirmed the Tip
+-- table has 0 rows on every node today (still recovering from the
+-- CawProfileLedger L1-peer wiring bug), so there is no existing
+-- duplicate data for this constraint to conflict with.
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tip_senderId_recipientId_cawonce_key" ON "Tip"("senderId", "recipientId", "cawonce");

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -613,6 +613,7 @@ model Tip {
 
   @@index([senderId])
   @@index([senderId, recipientId, cawId])
+  @@unique([senderId, recipientId, cawonce])
   @@index([senderId, pending])
   @@index([recipientId])
   @@index([cawId])

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -613,6 +613,19 @@ model Tip {
 
   @@index([senderId])
   @@index([senderId, recipientId, cawId])
+  // This is not just a TOCTOU backstop behind serialized application
+  // code. checkOtherExists (the tip-branch of checkDomainObjectExists) has
+  // two callers with different concurrency guarantees: actionCreation.ts
+  // runs inside ActionProcessor's processChain (serialized against every
+  // other live-path call), but DataCleaner's orphan-action reconciliation
+  // calls the same check on its own timer, outside that chain, gated only
+  // by a 2-minute debounce. The live path's own worst case (Tx2: 3 retries
+  // x 30s timeout) is also exactly 2 minutes -- no margin by design. If a
+  // live-path run and DataCleaner's orphan sweep for the same action ever
+  // overlap inside that window, this constraint is the only thing
+  // preventing a duplicate row -- not a second line of defense, since one
+  // of the two callers isn't serialized at all. Don't relax the debounce
+  // or the retry ceiling without re-checking this margin.
   @@unique([senderId, recipientId, cawonce])
   @@index([senderId, pending])
   @@index([recipientId])

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -220,10 +220,25 @@ export async function handleCawAction(
             shouldNotify = true
           } catch (createErr: any) {
             // Unique constraint violation (senderId, recipientId, cawonce) —
-            // another validator's concurrent transaction won the race and
-            // created this row between our findFirst and create (TOCTOU).
-            // The row now exists either way, so this is a no-op, not a
-            // failure.
+            // two possible causes, both correctly resolved as a no-op:
+            //   1. Another validator's concurrent transaction won the race
+            //      and created this row between our findFirst and create
+            //      (TOCTOU). The row now exists either way.
+            //   2. This action's own recipients[]/amounts[] names the same
+            //      recipientId at two different indices (e.g. recipients=
+            //      [5,5]). CawActions._distributeAmountsMem has no on-chain
+            //      uniqueness check on recipients[i] — only numRecipients
+            //      <=10 and the amounts-length relation are enforced — so
+            //      such a payload is structurally valid and both amounts
+            //      ARE credited on-chain via addTokensToBalance. Here,
+            //      first-index-wins: whichever index this loop reaches
+            //      first records the Tip row; the second index's amount is
+            //      silently absent from the Tip table and its aggregates,
+            //      even though it landed on-chain. TipAttachmentControl.tsx
+            //      dedupes recipientId before submission so this doesn't
+            //      happen through normal UI use, but a client bypassing
+            //      the frontend can still produce it. Known tradeoff, not
+            //      a bug in this constraint — see PR #55 discussion.
             if (createErr?.code !== 'P2002') throw createErr
           }
         }
@@ -1145,6 +1160,29 @@ async function handleTipAction(
     recipients: rawAction.recipients,
     amounts: rawAction.amounts
   })
+
+  // The tip: text protocol ("tip:userId:cawonce" / "tip:") is single-
+  // recipient by design -- it names exactly one target. Only recipients[0]
+  // is processed below, matching that semantics. If a payload names more
+  // than one recipient here, it's malformed relative to this protocol
+  // (multi-recipient tips belong in handleCawAction via a CAW/REPLY action,
+  // not here) -- CawActions._distributeAmountsMem has no on-chain check
+  // preventing recipients.length > 1 on an OTHER action though, so a
+  // client bypassing TipModal.tsx (which always sends a single-element
+  // array) could still submit one. On-chain, every recipient in such a
+  // payload IS paid; off-chain, only recipients[0] gets a Tip row --
+  // recipients[1:] are indexed nowhere. Deliberately not looping over all
+  // recipients here to "rescue" them: inventing an interpretation for
+  // recipients[1:] (e.g. treating them as profile tips) would put words
+  // in the sender's mouth that the tip: protocol doesn't actually specify.
+  // Chose the low-risk option -- log and continue processing recipients[0]
+  // only, rather than rewriting this into a loop -- since this has never
+  // occurred in production (checked V1: zero rows match this shape) and
+  // the fix's blast radius (any regression here touches every tip on the
+  // network) outweighs defending against a payload shape nobody has sent.
+  if (Array.isArray(rawAction.recipients) && rawAction.recipients.length > 1) {
+    console.warn(`[handleTipAction] Malformed tip payload: expected 1 recipient for tip: action, got ${rawAction.recipients.length} (sender ${senderId}, cawonce ${action.cawonce}). Only recipients[0] will be recorded; the rest were paid on-chain but will not appear in the Tip table.`)
+  }
 
   const recipientTokenId = Number(rawAction.recipients?.[0])
   const tipAmount = Number(rawAction.amounts?.[0])

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -186,30 +186,53 @@ export async function handleCawAction(
       if (!recipientTokenId || !tipAmount) continue
       try {
         const recipientId = await findOrCreateUser(recipientTokenId)
+        // Look up by (senderId, recipientId, cawonce) WITHOUT filtering on
+        // pending — a resync/replay of an already-confirmed event must find
+        // the existing row and no-op, not fall through to create a
+        // duplicate. See PR discussion: filtering on pending:true here was
+        // the root cause of Tip rows doubling/tripling on rescan (confirmed
+        // 12 duplicate rows / 347,312,728 CAW over-counted on V1 prod).
         const existingTip = await tx.tip.findFirst({
-          where: { senderId: authorId, recipientId, cawonce: action.cawonce, pending: true },
+          where: { senderId: authorId, recipientId, cawonce: action.cawonce },
         })
+        let shouldNotify = false
         if (existingTip) {
-          await tx.tip.update({
-            where: { id: existingTip.id },
-            data: { pending: false, cawId: newCaw.id },
-          })
+          if (existingTip.pending) {
+            await tx.tip.update({
+              where: { id: existingTip.id },
+              data: { pending: false, cawId: newCaw.id },
+            })
+            shouldNotify = true
+          }
+          // else: already confirmed — this is a replay, no-op.
         } else {
-          await tx.tip.create({
-            data: {
-              senderId: authorId,
-              recipientId,
-              amount: tipAmount,
-              cawId: newCaw.id,
-              cawonce: action.cawonce,
-              pending: false,
-            },
-          })
+          try {
+            await tx.tip.create({
+              data: {
+                senderId: authorId,
+                recipientId,
+                amount: tipAmount,
+                cawId: newCaw.id,
+                cawonce: action.cawonce,
+                pending: false,
+              },
+            })
+            shouldNotify = true
+          } catch (createErr: any) {
+            // Unique constraint violation (senderId, recipientId, cawonce) —
+            // another validator's concurrent transaction won the race and
+            // created this row between our findFirst and create (TOCTOU).
+            // The row now exists either way, so this is a no-op, not a
+            // failure.
+            if (createErr?.code !== 'P2002') throw createErr
+          }
         }
-        try {
-          await NotificationService.createTipNotification(recipientId, authorId, newCaw.id, tipAmount, tx)
-        } catch (notifErr) {
-          console.error(`[handleCawAction] Failed to create embedded tip notification for recipient ${recipientId}:`, notifErr)
+        if (shouldNotify) {
+          try {
+            await NotificationService.createTipNotification(recipientId, authorId, newCaw.id, tipAmount, tx)
+          } catch (notifErr) {
+            console.error(`[handleCawAction] Failed to create embedded tip notification for recipient ${recipientId}:`, notifErr)
+          }
         }
       } catch (tipErr) {
         console.error(`[handleCawAction] Failed to process embedded tip for recipient ${recipientTokenId}:`, tipErr)
@@ -1162,46 +1185,64 @@ async function handleTipAction(
     }
   }
 
-  // Confirm pending tip or create new one (for actions from other validators)
+  // Confirm pending tip or create new one (for actions from other validators).
+  // Look up WITHOUT filtering on pending — a resync/replay of an
+  // already-confirmed event must find the existing row and no-op, not
+  // fall through to create a duplicate.
   const existingTip = await tx.tip.findFirst({
     where: {
       senderId,
       recipientId,
       cawonce: action.cawonce,
-      pending: true
     }
   })
 
+  let shouldNotify = false
   if (existingTip) {
-    await tx.tip.update({
-      where: { id: existingTip.id },
-      data: { pending: false, cawId }
-    })
-    console.log('[handleTipAction] Confirmed pending tip:', existingTip.id)
+    if (existingTip.pending) {
+      await tx.tip.update({
+        where: { id: existingTip.id },
+        data: { pending: false, cawId }
+      })
+      console.log('[handleTipAction] Confirmed pending tip:', existingTip.id)
+      shouldNotify = true
+    } else {
+      console.log('[handleTipAction] Tip already confirmed, treating as replay no-op:', existingTip.id)
+    }
   } else {
-    await tx.tip.create({
-      data: {
+    try {
+      await tx.tip.create({
+        data: {
+          senderId,
+          recipientId,
+          amount: Number(tipAmount),
+          cawId,
+          cawonce: action.cawonce,
+          pending: false
+        }
+      })
+      console.log('[handleTipAction] Created tip record:', {
         senderId,
         recipientId,
         amount: Number(tipAmount),
-        cawId,
-        cawonce: action.cawonce,
-        pending: false
-      }
-    })
-    console.log('[handleTipAction] Created tip record:', {
-      senderId,
-      recipientId,
-      amount: Number(tipAmount),
-      cawId
-    })
+        cawId
+      })
+      shouldNotify = true
+    } catch (createErr: any) {
+      // Unique constraint violation — another validator's concurrent
+      // transaction won the race (TOCTOU). Row exists either way.
+      if (createErr?.code !== 'P2002') throw createErr
+      console.log('[handleTipAction] Tip create raced with concurrent processor, treating as no-op')
+    }
   }
 
   // Create notification
-  try {
-    await NotificationService.createTipNotification(recipientId, senderId, cawId || undefined, Number(tipAmount), tx)
-  } catch (err) {
-    console.error('[handleTipAction] Failed to create tip notification:', err)
+  if (shouldNotify) {
+    try {
+      await NotificationService.createTipNotification(recipientId, senderId, cawId || undefined, Number(tipAmount), tx)
+    } catch (err) {
+      console.error('[handleTipAction] Failed to create tip notification:', err)
+    }
   }
 }
 

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -220,10 +220,26 @@ export async function handleCawAction(
             shouldNotify = true
           } catch (createErr: any) {
             // Unique constraint violation (senderId, recipientId, cawonce) —
-            // two possible causes, both correctly resolved as a no-op:
+            // three possible causes, all correctly resolved as a no-op:
             //   1. Another validator's concurrent transaction won the race
             //      and created this row between our findFirst and create
             //      (TOCTOU). The row now exists either way.
+            //   1b. Specifically: checkDomainObjectExists' tip branch
+            //      (checkOtherExists) has two callers with different
+            //      concurrency guarantees. actionCreation.ts runs inside
+            //      ActionProcessor's processChain (serialized against every
+            //      other live-path call), but DataCleaner's orphan-action
+            //      reconciliation calls the same check on its own timer,
+            //      outside that chain, gated only by a 2-minute debounce.
+            //      The live path's own worst case (Tx2: 3 retries x 30s
+            //      timeout) is also exactly 2 minutes — no margin by
+            //      design. If a live-path run and DataCleaner's orphan
+            //      sweep for the same action ever overlap inside that
+            //      window, this constraint is the only thing preventing a
+            //      duplicate row here, not a second line of defense — one
+            //      of the two callers isn't serialized at all. Don't relax
+            //      the debounce or the retry ceiling without re-checking
+            //      this margin.
             //   2. This action's own recipients[]/amounts[] names the same
             //      recipientId at two different indices (e.g. recipients=
             //      [5,5]). CawActions._distributeAmountsMem has no on-chain
@@ -1268,7 +1284,12 @@ async function handleTipAction(
       shouldNotify = true
     } catch (createErr: any) {
       // Unique constraint violation — another validator's concurrent
-      // transaction won the race (TOCTOU). Row exists either way.
+      // transaction won the race (TOCTOU). Row exists either way. This can
+      // also be checkOtherExists' two differently-serialized callers
+      // (actionCreation.ts inside ActionProcessor's processChain vs
+      // DataCleaner's orphan-action reconciliation on its own timer) —
+      // see the fuller note on the @@unique constraint in schema.prisma
+      // and the equivalent comment in handleCawAction above.
       if (createErr?.code !== 'P2002') throw createErr
       console.log('[handleTipAction] Tip create raced with concurrent processor, treating as no-op')
     }


### PR DESCRIPTION
## Problem

`handleCawAction` and `handleTipAction` both looked up existing Tip rows filtered on `pending: true`. Once a tip was confirmed (`pending: false`), a replayed or rescanned event no longer matched the lookup and fell through to the `else` branch, creating a duplicate row and duplicate notification.

Confirmed on V1 production data (`caw_default`): 12 duplicate rows across 4 `(senderId, recipientId, cawonce)` groups, 347,312,728 CAW over-counted in aggregated tip totals. Confirmed this is display-only: `ValidatorService` reward calculation does not read the `Tip` table, and `Tip` is not referenced anywhere in the on-chain settlement path. V1 and V2 are separately deployed (not the same file), but the affected lookup (`where: { senderId, recipientId, cawonce: action.cawonce, pending: true }`) is byte-identical in both — confirmed by diffing both live deployments before this fix.

## Fix

Two parts:

**1. Application logic** — drop the `pending: true` filter from both lookups. If the existing row is still pending, confirm it. If it's already confirmed, treat the replay as a no-op (skip both the DB write and the notification). If no row exists, create one.

**2. DB constraint** — added `@@unique([senderId, recipientId, cawonce])` on `Tip`. The application-logic fix alone is not sufficient under concurrent processing — verified independently that two simultaneous transactions can both pass `findFirst` before either commits its `create` (TOCTOU), producing a duplicate even with the pending-filter fix in place. The unique index closes that window; the `create`'s `P2002` violation is caught and treated as a no-op, consistent with the existing pattern in this file for `Reply` rows.

Migration is a plain `CREATE UNIQUE INDEX`, safe to apply via `prisma migrate deploy` — confirmed the `Tip` table currently has 0 rows on every running V2 node (still recovering from the CawProfileLedger L1-peer wiring bug), so there's no existing duplicate data for the constraint to conflict with. Also confirmed this migration doesn't interact with the two hand-rolled partial unique indexes elsewhere in the schema (`TxQueue_senderId_cawonce_active_unique`, `NotificationGroup_open_bucket_key`) — those aren't in `schema.prisma` and this change doesn't touch `db push` behavior.

## Testing

Verified with an isolated test DB (not touching any live install):

- Sequential replay (3x) of the buggy lookup: reproduces 3 rows / 3x the amount, matching the shape found in V1 production data.
- Sequential replay (3x) with the fix: 1 row, correct amount.
- Concurrent execution with an injected delay between `findFirst` and `create` (forcing the TOCTOU window open): 1 row, correct amount — only passes with **both** the logic fix and the DB constraint; the logic fix alone does not close this window.

## Not addressed in this PR

The frontend already dedupes `recipientId` within a single action's `recipients[]`/`amounts[]` before submission (`TipAttachmentControl.tsx` explicitly dedupes by recipient), so this isn't reachable through normal UI use. A client bypassing the frontend could still submit a payload with a duplicate `recipientId`; the new unique constraint means only the first would persist and subsequent ones become silent no-ops rather than duplicates, but backend-side validation to reject such a payload outright is a separate concern worth a follow-up if needed.

## Addendum: the `@@unique` constraint is not just a TOCTOU backstop

`checkOtherExists` (the tip-branch of `checkDomainObjectExists`, used to skip already-processed actions) has two callers with different concurrency guarantees:

- `actionCreation.ts` runs inside `ActionProcessor/index.ts`'s `processChain` — every call is serialized against every other live-path call.
- `DataCleaner`'s orphan-action reconciliation (`DataCleaner/index.ts`) calls the same check on its own timer, outside that chain, gated only by `ORPHAN_ACTION_DEBOUNCE_MS = 2 minutes`.

The live path's own worst-case duration — `MAX_TX2_RETRIES = 3` retries at `timeout: 30s` each — is also 2 minutes, identical to the debounce window. That's not a margin, it's an exact match: the debounce is sized to the live path's configured ceiling, not to a ceiling-plus-buffer. If a live-path Tx2 run and DataCleaner's orphan sweep for the same action ever land inside that window at the same time, both are checking-then-acting outside a shared transaction, and the `@@unique(senderId, recipientId, cawonce)` constraint added in this PR is the only thing preventing a duplicate row in that case — not a second line of defense behind serialization, since one of the two callers isn't serialized at all.

Flagging this so a future change to either the debounce window or the retry ceiling doesn't quietly remove the only thing enforcing this invariant.

---

zinsanjp
