### PR TITLE
fix(validator): retry stranded finalize failures instead of losing them past the checkpoint

### DIFF
--- a/client/src/services/ValidatorService/index.ts
+++ b/client/src/services/ValidatorService/index.ts
@@ -4814,6 +4814,14 @@ console.log("succeededKeys", succeededKeys)
     // needs to run hourly — see the gate inside the loop body.
     let lastFinalizeRunAt = 0
 
+    // Concurrency guard for autoFinalizeSubmissions. The current call site
+    // awaits this function inline in the replication loop, so overlapping
+    // calls can't happen today — but that's a property of how the loop
+    // happens to be written, not something this function can rely on. Cheap
+    // insurance against a future refactor (e.g. firing it off without
+    // awaiting) causing two finalize passes to race on the same retry queue.
+    let isFinalizingSubmissions = false
+
     /**
      * Optimistic replication loop: submits checkpoint data directly to L2b
      * archive contract with stake-based security instead of LZ fees per batch.
@@ -5218,11 +5226,71 @@ console.log("succeededKeys", succeededKeys)
      * once, then write the checkpoint so subsequent ticks are cheap.
      */
     async function autoFinalizeSubmissions() {
+      if (isFinalizingSubmissions) return
+      isFinalizingSubmissions = true
       try {
         const { archiveRead: archive, archiveWrite: archiveW, l2bProvider: provider, l2bSubmitter: w } = await getL2bContracts()
 
         const latestBlock = await provider!.getBlockNumber()
         const checkpointKey = `optimistic-finalize:${w.getAddress().toLowerCase()}:last-block`
+        // Submissions that failed to finalize (transient RPC/gas error) go
+        // here instead of being dropped. Without this, the checkpoint below
+        // still advances unconditionally past their block — the only thing
+        // that changed is failures no longer strand the submission forever;
+        // they get retried here every cycle until they succeed, get resolved
+        // externally, or exhaust MAX_FINALIZE_RETRIES. Stored as a plain
+        // array (not JSON.stringify'd) since ChainData.value is a native
+        // Prisma Json column — same pattern as the checkpoint value above.
+        const retryKey = `optimistic-finalize:${w.getAddress().toLowerCase()}:pending-retry`
+        const MAX_FINALIZE_RETRIES = 10
+
+        interface RetryItem { id: number; retries: number }
+        const retryRecord = await prisma.chainData.findUnique({ where: { key: retryKey } })
+        const pendingRetries: RetryItem[] = Array.isArray(retryRecord?.value) ? retryRecord.value as any : []
+        const nextRetries: RetryItem[] = []
+
+        for (const item of pendingRetries) {
+          // getSubmission (read) and finalizeSubmission (write) are
+          // deliberately in separate try/catches. Both used to share one
+          // catch block, which meant an RPC hiccup on the read side spent a
+          // retry attempt identically to an actual finalize failure — during
+          // a provider outage, every pending submission would burn through
+          // MAX_FINALIZE_RETRIES on reads alone and dead-letter together,
+          // even though none of them had actually failed to finalize yet.
+          let sub: any
+          try {
+            sub = await archive.getSubmission(item.id)
+          } catch (readErr: any) {
+            // Couldn't even check status — leave retries untouched, try
+            // again next cycle. Don't count this against the submission.
+            nextRetries.push(item)
+            continue
+          }
+
+          const status = Number(sub[6])
+          if (status !== 0) continue // Finalized or slashed by someone else — drop from queue
+
+          const finalizedAt = Number(sub[5])
+          if (Math.floor(Date.now() / 1000) < finalizedAt) {
+            nextRetries.push(item) // Challenge period still active — keep waiting
+            continue
+          }
+
+          try {
+            console.log(`[OptimisticReplication] Retrying stranded submission ${item.id} (attempt ${item.retries + 1})...`)
+            const tx = await archiveW.finalizeSubmission(item.id)
+            await tx.wait()
+            console.log(`[OptimisticReplication] Finalized previously-stranded submission ${item.id}.`)
+          } catch (err: any) {
+            if (err?.reason?.includes('Not pending')) continue
+            if (item.retries + 1 >= MAX_FINALIZE_RETRIES) {
+              console.error(`[OptimisticReplication] Submission ${item.id} failed ${MAX_FINALIZE_RETRIES} times — dropping from retry queue. Last error: ${err?.shortMessage || err?.message}`)
+            } else {
+              nextRetries.push({ id: item.id, retries: item.retries + 1 })
+            }
+          }
+        }
+
         const cp = await prisma.chainData.findUnique({ where: { key: checkpointKey } })
         // ~12s/block on Arbitrum = ~28800 blocks/day. 4-day cold-start lookback.
         const cold = !cp
@@ -5231,54 +5299,80 @@ console.log("succeededKeys", succeededKeys)
           : Math.max(0, latestBlock - 28800 * 4)
         if (cold) console.log(`[OptimisticReplication] Cold-start finalize scan: ${fromBlock}..${latestBlock}`)
 
-        if (fromBlock > latestBlock) {
-          // No new blocks since last check. Common case — nothing to do.
-          return
-        }
+        if (fromBlock <= latestBlock) {
+          const events = await scanArchiveEvents(
+            archive,
+            provider,
+            archive.filters.SubmissionCreated(null, w.getAddress()),
+            fromBlock,
+            latestBlock,
+          )
 
-        const events = await scanArchiveEvents(
-          archive,
-          provider,
-          archive.filters.SubmissionCreated(null, w.getAddress()),
-          fromBlock,
-          latestBlock,
-        )
+          for (const ev of events) {
+            const args: any = ev.args
+            if (!args) continue
+            const submissionId = Number(args[0] || args.submissionId)
 
-        for (const ev of events) {
-          const args: any = ev.args
-          if (!args) continue
-          const submissionId = Number(args[0] || args.submissionId)
+            try {
+              const sub = await archive.getSubmission(submissionId)
+              const status = Number(sub[6]) // status enum: 0=PENDING, 1=FINALIZED, 2=SLASHED
+              if (status !== 0) continue // Not pending
 
-          try {
-            const sub = await archive.getSubmission(submissionId)
-            const status = Number(sub[6]) // status enum: 0=PENDING, 1=FINALIZED, 2=SLASHED
-            if (status !== 0) continue // Not pending
+              const finalizedAt = Number(sub[5])
+              const now = Math.floor(Date.now() / 1000)
+              if (now < finalizedAt) continue // Challenge period still active
 
-            const finalizedAt = Number(sub[5])
-            const now = Math.floor(Date.now() / 1000)
-            if (now < finalizedAt) continue // Challenge period still active
-
-            console.log(`[OptimisticReplication] Finalizing submission ${submissionId}...`)
-            const tx = await archiveW.finalizeSubmission(submissionId)
-            const receipt = await tx.wait()
-            console.log(`[OptimisticReplication] Finalized submission ${submissionId}. tx: ${receipt?.hash}`)
-          } catch (err: any) {
-            // Already finalized or slashed — not an error
-            if (err?.reason?.includes('Not pending')) continue
-            console.error(`[OptimisticReplication] Failed to finalize submission ${submissionId}: ${err?.shortMessage || err?.message}`)
+              console.log(`[OptimisticReplication] Finalizing submission ${submissionId}...`)
+              const tx = await archiveW.finalizeSubmission(submissionId)
+              const receipt = await tx.wait()
+              console.log(`[OptimisticReplication] Finalized submission ${submissionId}. tx: ${receipt?.hash}`)
+            } catch (err: any) {
+              // Already finalized or slashed — not an error
+              if (err?.reason?.includes('Not pending')) continue
+              console.error(`[OptimisticReplication] Failed to finalize submission ${submissionId}: ${err?.shortMessage || err?.message}`)
+              // Queue for retry instead of silently losing it — this is the
+              // fix for the stake-lock bug: a transient failure here used to
+              // mean this submission was never looked at again once the
+              // checkpoint (below) passed its block. Guard against a
+              // duplicate push: shouldn't happen since the checkpoint only
+              // moves forward (each submissionId's block is scanned once),
+              // but this loop's SubmissionCreated filter isn't proof against
+              // a future change reintroducing overlap, so check defensively.
+              if (!nextRetries.some(r => r.id === submissionId)) {
+                nextRetries.push({ id: submissionId, retries: 0 })
+              }
+            }
           }
         }
 
-        // Advance the checkpoint regardless of whether we found events. The
-        // next tick should resume from latestBlock+1 either way; failures
-        // above don't invalidate the scan range we already covered.
-        await prisma.chainData.upsert({
-          where: { key: checkpointKey },
-          create: { key: checkpointKey, value: latestBlock as any },
-          update: { value: latestBlock as any },
-        })
+        // The checkpoint always advances to latestBlock on every cycle,
+        // regardless of finalize failures above. This keeps the event scan
+        // window bounded to one cycle's worth of new blocks (never grows
+        // unbounded), so scanArchiveEvents/scanLogsForward's maxWindows cap
+        // is never at risk here — that's what the retry queue above is for.
+        //
+        // Both writes happen in one transaction: if the checkpoint advanced
+        // but this cycle's retry-queue update was lost (crash/OOM between
+        // the two), any newly-failed submission discovered this cycle would
+        // silently drop out of the retry queue forever — the exact bug this
+        // whole change exists to fix, just reintroduced at a lower
+        // probability. Committing them together closes that gap.
+        await prisma.$transaction([
+          prisma.chainData.upsert({
+            where: { key: checkpointKey },
+            create: { key: checkpointKey, value: latestBlock as any },
+            update: { value: latestBlock as any },
+          }),
+          prisma.chainData.upsert({
+            where: { key: retryKey },
+            create: { key: retryKey, value: nextRetries as any },
+            update: { value: nextRetries as any },
+          }),
+        ])
       } catch (err: any) {
         console.error(`[OptimisticReplication] Auto-finalize error: ${err?.shortMessage || err?.message}`)
+      } finally {
+        isFinalizingSubmissions = false
       }
     }
 


### PR DESCRIPTION
## Problem

`autoFinalizeSubmissions` in `ValidatorService/index.ts` periodically finalizes past submissions to release the validator's locked stake once the challenge period passes. If `finalizeSubmission` fails for a transient reason (RPC timeout, gas spike), the error was caught and logged, but the block checkpoint was still unconditionally advanced to `latestBlock`. Since the next cycle only scans from `checkpoint + 1`, the failed submission's block was never revisited — permanently stranding that submission's stake in the contract with no further attempt and no record of what was lost.

## Status of real-world impact

I could not confirm this has actually happened on my own nodes. On my V1, `DISABLE_OPTIMISTIC_REPLICATION=true` has been set since 2026-05-02 as an operational choice on my end (the `optimistic-finalize` checkpoint in `ChainData` hasn't moved since, consistent with that), so the code path this bug lives in hasn't run there. My V2 was rebuilt in early August after the CawProfileLedger wiring bug and doesn't have enough runtime yet to have hit this either.

That said, I can't speak for other validators' setups — if anyone else has been running with Optimistic Replication enabled, they may have hit this without it being obvious (the original bug leaves no trace once the checkpoint passes the failed submission's block). So this is a bug found by code review on my end, not one I've confirmed via an on-chain incident — flagging that distinction rather than overstating it, but not ruling out that it's already bitten someone. If anyone reviewing this has logs showing `Failed to finalize submission` from their own node, I'd be curious to see them.

## Fix

Added a persistent retry queue instead of relying solely on the checkpoint:

- Failed `submissionId`s are stored in `ChainData` under a separate key (`optimistic-finalize:<addr>:pending-retry`), as a plain array — `ChainData.value` is already a native `Json` column, so no `JSON.stringify`/`JSON.parse` round-trip is needed (matches how the existing checkpoint value is written).
- Each cycle retries the queue first, before the normal forward scan.
- A submission is dropped from the queue when it's already resolved by someone else (`status !== 0`) or after `MAX_FINALIZE_RETRIES` (10) consecutive failures — logged, not silently discarded.
- The block checkpoint still advances to `latestBlock` every cycle unconditionally. An earlier version of this fix instead held the checkpoint back to force a rescan, but that reintroduces its own failure mode: `scanLogsForward`'s `maxWindows` cap (100 chunks × 10k blocks ≈ 1M blocks, ~35 days on Arbitrum) means a long enough failure streak would make the scan itself start throwing. Keeping the checkpoint monotonic and routing failures through the retry queue instead avoids that entirely — the event scan window is always bounded to one cycle's worth of new blocks.
- Checkpoint and retry-queue writes happen in one `prisma.$transaction` — writing them separately would let a crash between the two silently drop that cycle's newly-failed submissions from the retry queue, reintroducing a lower-probability version of the same bug.
- `getSubmission` (read) and `finalizeSubmission` (write) failures are handled in separate try/catches. They used to share one — meaning an RPC error on the *read* side burned a retry attempt identically to an actual finalize failure. Under a provider outage, every pending submission would exhaust `MAX_FINALIZE_RETRIES` from failed status checks alone, dead-lettering submissions that never actually failed to finalize.
- Added a concurrency guard (`isFinalizingSubmissions`, module-scope flag). The current call site awaits this function inline in the replication loop, so overlapping calls can't happen today — this is cheap insurance against a future refactor changing that, not a fix for an active bug.

## Testing

Verified against an isolated test DB with a mocked contract (not touching any live install or RPC):
- Transient failure followed by recovery: submission retried and finalized on the next cycle, queue empties.
- Permanent failure (12 consecutive cycles): dead-lettered after 10 attempts, dropped from queue.
- External resolution while queued (status flips to finalized/slashed by another actor): removed from queue without calling `finalizeSubmission` again.
- Corrupted retry-queue value (non-array JSON) in `ChainData`: falls back to an empty queue rather than throwing.
- `getSubmission` failing repeatedly (read-side RPC error): retry count stays at 0 across 15 cycles, submission stays queued rather than dead-lettering on failed status checks.
- Concurrency guard: two overlapping invocations of a guarded function — one executes, one is skipped; a subsequent call after completion executes normally.

## Not addressed in this PR

- No alerting/notification when a submission dead-letters after 10 retries — it's logged via `console.error` only. An operator would need to be watching logs to notice. Worth a follow-up if this needs to surface more visibly.
- No cap on the total number of items the retry queue can hold — only per-item retry count is bounded. Given how infrequently submissions are created, this seems low-risk, but noting it as an unbounded-in-theory case.
- The concurrency guard only protects against overlapping calls within a single process; it does nothing for multiple processes/replicas running the same validator key concurrently, if that's ever a deployment shape here.

---

zinsanjp

