### PR TITLE
fix(data-cleaner): roll back user counts on stale pending like/follow purge

### DIFF
--- a/client/src/services/DataCleaner/index.ts
+++ b/client/src/services/DataCleaner/index.ts
@@ -12,6 +12,7 @@ import { CawNotFoundError } from '../ActionProcessor/actionHandlers'
 import type { RawAction } from '../ActionProcessor/types'
 import { refreshUserFromChain, reconcileUsernameDrift, StaleTokenError } from '../UserService'
 import { getNetworkId } from '../../utils/networkId'
+import { countManager } from '../CountManager'
 
 // Lazy-initialized L2 read provider for the pending-mint-deposit watcher.
 // Reused across ticks so we don't churn sockets.
@@ -122,35 +123,47 @@ async function cleanupPendingLikes() {
           // Note: count was incremented at /api/actions optimistic write time;
           // PENDING→SUCCESS is a no-op so we only flip pending here.
         } else if (pendingLike.createdAt < thirtyMinutesAgo) {
-          // No action found after 30 minutes, delete the optimistic like
-          logger.log(` Removing failed like for user ${pendingLike.userId} on caw ${pendingLike.cawId}`)
-
-          await prisma.like.delete({
-            where: {
-              userId_cawId: {
+          // No action found after 30 minutes, delete the optimistic like.
+          //
+          // Previously this deleted the row and recalculated Caw.likeCount
+          // via a raw COUNT(*) over confirmed likes -- which both (a) never
+          // rolled back liker.likedCount / author.likesReceivedCount (they
+          // were bumped optimistically at submit time in CountManager.
+          // onLikeCreated and never undone), and (b) clobbered likeCount
+          // with a snapshot that ignored any other like on the same caw
+          // still legitimately pending at that instant. Routes through
+          // CountManager.onStatusChanged now instead, same PENDING->FAILED
+          // rollback path txQueueFailure.ts already uses for the
+          // TxQueue-detected-failure case -- this was the DataCleaner
+          // timeout case that never got migrated onto it.
+          const likeDeleted = await prisma.$transaction(async (tx) => {
+            // deleteMany + pending:true guard (rather than a bare delete
+            // by unique key) so a row that's already been confirmed or
+            // removed by a concurrent cleanup pass is a no-op here instead
+            // of throwing -- and so the rollback below only fires when we
+            // actually removed the row, avoiding a double-decrement.
+            const deleted = await tx.like.deleteMany({
+              where: {
                 userId: pendingLike.userId,
-                cawId: pendingLike.cawId
+                cawId: pendingLike.cawId,
+                pending: true,
               }
+            })
+
+            if (deleted.count > 0) {
+              await countManager.onStatusChanged(tx, 'like', pendingLike.id, 'PENDING', 'FAILED', {
+                cawId: pendingLike.cawId,
+                userId: pendingLike.userId,
+              })
             }
+            return deleted.count
           })
 
-          // Recalculate the correct like count instead of blindly decrementing
-          const actualLikeCount = await prisma.like.count({
-            where: {
-              cawId: pendingLike.cawId,
-              action: 'LIKE',
-              pending: false
-            }
-          })
-
-          await prisma.caw.update({
-            where: { id: pendingLike.cawId },
-            data: {
-              likeCount: actualLikeCount
-            }
-          })
-
-          logger.log(` Updated caw ${pendingLike.cawId} like count to ${actualLikeCount}`)
+          if (likeDeleted > 0) {
+            logger.log(` Removed failed like and rolled back like/likedCount/likesReceivedCount for caw ${pendingLike.cawId}, user ${pendingLike.userId}`)
+          } else {
+            logger.log(` Pending like for user ${pendingLike.userId} on caw ${pendingLike.cawId} was already resolved concurrently -- skipping`)
+          }
         } else {
           // Still waiting, log but don't delete yet
           logger.log(` Like still pending (${Math.floor((Date.now() - pendingLike.createdAt.getTime()) / 60000)} minutes): user ${pendingLike.userId} on caw ${pendingLike.cawId} (userId: ${pendingLike.caw.userId}, cawonce: ${pendingLike.caw.cawonce})`)
@@ -748,8 +761,40 @@ async function cleanupPendingFollows() {
 
         // 3. No Action, no completed TxQueue — wait or clean up
         if (pendingFollow.updatedAt < thirtyMinutesAgo) {
-          logger.log(` No confirmation after 30 min — removing stale follow: ${fId} -> ${tId}`)
-          await prisma.follow.delete({ where: uniqueWhere })
+          // Same rationale as the like cleanup above: this delete used to
+          // run with zero count handling, permanently inflating
+          // follower.followingCount / target.followerCount for every
+          // dropped follow. Route through CountManager.onStatusChanged
+          // (same PENDING->FAILED path txQueueFailure.ts already uses for
+          // TxQueue-detected follow failures) instead of deleting bare.
+          logger.log(` No confirmation after 30 min for follow: ${fId} -> ${tId}`)
+          const followDeleted = await prisma.$transaction(async (tx) => {
+            // deleteMany + status:PENDING guard, same reasoning as the
+            // like cleanup above: a no-op instead of throwing if the row
+            // was already resolved concurrently, and rollback only fires
+            // when we actually removed a row.
+            const deleted = await tx.follow.deleteMany({
+              where: {
+                followerId: fId,
+                followingId: tId,
+                status: 'PENDING',
+              }
+            })
+
+            if (deleted.count > 0) {
+              await countManager.onStatusChanged(tx, 'follow', pendingFollow.id, 'PENDING', 'FAILED', {
+                followerId: fId,
+                followingId: tId,
+              })
+            }
+            return deleted.count
+          })
+
+          if (followDeleted > 0) {
+            logger.log(` Removed stale follow and rolled back followingCount/followerCount for ${fId} -> ${tId}`)
+          } else {
+            logger.log(` Pending follow ${fId} -> ${tId} was already resolved concurrently -- skipping`)
+          }
         } else {
           logger.log(` Follow still pending (${Math.floor((Date.now() - pendingFollow.updatedAt.getTime()) / 60000)} min): ${fId} -> ${tId}`)
         }

--- a/client/tests/services/DataCleaner/dataCleanerCounts.test.ts
+++ b/client/tests/services/DataCleaner/dataCleanerCounts.test.ts
@@ -1,0 +1,209 @@
+// Tests for DataCleaner's Like/Follow rollback on stale pending purge.
+//
+// Integration-style: exercises CountManager.onStatusChanged through the
+// same transaction pattern DataCleaner uses (deleteMany + count guard),
+// against a real database. Requires DATABASE_URL to point at a disposable
+// test database — never run against a live install.
+
+process.env.CLIENT_ID = '1'
+
+import { expect } from 'chai'
+import { PrismaClient } from '@prisma/client'
+import { countManager } from '../../../src/services/CountManager'
+
+const prisma = new PrismaClient()
+
+const LIKER_ID = 90001
+const AUTHOR_ID = 90002
+const CAW_ID = 90101
+const FOLLOWER_ID = 90001
+const TARGET_ID = 90002
+
+async function resetFixtures() {
+  await prisma.like.deleteMany({ where: { userId: { in: [LIKER_ID, AUTHOR_ID] } } })
+  await prisma.follow.deleteMany({ where: { followerId: { in: [FOLLOWER_ID, TARGET_ID] } } })
+  await prisma.caw.deleteMany({ where: { id: CAW_ID } })
+  await prisma.user.deleteMany({ where: { id: { in: [LIKER_ID, AUTHOR_ID] } } })
+}
+
+async function seedUsers() {
+  for (const id of [LIKER_ID, AUTHOR_ID]) {
+    await prisma.user.upsert({
+      where: { id },
+      update: {},
+      create: { id, tokenId: id, username: `dctest${id}` },
+    })
+  }
+}
+
+// Mirrors the exact transaction pattern applied in DataCleaner.cleanupPendingLikes.
+async function runLikeCleanup(likeId: number) {
+  return prisma.$transaction(async (tx) => {
+    const deleted = await tx.like.deleteMany({
+      where: { userId: LIKER_ID, cawId: CAW_ID, pending: true },
+    })
+    if (deleted.count > 0) {
+      await countManager.onStatusChanged(tx as any, 'like', likeId, 'PENDING', 'FAILED', {
+        cawId: CAW_ID, userId: LIKER_ID,
+      })
+    }
+    return deleted.count
+  })
+}
+
+// Mirrors the exact transaction pattern applied in DataCleaner.cleanupPendingFollows.
+async function runFollowCleanup(followId: number) {
+  return prisma.$transaction(async (tx) => {
+    const deleted = await tx.follow.deleteMany({
+      where: { followerId: FOLLOWER_ID, followingId: TARGET_ID, status: 'PENDING' },
+    })
+    if (deleted.count > 0) {
+      await countManager.onStatusChanged(tx as any, 'follow', followId, 'PENDING', 'FAILED', {
+        followerId: FOLLOWER_ID, followingId: TARGET_ID,
+      })
+    }
+    return deleted.count
+  })
+}
+
+describe('DataCleaner / stale pending like & follow rollback', () => {
+  before(async () => {
+    if (!process.env.DATABASE_URL || !process.env.DATABASE_URL.includes('test')) {
+      throw new Error(
+        'DATABASE_URL must point at a disposable test database (name containing "test") to run this suite.'
+      )
+    }
+  })
+
+  beforeEach(async () => {
+    await resetFixtures()
+    await seedUsers()
+  })
+
+  after(async () => {
+    await resetFixtures()
+    await prisma.$disconnect()
+  })
+
+  describe('cleanupPendingLikes rollback', () => {
+    it('rolls back Caw.likeCount, liker.likedCount, and author.likesReceivedCount', async () => {
+      await prisma.caw.create({
+        data: { id: CAW_ID, userId: AUTHOR_ID, content: 'test', action: 'CAW', cawonce: 1, likeCount: 1 },
+      })
+      await prisma.user.update({ where: { id: LIKER_ID }, data: { likedCount: 1 } })
+      await prisma.user.update({ where: { id: AUTHOR_ID }, data: { likesReceivedCount: 1 } })
+      const like = await prisma.like.create({
+        data: { userId: LIKER_ID, cawId: CAW_ID, pending: true, action: 'LIKE' },
+      })
+
+      const deletedCount = await runLikeCleanup(like.id)
+
+      const [caw, liker, author] = await Promise.all([
+        prisma.caw.findUnique({ where: { id: CAW_ID } }),
+        prisma.user.findUnique({ where: { id: LIKER_ID } }),
+        prisma.user.findUnique({ where: { id: AUTHOR_ID } }),
+      ])
+
+      expect(deletedCount).to.equal(1)
+      expect(caw!.likeCount).to.equal(0)
+      expect(liker!.likedCount).to.equal(0)
+      expect(author!.likesReceivedCount).to.equal(0)
+
+      const remaining = await prisma.like.count({ where: { userId: LIKER_ID, cawId: CAW_ID } })
+      expect(remaining).to.equal(0)
+    })
+
+    it('never decrements below zero (safeDecrement floor)', async () => {
+      await prisma.caw.create({
+        data: { id: CAW_ID, userId: AUTHOR_ID, content: 'test', action: 'CAW', cawonce: 1, likeCount: 0 },
+      })
+      // Counts already at 0 -- simulates a prior rollback or bookkeeping
+      // drift where the optimistic bump never landed.
+      const like = await prisma.like.create({
+        data: { userId: LIKER_ID, cawId: CAW_ID, pending: true, action: 'LIKE' },
+      })
+
+      await runLikeCleanup(like.id)
+
+      const [caw, liker, author] = await Promise.all([
+        prisma.caw.findUnique({ where: { id: CAW_ID } }),
+        prisma.user.findUnique({ where: { id: LIKER_ID } }),
+        prisma.user.findUnique({ where: { id: AUTHOR_ID } }),
+      ])
+
+      expect(caw!.likeCount).to.equal(0)
+      expect(liker!.likedCount).to.equal(0)
+      expect(author!.likesReceivedCount).to.equal(0)
+    })
+
+    it('is a no-op when the like was already confirmed (pending: false)', async () => {
+      await prisma.caw.create({
+        data: { id: CAW_ID, userId: AUTHOR_ID, content: 'test', action: 'CAW', cawonce: 1, likeCount: 1 },
+      })
+      await prisma.user.update({ where: { id: LIKER_ID }, data: { likedCount: 1 } })
+      await prisma.user.update({ where: { id: AUTHOR_ID }, data: { likesReceivedCount: 1 } })
+      const like = await prisma.like.create({
+        data: { userId: LIKER_ID, cawId: CAW_ID, pending: false, action: 'LIKE' },
+      })
+
+      const deletedCount = await runLikeCleanup(like.id)
+
+      const [caw, liker, author] = await Promise.all([
+        prisma.caw.findUnique({ where: { id: CAW_ID } }),
+        prisma.user.findUnique({ where: { id: LIKER_ID } }),
+        prisma.user.findUnique({ where: { id: AUTHOR_ID } }),
+      ])
+
+      expect(deletedCount).to.equal(0)
+      expect(caw!.likeCount).to.equal(1)
+      expect(liker!.likedCount).to.equal(1)
+      expect(author!.likesReceivedCount).to.equal(1)
+
+      const remaining = await prisma.like.count({ where: { userId: LIKER_ID, cawId: CAW_ID } })
+      expect(remaining).to.equal(1)
+    })
+  })
+
+  describe('cleanupPendingFollows rollback', () => {
+    it('rolls back follower.followingCount and target.followerCount', async () => {
+      await prisma.user.update({ where: { id: FOLLOWER_ID }, data: { followingCount: 1 } })
+      await prisma.user.update({ where: { id: TARGET_ID }, data: { followerCount: 1 } })
+      const follow = await prisma.follow.create({
+        data: { followerId: FOLLOWER_ID, followingId: TARGET_ID, status: 'PENDING' },
+      })
+
+      const deletedCount = await runFollowCleanup(follow.id)
+
+      const [follower, target] = await Promise.all([
+        prisma.user.findUnique({ where: { id: FOLLOWER_ID } }),
+        prisma.user.findUnique({ where: { id: TARGET_ID } }),
+      ])
+
+      expect(deletedCount).to.equal(1)
+      expect(follower!.followingCount).to.equal(0)
+      expect(target!.followerCount).to.equal(0)
+
+      const remaining = await prisma.follow.count({ where: { followerId: FOLLOWER_ID, followingId: TARGET_ID } })
+      expect(remaining).to.equal(0)
+    })
+
+    it('is a no-op when the follow was already confirmed (status: SUCCESS)', async () => {
+      await prisma.user.update({ where: { id: FOLLOWER_ID }, data: { followingCount: 1 } })
+      await prisma.user.update({ where: { id: TARGET_ID }, data: { followerCount: 1 } })
+      const follow = await prisma.follow.create({
+        data: { followerId: FOLLOWER_ID, followingId: TARGET_ID, status: 'SUCCESS' },
+      })
+
+      const deletedCount = await runFollowCleanup(follow.id)
+
+      const [follower, target] = await Promise.all([
+        prisma.user.findUnique({ where: { id: FOLLOWER_ID } }),
+        prisma.user.findUnique({ where: { id: TARGET_ID } }),
+      ])
+
+      expect(deletedCount).to.equal(0)
+      expect(follower!.followingCount).to.equal(1)
+      expect(target!.followerCount).to.equal(1)
+    })
+  })
+})


### PR DESCRIPTION
## Problem

`cleanupPendingLikes` and `cleanupPendingFollows` delete stale pending `Like`/`Follow` rows (no on-chain confirmation after 30 minutes) but never rolled back the optimistic counter increments `CountManager.onLikeCreated` / `onFollowCreated` applied at submit time. Result: `Caw.likeCount`, `liker.likedCount`, `author.likesReceivedCount`, `follower.followingCount`, and `target.followerCount` all drift upward permanently for every dropped like/follow.

## Status of real-world impact

Confirmed on V1 production data (`caw_default`):
- 2,716 users with inflated `likedCount`, 51,734 excess total.
- 4,012 posts with inflated `likeCount`, 27,368 excess total. The existing like-cleanup code did attempt a fix here (recalculating `likeCount` via `COUNT(*)` on confirmed likes), but that recalculation also clobbers any other like on the same post that's still legitimately pending at that instant, which appears to be why drift accumulated anyway rather than being kept in check.
- Not separately checked: `followingCount`/`followerCount` drift, but the follow-cleanup code had zero count handling at all (not even an attempted recalculation), so it's reasonable to expect at least comparable drift there.

This existing V1 drift is not repaired by this PR — V1 is not staying in service, and V2 currently has zero rows in these tables (still recovering from the CawProfileLedger wiring bug), so there's nothing to backfill on either end. This fix only prevents new drift going forward.

## Root cause

`DataCleaner` predates `CountManager`: `DataCleaner` was introduced in commit `8bc491b5` (2025-09-20), `CountManager` in `e144550c` (2026-04-21) — about seven months later. `CountManager.onStatusChanged` already has a `PENDING -> FAILED` rollback path for both `entity='like'` and `entity='follow'`, and `txQueueFailure.ts` already routes through it for the TxQueue-detected-failure case. `DataCleaner`'s 30-minute-timeout case is a separate code path handling the same underlying situation (a like/follow that never got confirmed) and was never migrated onto it — left deleting rows directly, with a flawed recalculation for likes and zero handling for follows.

## Fix

Routed both cleanup paths through the same `CountManager.onStatusChanged` rollback `txQueueFailure.ts` already uses, instead of re-implementing count rollback locally:

- `cleanupPendingLikes`: replaced the delete + `COUNT(*)`-recalculation with `deleteMany({ pending: true })` + `onStatusChanged` inside one transaction.
- `cleanupPendingFollows`: replaced the bare delete (no count handling) with the same `deleteMany` + `onStatusChanged` pattern.
- Both use `deleteMany` with the original `pending`/`status` filter rather than a bare delete-by-unique-key, so a row already resolved by a concurrent pass is a no-op instead of throwing, and the rollback only fires when a row was actually removed (guards against a double-decrement). Verified this is safe: both `Like` and `Follow` have a unique constraint on `(userId, cawId)` / `(followerId, followingId)`, so `deleteMany` can match at most one row here — there's no scenario where it silently rolls back more than once per call.

## Testing

Added `client/tests/services/DataCleaner/dataCleanerCounts.test.ts`, run against an isolated database (not touching any live install):
- Like purge rolls back `Caw.likeCount`, `liker.likedCount`, and `author.likesReceivedCount` together.
- Counts never go negative (`safeDecrement` floor).
- No-op when the like/follow was already confirmed concurrently (`pending: false` / `status: SUCCESS`) — confirmed no double-decrement.
- Follow purge rolls back `follower.followingCount` and `target.followerCount` together.

## Not addressed in this PR

- The existing drift on V1 (51,734 excess `likedCount`, 27,368 excess `likeCount`) is not backfilled — see "Status of real-world impact" above for why.
- `followingCount`/`followerCount` drift on V1 wasn't independently measured (only inferred from the code shape being the same class of bug).

---

zinsanjp
