### PR TITLE
fix(api): reject unauthenticated upload requests before buffering in multer

### DIFF
--- a/client/src/api/routes/upload.ts
+++ b/client/src/api/routes/upload.ts
@@ -131,7 +131,18 @@ const upload = multer({
   }
 })
 
-router.post('/', upload.array('media', 10), requireAuth({ field: 'tokenId', verifyOwnership: true }), async (req: any, res: any) => {
+// Pre-auth guard: requireAuth({ anySession: true }) only needs the
+// Authorization/cookie header (via extractSession), so it can reject
+// unauthenticated requests before Multer buffers the multipart body into
+// heap memory. Without this, an unauthenticated request still gets a 401,
+// but only after Multer has already read the full payload (up to 100MB:
+// 10 files x 10MB) into memory -- letting an unauthenticated client burn
+// server memory it was never going to be allowed to use.
+//
+// The downstream requireAuth({ field: 'tokenId', verifyOwnership: true })
+// is unchanged and still runs after Multer, since it needs the parsed
+// body.tokenId.
+router.post('/', requireAuth({ anySession: true }), upload.array('media', 10), requireAuth({ field: 'tokenId', verifyOwnership: true }), async (req: any, res: any) => {
   try {
     const { tokenId } = req.body
     const files = req.files as Express.Multer.File[]
@@ -213,7 +224,8 @@ const variantUpload = multer({
   },
 })
 
-router.post('/variant', variantUpload.single('media'), requireAuth({ field: 'tokenId', verifyOwnership: true }), async (req: any, res: any) => {
+// Same pre-auth guard as POST / above -- see the comment there.
+router.post('/variant', requireAuth({ anySession: true }), variantUpload.single('media'), requireAuth({ field: 'tokenId', verifyOwnership: true }), async (req: any, res: any) => {
   try {
     const { baseFilename, width } = req.body
     const file = req.file as Express.Multer.File | undefined


### PR DESCRIPTION
## Problem

`POST /api/upload` and `POST /api/upload/variant` mount Multer (`multer.memoryStorage()`) before the `requireAuth` check:

```typescript
router.post('/', upload.array('media', 10), requireAuth({ field: 'tokenId', verifyOwnership: true }), ...)
router.post('/variant', variantUpload.single('media'), requireAuth({ field: 'tokenId', verifyOwnership: true }), ...)
```

This is necessary because `requireAuth({ field: 'tokenId' })` reads `req.body.tokenId`, which only exists after Multer parses the multipart body — so ownership verification genuinely has to run after Multer. But the session check itself (`extractSession`, reading the `Authorization`/cookie header) doesn't need the parsed body at all, and currently only runs after Multer has already buffered the full upload into memory.

## Status of real-world impact / severity

Confirmed the theoretical worst case is smaller than it first looks: `/api/upload` already has an IP-based rate limit — 10 requests/day for unauthenticated traffic (`server.ts`, mounted ahead of the router). So a single-IP attacker can't do unbounded damage today; the realistic exposure is closer to 10 × 100MB = ~1GB of wasted buffering per IP per day, not an unbounded flood. This is still worth fixing (the rate limit is IP-based and trivially bypassed with multiple source IPs, and 1GB/IP/day multiplied across many IPs is a real cost), but I want to be upfront that this isn't "the server falls over from a single attacker" the way an initial read might suggest — the existing rate limit is already doing real work here, and this change is additive defense-in-depth on top of it, not the only thing standing between the server and an OOM crash.

## Fix

Added a lightweight `requireAuth({ anySession: true })` guard before Multer, keeping the existing `requireAuth({ field: 'tokenId', verifyOwnership: true })` check after Multer parses `req.body` unchanged:

```typescript
router.post(
  '/',
  requireAuth({ anySession: true }),                          // reject before any bytes are buffered
  upload.array('media', 10),
  requireAuth({ field: 'tokenId', verifyOwnership: true }),    // unchanged — still needs parsed body.tokenId
  async (req, res) => { ... }
)
```

Same change applied to `/variant`. The ownership-verification middleware itself is untouched — it reads `req.sessionData` (set by `extractSession`, unaffected by this change) and `req.body.tokenId` (set by Multer, also unaffected), so its behavior for authenticated requests is identical before and after.

## Testing

Built an isolated Express+Multer repro (not touching any live install) mirroring the before/after middleware order, and measured actual process RSS rather than relying on the 401 status code alone:

- **Before** (Multer first): 10 unauthenticated requests × 5MB each — all correctly returned 401, but server RSS grew by ~74MB, confirming the full payload was buffered before rejection.
- **After** (anySession guard first): same 10×5MB attempt — RSS grew by ~3MB (noise-level, not Multer-attributable) and total request time dropped from 1.75s to 0.14s.
- Added a debug hook directly in the Multer-adjacent middleware to confirm this isn't just inferred from memory numbers: for all 10 unauthenticated requests post-fix, **the Multer stage was never reached** — zero hits logged.

## Not addressed in this PR

- `extractSession` still does one Redis lookup (`getSession`) per request regardless of whether the token is valid, garbage, or absent-with-a-header-present. A flood of requests carrying junk session tokens (empty body, no file) would still generate Redis load — this fix stops the memory-buffering DoS, not a Redis-request-volume DoS. That's a pre-existing shape (the original code also called `extractSession` via `requireAuth({ field: 'tokenId' })`), not something this PR introduces, but noting it since "DoS fix" could otherwise read as more complete than it is.
- The two `requireAuth` calls per authenticated request each do their own `extractSession`/`getSession` round-trip (previously one, now two). `getSession` is backed by Redis, not Postgres, so the added latency should be sub-millisecond — not flagging this as a real concern, just noting the duplication exists.
- `/bug-report`'s stated "4MB" limit in earlier notes on this issue was imprecise — it's actually 1MB per file × 4 files (`IMAGE_MAX_BYTES = 1MB`, `files: 4`), which does total 4MB but isn't a single 4MB cap. No code change needed here, just correcting the description for anyone cross-referencing it.

---

zinsanjp