### PR TITLE
fix(raw-events): distinguish RPC failure from irrelevant tx when unpacking calldata, and stop advancing the cursor on failure

### DIFF
--- a/client/scripts/verify-raw-events-rescan-skip.js
+++ b/client/scripts/verify-raw-events-rescan-skip.js
@@ -3,7 +3,9 @@
 // which has no catch around the historical-sync call site and would
 // otherwise crash the service on restart for nodes on non-archive RPCs).
 // Mirrors the all-or-nothing countExisting check added before the
-// processEvents(past, ...) call.
+// processEvents(past, ...) call, and the flag-based branch (rather than
+// clearing `past`) added after review found that clearing `past` corrupts
+// the poll cursor's seed value read further down in the same function.
 // Run: node scripts/verify-raw-events-rescan-skip.js
 
 let failures = 0
@@ -28,29 +30,40 @@ function makeStore(existingKeys) {
   }
 }
 
-// --- Mirrors the all-or-nothing skip logic added before
-//     `await processEvents(past, httpContract)` ---
-async function resolvePastAfterSkipCheck(past, rawEventsProvider) {
-  if (past.length > 0 && rawEventsProvider.countExisting) {
-    const existingCount = await rawEventsProvider.countExisting(past)
-    if (existingCount === past.length) {
-      return [] // skip: nothing new to derive
-    }
-  }
-  return past // unchanged: at least one genuinely new event
+// --- Mirrors the CURRENT implementation: a flag decides whether
+//     processEvents() runs, but `past` itself is never mutated. Also
+//     mirrors the lastSyncedBlock seed read that lives further down in the
+//     real function: `past.length > 0 ? past[past.length - 1].blockNumber
+//     : startBlock`. Returns both so tests can check the skip decision AND
+//     that the seed still resolves off the real scanned range. ---
+async function resolveSkipAndSeed(past, rawEventsProvider, startBlock) {
+  const skipDerive =
+    past.length > 0 &&
+    !!rawEventsProvider.countExisting &&
+    (await rawEventsProvider.countExisting(past)) === past.length
+
+  // past is intentionally NOT reassigned here -- this is the bug tentencaw
+  // caught: the original implementation did `past = []` on skip, which
+  // corrupted this exact read.
+  const lastSyncedBlockSeed = past.length > 0 ? past[past.length - 1].blockNumber : startBlock
+
+  return { skipDerive, past, lastSyncedBlockSeed }
 }
 
-// 1) Empty past: no-op regardless of provider. Guards against calling
-//    countExisting on an empty array (would be a wasted DB round trip).
+// 1) Empty past: no skip decision needed, seed falls through to startBlock
+//    regardless (nothing was scanned). Guards against calling countExisting
+//    on an empty array (would be a wasted DB round trip).
 async function test1() {
   const provider = makeStore([])
-  const result = await resolvePastAfterSkipCheck([], provider)
-  check('1: empty past stays empty, countExisting not required to be called', result, [])
+  const { skipDerive, past, lastSyncedBlockSeed } = await resolveSkipAndSeed([], provider, 1000)
+  check('1a: empty past never triggers skip', skipDerive, false)
+  check('1b: empty past stays empty', past, [])
+  check('1c: empty past seeds from startBlock', lastSyncedBlockSeed, 1000)
 }
 
-// 2) All events already stored: rescan should skip entirely (past -> []),
-//    which is what prevents the fetch_failed throw for settled history on
-//    non-archive RPCs.
+// 2) All events already stored: skipDerive is true (processEvents is
+//    skipped), but `past` itself must remain the full scanned array so the
+//    seed below reads the real last-scanned block, not startBlock.
 async function test2() {
   const events = [
     { blockNumber: 100, logIndex: 0, transactionHash: '0xaaa' },
@@ -58,56 +71,62 @@ async function test2() {
     { blockNumber: 101, logIndex: 0, transactionHash: '0xccc' },
   ]
   const provider = makeStore(events.map(e => `${e.blockNumber}:${e.logIndex}:${e.transactionHash}`))
-  const result = await resolvePastAfterSkipCheck(events, provider)
-  check('2: all-known past is skipped (resolves to empty array)', result, [])
+  const { skipDerive, past, lastSyncedBlockSeed } = await resolveSkipAndSeed(events, provider, 50)
+  check('2a: all-known past triggers skip', skipDerive, true)
+  check('2b: past is NOT cleared -- stays the full scanned array', past, events)
+  check('2c: seed reads the real last-scanned block (101), not startBlock (50)', lastSyncedBlockSeed, 101)
 }
 
-// 3) None stored (fresh node, cold start): rescan must proceed unchanged so
-//    genuinely new events still get processed normally.
+// 3) None stored (fresh node, cold start): no skip, processEvents runs on
+//    the full array, seed reads the last scanned block as usual.
 async function test3() {
   const events = [
     { blockNumber: 200, logIndex: 0, transactionHash: '0xddd' },
     { blockNumber: 200, logIndex: 1, transactionHash: '0xeee' },
   ]
   const provider = makeStore([])
-  const result = await resolvePastAfterSkipCheck(events, provider)
-  check('3: none-known past passes through unchanged', result, events)
+  const { skipDerive, past, lastSyncedBlockSeed } = await resolveSkipAndSeed(events, provider, 10)
+  check('3a: none-known past does not trigger skip', skipDerive, false)
+  check('3b: none-known past passes through unchanged', past, events)
+  check('3c: seed reads the last scanned block', lastSyncedBlockSeed, 200)
 }
 
-// 4) Partial overlap (some already stored, some genuinely new): must NOT
-//    skip and must NOT filter down to just the new ones -- all-or-nothing,
-//    per tentencaw's point that per-event filtering would break the
-//    sequential parentHash chaining in processEvents, which depends on
-//    processing the full contiguous range in order.
+// 4) Partial overlap (some already stored, some genuinely new): no skip --
+//    all-or-nothing, per tentencaw's original point that per-event
+//    filtering would break the sequential parentHash chaining in
+//    processEvents, which depends on processing the full contiguous range
+//    in order.
 async function test4() {
   const events = [
     { blockNumber: 300, logIndex: 0, transactionHash: '0xfff' }, // already stored
     { blockNumber: 300, logIndex: 1, transactionHash: '0x111' }, // genuinely new
   ]
   const provider = makeStore(['300:0:0xfff'])
-  const result = await resolvePastAfterSkipCheck(events, provider)
-  check('4: partial overlap passes through the FULL unfiltered array (all-or-nothing)', result, events)
+  const { skipDerive, past } = await resolveSkipAndSeed(events, provider, 10)
+  check('4a: partial overlap does not trigger skip', skipDerive, false)
+  check('4b: partial overlap passes through the FULL unfiltered array (all-or-nothing)', past, events)
 }
 
 // 5) Backward compatibility: rawEventsProvider without countExisting (older
 //    caller, or a provider that hasn't implemented the optional method)
-//    must behave exactly as before this fix -- past always passes through.
+//    must never skip -- processEvents always runs, matching pre-fix
+//    behavior.
 async function test5() {
   const events = [
     { blockNumber: 400, logIndex: 0, transactionHash: '0x222' },
   ]
   const providerWithoutCountExisting = {} // countExisting intentionally absent
-  const result = await resolvePastAfterSkipCheck(events, providerWithoutCountExisting)
-  check('5: provider without countExisting leaves past untouched (backward compatible)', result, events)
+  const { skipDerive, past } = await resolveSkipAndSeed(events, providerWithoutCountExisting, 10)
+  check('5a: provider without countExisting never skips', skipDerive, false)
+  check('5b: past left untouched (backward compatible)', past, events)
 }
 
-// 6) The specific regression tentencaw reported: 59 events, all already
-//    stored, on a non-archive RPC that can no longer serve their tx bodies.
-//    Before this fix, processEvents would throw fetch_failed for all 59 on
-//    every restart, and since the historical-sync call site has no catch
-//    around it (unlike poll()'s), that crashes the whole service. After
-//    this fix, the rescan recognizes all 59 are already ingested and never
-//    calls processEvents on them at all.
+// 6) The specific regression tentencaw originally reported: 59 events, all
+//    already stored, on a non-archive RPC that can no longer serve their tx
+//    bodies. Before the countExisting fix, processEvents would throw
+//    fetch_failed for all 59 on every restart, crashing the service since
+//    the historical-sync call site has no catch around it. After the fix,
+//    skipDerive is true and processEvents is never called on them.
 async function test6() {
   const events = Array.from({ length: 59 }, (_, i) => ({
     blockNumber: 1000 + i,
@@ -115,16 +134,13 @@ async function test6() {
     transactionHash: `0xtx${i}`,
   }))
   const provider = makeStore(events.map(e => `${e.blockNumber}:${e.logIndex}:${e.transactionHash}`))
-  const result = await resolvePastAfterSkipCheck(events, provider)
-  check('6: reported regression scenario (59/59 already stored) resolves to empty, avoiding the fetch_failed throw', result, [])
+  const { skipDerive, lastSyncedBlockSeed } = await resolveSkipAndSeed(events, provider, 500)
+  check('6a: reported regression scenario (59/59 already stored) triggers skip', skipDerive, true)
+  check('6b: seed reads the last of the 59 scanned blocks, not the floor (500)', lastSyncedBlockSeed, 1058)
 }
 
-// 7) countExisting itself is batched internally (COUNT_EXISTING_BATCH_SIZE
-//    in RawEventsGatherer/index.ts) to keep any single query's OR clause
-//    bounded on nodes with large RawEvent tables. Simulate a countExisting
-//    that enforces its own batch limit (mirrors the real implementation's
-//    chunking) and confirm the skip logic still resolves correctly when the
-//    event count crosses multiple batches.
+// --- Batched countExisting, same as the real implementation's internal
+//     chunking (COUNT_EXISTING_BATCH_SIZE in RawEventsGatherer/index.ts) ---
 function makeBatchedStore(existingKeys, batchSize) {
   const stored = new Set(existingKeys)
   return {
@@ -142,16 +158,39 @@ function makeBatchedStore(existingKeys, batchSize) {
   }
 }
 
+// 7) All-known past spanning multiple internal countExisting batches still
+//    triggers the skip correctly.
 async function test7() {
-  // 12 events, batch size 5 -> 3 batches (5, 5, 2). All stored.
   const events = Array.from({ length: 12 }, (_, i) => ({
     blockNumber: 500 + i,
     logIndex: 0,
     transactionHash: `0xbatch${i}`,
   }))
   const provider = makeBatchedStore(events.map(e => `${e.blockNumber}:${e.logIndex}:${e.transactionHash}`), 5)
-  const result = await resolvePastAfterSkipCheck(events, provider)
-  check('7: all-known past spanning multiple internal batches still resolves to empty', result, [])
+  const { skipDerive } = await resolveSkipAndSeed(events, provider, 10)
+  check('7: all-known past spanning multiple internal batches still triggers skip', skipDerive, true)
+}
+
+// 8) THE REGRESSION tentencaw caught in review: the original implementation
+//    did `past = []` when skipping, which corrupted the lastSyncedBlock
+//    seed read (`past.length > 0 ? past[...].blockNumber : startBlock`) --
+//    on a node with a configured startBlock, that fell through to the
+//    floor instead of the real high-water mark, sending every subsequent
+//    poll tick re-walking the whole floor-to-tip range on every restart
+//    where the skip fires. This test locks in that the CURRENT
+//    implementation (flag-based, past left untouched) does not reproduce
+//    that: the seed must equal the real last-scanned block even when the
+//    skip fires and the configured startBlock floor is far below it.
+async function test8() {
+  const events = [
+    { blockNumber: 45723253, logIndex: 0, transactionHash: '0xlatest1' },
+    { blockNumber: 45723253, logIndex: 1, transactionHash: '0xlatest2' },
+  ]
+  const provider = makeStore(events.map(e => `${e.blockNumber}:${e.logIndex}:${e.transactionHash}`))
+  const configuredFloorStartBlock = 40000000 // far below the real watermark
+  const { skipDerive, lastSyncedBlockSeed } = await resolveSkipAndSeed(events, provider, configuredFloorStartBlock)
+  check('8a: skip fires (regression precondition)', skipDerive, true)
+  check('8b: seed is the real watermark (45723253), NOT the configured floor (40000000) -- the exact bug tentencaw caught', lastSyncedBlockSeed, 45723253)
 }
 
 async function main() {
@@ -162,7 +201,8 @@ async function main() {
   await test5()
   await test6()
   await test7()
-  console.log(`\n${7 - failures}/7 passed`)
+  await test8()
+  console.log(`\n${19 - failures}/19 passed`)
   process.exit(failures > 0 ? 1 : 0)
 }
 

--- a/client/scripts/verify-raw-events-rescan-skip.js
+++ b/client/scripts/verify-raw-events-rescan-skip.js
@@ -1,0 +1,169 @@
+// Standalone verification of the historical-rescan skip added to
+// listenForRawEvents.ts (companion fix for PR #60's fetch_failed throw,
+// which has no catch around the historical-sync call site and would
+// otherwise crash the service on restart for nodes on non-archive RPCs).
+// Mirrors the all-or-nothing countExisting check added before the
+// processEvents(past, ...) call.
+// Run: node scripts/verify-raw-events-rescan-skip.js
+
+let failures = 0
+function check(label, actual, expected) {
+  const pass = JSON.stringify(actual) === JSON.stringify(expected)
+  if (!pass) failures++
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${label} -> got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`)
+}
+
+// --- Simulated RawEvent store ---
+function makeStore(existingKeys) {
+  const stored = new Set(existingKeys) // keys: "blockNumber:logIndex:txHash"
+  return {
+    countExisting: async (events) => {
+      let n = 0
+      for (const e of events) {
+        const key = `${e.blockNumber}:${e.logIndex}:${e.transactionHash}`
+        if (stored.has(key)) n++
+      }
+      return n
+    },
+  }
+}
+
+// --- Mirrors the all-or-nothing skip logic added before
+//     `await processEvents(past, httpContract)` ---
+async function resolvePastAfterSkipCheck(past, rawEventsProvider) {
+  if (past.length > 0 && rawEventsProvider.countExisting) {
+    const existingCount = await rawEventsProvider.countExisting(past)
+    if (existingCount === past.length) {
+      return [] // skip: nothing new to derive
+    }
+  }
+  return past // unchanged: at least one genuinely new event
+}
+
+// 1) Empty past: no-op regardless of provider. Guards against calling
+//    countExisting on an empty array (would be a wasted DB round trip).
+async function test1() {
+  const provider = makeStore([])
+  const result = await resolvePastAfterSkipCheck([], provider)
+  check('1: empty past stays empty, countExisting not required to be called', result, [])
+}
+
+// 2) All events already stored: rescan should skip entirely (past -> []),
+//    which is what prevents the fetch_failed throw for settled history on
+//    non-archive RPCs.
+async function test2() {
+  const events = [
+    { blockNumber: 100, logIndex: 0, transactionHash: '0xaaa' },
+    { blockNumber: 100, logIndex: 1, transactionHash: '0xbbb' },
+    { blockNumber: 101, logIndex: 0, transactionHash: '0xccc' },
+  ]
+  const provider = makeStore(events.map(e => `${e.blockNumber}:${e.logIndex}:${e.transactionHash}`))
+  const result = await resolvePastAfterSkipCheck(events, provider)
+  check('2: all-known past is skipped (resolves to empty array)', result, [])
+}
+
+// 3) None stored (fresh node, cold start): rescan must proceed unchanged so
+//    genuinely new events still get processed normally.
+async function test3() {
+  const events = [
+    { blockNumber: 200, logIndex: 0, transactionHash: '0xddd' },
+    { blockNumber: 200, logIndex: 1, transactionHash: '0xeee' },
+  ]
+  const provider = makeStore([])
+  const result = await resolvePastAfterSkipCheck(events, provider)
+  check('3: none-known past passes through unchanged', result, events)
+}
+
+// 4) Partial overlap (some already stored, some genuinely new): must NOT
+//    skip and must NOT filter down to just the new ones -- all-or-nothing,
+//    per tentencaw's point that per-event filtering would break the
+//    sequential parentHash chaining in processEvents, which depends on
+//    processing the full contiguous range in order.
+async function test4() {
+  const events = [
+    { blockNumber: 300, logIndex: 0, transactionHash: '0xfff' }, // already stored
+    { blockNumber: 300, logIndex: 1, transactionHash: '0x111' }, // genuinely new
+  ]
+  const provider = makeStore(['300:0:0xfff'])
+  const result = await resolvePastAfterSkipCheck(events, provider)
+  check('4: partial overlap passes through the FULL unfiltered array (all-or-nothing)', result, events)
+}
+
+// 5) Backward compatibility: rawEventsProvider without countExisting (older
+//    caller, or a provider that hasn't implemented the optional method)
+//    must behave exactly as before this fix -- past always passes through.
+async function test5() {
+  const events = [
+    { blockNumber: 400, logIndex: 0, transactionHash: '0x222' },
+  ]
+  const providerWithoutCountExisting = {} // countExisting intentionally absent
+  const result = await resolvePastAfterSkipCheck(events, providerWithoutCountExisting)
+  check('5: provider without countExisting leaves past untouched (backward compatible)', result, events)
+}
+
+// 6) The specific regression tentencaw reported: 59 events, all already
+//    stored, on a non-archive RPC that can no longer serve their tx bodies.
+//    Before this fix, processEvents would throw fetch_failed for all 59 on
+//    every restart, and since the historical-sync call site has no catch
+//    around it (unlike poll()'s), that crashes the whole service. After
+//    this fix, the rescan recognizes all 59 are already ingested and never
+//    calls processEvents on them at all.
+async function test6() {
+  const events = Array.from({ length: 59 }, (_, i) => ({
+    blockNumber: 1000 + i,
+    logIndex: 0,
+    transactionHash: `0xtx${i}`,
+  }))
+  const provider = makeStore(events.map(e => `${e.blockNumber}:${e.logIndex}:${e.transactionHash}`))
+  const result = await resolvePastAfterSkipCheck(events, provider)
+  check('6: reported regression scenario (59/59 already stored) resolves to empty, avoiding the fetch_failed throw', result, [])
+}
+
+// 7) countExisting itself is batched internally (COUNT_EXISTING_BATCH_SIZE
+//    in RawEventsGatherer/index.ts) to keep any single query's OR clause
+//    bounded on nodes with large RawEvent tables. Simulate a countExisting
+//    that enforces its own batch limit (mirrors the real implementation's
+//    chunking) and confirm the skip logic still resolves correctly when the
+//    event count crosses multiple batches.
+function makeBatchedStore(existingKeys, batchSize) {
+  const stored = new Set(existingKeys)
+  return {
+    countExisting: async (events) => {
+      let total = 0
+      for (let i = 0; i < events.length; i += batchSize) {
+        const batch = events.slice(i, i + batchSize)
+        for (const e of batch) {
+          const key = `${e.blockNumber}:${e.logIndex}:${e.transactionHash}`
+          if (stored.has(key)) total++
+        }
+      }
+      return total
+    },
+  }
+}
+
+async function test7() {
+  // 12 events, batch size 5 -> 3 batches (5, 5, 2). All stored.
+  const events = Array.from({ length: 12 }, (_, i) => ({
+    blockNumber: 500 + i,
+    logIndex: 0,
+    transactionHash: `0xbatch${i}`,
+  }))
+  const provider = makeBatchedStore(events.map(e => `${e.blockNumber}:${e.logIndex}:${e.transactionHash}`), 5)
+  const result = await resolvePastAfterSkipCheck(events, provider)
+  check('7: all-known past spanning multiple internal batches still resolves to empty', result, [])
+}
+
+async function main() {
+  await test1()
+  await test2()
+  await test3()
+  await test4()
+  await test5()
+  await test6()
+  await test7()
+  console.log(`\n${7 - failures}/7 passed`)
+  process.exit(failures > 0 ? 1 : 0)
+}
+
+main()

--- a/client/src/services/RawEventsGatherer/index.ts
+++ b/client/src/services/RawEventsGatherer/index.ts
@@ -86,6 +86,56 @@ export const rawEventsGathererService: Service = {
           : null
       }
 
+      // Batched to keep any single query's OR clause bounded -- the
+      // historical rescan intentionally has no upper cap on how many events
+      // it can cover in one pass (see the "10K * 100K windows" comment
+      // above, for multi-month-gap operators), so `events` here can run into
+      // the thousands. One query with a several-thousand-clause OR is the
+      // kind of thing that's fine in dev and slow or memory-heavy on a
+      // loaded production Postgres; chunking keeps each round trip small
+      // and predictable regardless of how large the rescan range is.
+      // 5000 is a conservative upper-bound estimate, not a measured
+      // single-rescan size -- checked this node's cumulative RawEvent
+      // count (622,843 rows total) as a sanity ceiling, but that's lifetime
+      // volume, not what any one historical rescan actually covers (a
+      // normal restart resumes from getLastProcessedEvent and only
+      // rescans a small trailing range; checked directly on cawnest.com
+      // and its most recent restart's rescan was near-empty). A worst-case
+      // full rescan (e.g. after a startBlock/creationBlock reset) could in
+      // principle put `past` somewhere in that lifetime-volume range, which
+      // is what this batch size is sized against. Sequential batches of
+      // 500 would mean over a thousand round trips in that scenario; 5000
+      // keeps it to roughly 125 while keeping each query's OR clause well
+      // clear of Postgres parameter/plan limits. Deliberately sequential
+      // rather than parallelized -- concurrent batches would each hold a
+      // Prisma pool connection at once, and this runs during service
+      // startup alongside other initialization work sharing the same pool
+      // (connection_limit=70 in this node's DATABASE_URL); a burst of
+      // concurrent queries here risks starving that startup path instead.
+      const COUNT_EXISTING_BATCH_SIZE = 5000
+      const countExisting = async (events: { blockNumber: number; logIndex: number; transactionHash: string }[]) => {
+        if (events.length === 0) return 0
+        let total = 0
+        for (let i = 0; i < events.length; i += COUNT_EXISTING_BATCH_SIZE) {
+          const batch = events.slice(i, i + COUNT_EXISTING_BATCH_SIZE)
+          // OR over the same [blockNumber, logIndex, transactionHash]
+          // unique key RawEvent enforces, so this counts exactly the events
+          // already stored -- no false positives from a coincidental
+          // transactionHash match alone, since two different logs never
+          // share the full triple.
+          total += await prisma.rawEvent.count({
+            where: {
+              OR: batch.map(e => ({
+                blockNumber: e.blockNumber,
+                logIndex: e.logIndex,
+                transactionHash: e.transactionHash,
+              })),
+            },
+          })
+        }
+        return total
+      }
+
       const store = async (e: RawEventInput) => {
         return await prisma.rawEvent.upsert({
           where: {
@@ -206,6 +256,7 @@ export const rawEventsGathererService: Service = {
           getLastProcessedEvent: getLast,
           storeEvent:            storeAndPublish,
           storeBatch:            storeBatchAndPublish,
+          countExisting,
         },
         onTick: () => ctx.heartbeat('poll'),
       })

--- a/client/src/services/RawEventsGatherer/listenForRawEvents.ts
+++ b/client/src/services/RawEventsGatherer/listenForRawEvents.ts
@@ -220,6 +220,24 @@ export default async function listenForRawEvents(
        * one INSERT instead of N. Falls back to storeEvent when absent.
        */
       storeBatch?(events: RawEventInput[]): Promise<void>
+      /**
+       * Counts how many of the given logs already have a matching RawEvent
+       * row (by the blockNumber/logIndex/transactionHash unique key). Used
+       * before the historical rescan's processEvents() call: if every log in
+       * `past` is already stored, there's nothing to derive and the rescan
+       * skips re-fetching tx calldata for it entirely. This matters because
+       * a restart re-walks the whole configured floor range by design (see
+       * startBlock comment above) -- on a long-running node most or all of
+       * that range is already ingested, and re-deriving packedActions for
+       * settled history means re-fetching every one of those tx bodies, which
+       * non-archive RPC providers (e.g. sepolia.base.org) stop serving after
+       * a few days. Without this check, a node on a free/non-archive RPC
+       * would hit the fetch_failed throw below on every restart for events
+       * it already has -- and unlike the poll() path, the historical-sync
+       * call site has no catch around it, so that throw takes the whole
+       * service down rather than just logging a warning.
+       */
+      countExisting?(events: Log[]): Promise<number>
     }
     /** Optional callback to signal liveness — called at the end of each successful poll */
     onTick?: () => void
@@ -499,6 +517,23 @@ export default async function listenForRawEvents(
     } catch (err) {
       console.error('[RawEventsGatherer] Error fetching past events, retrying in 5s', err)
       await delay(5000)
+    }
+  }
+
+  // Skip re-deriving events the DB already has. A restart re-walks the
+  // whole configured floor range by design; on a long-running node most of
+  // `past` is typically already ingested. processEvents() re-fetches each
+  // event's tx calldata to recover packedActions -- fine for genuinely new
+  // events, but non-archive RPC providers stop serving old tx bodies after a
+  // few days, which would otherwise turn this rescan into a fetch_failed
+  // throw for settled history it doesn't need to touch. All-or-nothing
+  // check (not per-event filtering) so the sequential parentHash chaining in
+  // processEvents stays untouched when any part of `past` is genuinely new.
+  if (past.length > 0 && config.rawEventsProvider.countExisting) {
+    const existingCount = await config.rawEventsProvider.countExisting(past)
+    if (existingCount === past.length) {
+      console.log(`[RawEventsGatherer] Historical rescan: all ${past.length} events already stored, skipping re-derive`)
+      past = []
     }
   }
 

--- a/client/src/services/RawEventsGatherer/listenForRawEvents.ts
+++ b/client/src/services/RawEventsGatherer/listenForRawEvents.ts
@@ -529,15 +529,26 @@ export default async function listenForRawEvents(
   // throw for settled history it doesn't need to touch. All-or-nothing
   // check (not per-event filtering) so the sequential parentHash chaining in
   // processEvents stays untouched when any part of `past` is genuinely new.
-  if (past.length > 0 && config.rawEventsProvider.countExisting) {
-    const existingCount = await config.rawEventsProvider.countExisting(past)
-    if (existingCount === past.length) {
-      console.log(`[RawEventsGatherer] Historical rescan: all ${past.length} events already stored, skipping re-derive`)
-      past = []
-    }
-  }
+  //
+  // Branches on a flag rather than clearing `past` itself: `past` is read
+  // again below (lastSyncedBlock = past.length > 0 ? past[...].blockNumber
+  // : startBlock) to seed the poll cursor's starting point. Emptying `past`
+  // here would fall that ternary through to startBlock -- the configured
+  // floor -- instead of the block the historical scan actually reached,
+  // sending every subsequent poll tick re-walking the whole floor-to-tip
+  // range on every restart where the skip fires. Keeping `past` intact
+  // preserves the real high-water mark for that read while still avoiding
+  // the processEvents() call itself.
+  const skipDerive =
+    past.length > 0 &&
+    !!config.rawEventsProvider.countExisting &&
+    (await config.rawEventsProvider.countExisting(past)) === past.length
 
-  await processEvents(past, httpContract)
+  if (skipDerive) {
+    console.log(`[RawEventsGatherer] Historical rescan: all ${past.length} events already stored, skipping re-derive`)
+  } else {
+    await processEvents(past, httpContract)
+  }
 
   // Setup WebSocket for real-time events
   async function setupWebSocket() {


### PR DESCRIPTION
## Problem

`RawEventsGatherer`'s HTTP polling loop (`processEvents`, called from `poll()`) reads `ActionsProcessed` event logs, then fetches each event's transaction to decode the actual action payload from calldata (the event itself only commits a batch hash). When `fetchPackedActionsFromTx` couldn't get or decode that calldata, the code logged a warning and `continue`d past the event:

```typescript
const packedHex = await fetchPackedActionsFromTx(httpProvider, ev.transactionHash)
if (!packedHex) {
  console.warn(`...`)
  continue
}
```

`processEvents` returning normally after a `continue` means `poll()` treats the whole batch as successful and advances `lastSyncedBlock` past it. Once that happens, this block is never revisited — if the failure was a transient RPC issue, any actions in that transaction are permanently lost from the database with no further attempt to recover them.

## Fix

**Distinguishing the two different reasons `fetchPackedActionsFromTx` can come back empty was the important part here, not just adding a `throw`.** The original null-return conflated two very different situations:

- **Genuinely not applicable**: the tx was fetched and decoded fine, but it isn't a `processActions`/`safeProcessActions`/`processActionsERC1271` call. This is expected — nothing to recover, correctly skip.
- **Fetch/parse failure**: couldn't get `tx.data` at all, or `parseTransaction` threw on malformed data. We don't know what this tx actually contained — treating this the same as "not applicable" is how actions get silently lost.

A blanket "throw on any null" fix (which is what I started with, based on the initial report) would have thrown on the *first* case too — turning routine, expected non-matching transactions into constant retry loops. Verified this matters in practice: `ActionsProcessed` is filtered by event, but nothing guarantees every matching tx decodes to one of the three known functions going forward, and the code's own pre-existing comment already called out "or the tx wasn't a (safe)processActions call" as a normal case.

Changed `fetchPackedActionsFromTx`'s return type to a discriminated result (`{ kind: 'ok', data } | { kind: 'not_applicable' } | { kind: 'fetch_failed' }`) so callers can tell these apart:

- `not_applicable` → `continue`, same as before.
- `fetch_failed` → `throw` in the HTTP polling path (`processEvents`), which `poll()`'s existing `catch` block catches without advancing `lastSyncedBlock`, so the range retries on the next tick or RPC fallback rotation.
- Conservatively treated `parseTransaction` throwing (malformed calldata) as `fetch_failed` rather than `not_applicable` — can't distinguish "genuinely unrelated tx" from "corrupted data from a bad RPC response" here, so erring toward retry rather than silent skip.

The two WebSocket handlers (`wsContract.on('ActionsProcessed', ...)` and its ERC-1271 sibling) call the same function but don't have a block-cursor to protect — WebSocket is purely additive/best-effort here, `lastSyncedBlock` only exists in the HTTP polling path. Updated them to match the new return type but kept their behavior as skip-and-log; a fetch failure there just means this one event doesn't get the WebSocket fast-path, and the HTTP poller's own fetch of the same tx will still throw and retry correctly if it was a genuine RPC issue.

## Design decision: no retry limit

Unlike a finalize-style operation where giving up after N attempts and dead-lettering is reasonable, there's no "give up" option here — the alternative to retrying is permanently losing actions. If the underlying RPC failure is long-lived (provider outage, sustained rate limiting), this means the poller stops making progress entirely until it resolves, rather than dropping data and moving on. That's the intended tradeoff (data loss is worse than a stalled indexer), but flagging it explicitly since it's a real operational implication — a long RPC outage now means indexing fully pauses rather than degrading.

## Verified but found already handled (not part of this fix)

Two things I checked because the retry-on-failure change made them more likely to matter, and confirmed the existing design already covers them:

- **WebSocket/HTTP double-processing**: both paths can independently pick up the same `ActionsProcessed` event. `RawEvent` has `@@unique([blockNumber, logIndex, transactionHash])`, and the actual storage functions (`store`, `storeBatchAndPublish` in `RawEventsGatherer/index.ts`) use `prisma.rawEvent.upsert(...)` and `createMany({ skipDuplicates: true })` respectively — both already no-op on a duplicate rather than throwing. Increased retry frequency from this fix doesn't introduce a new failure mode here.
- **`poll()`'s catch block**: confirmed directly (not just from the "Don't update lastSyncedBlock on error" comment) that it's a plain `catch (err) { console.error(...) }` with no branching on error type or message — the thrown error from this fix is caught unconditionally and `lastSyncedBlock` is never reached on that path.

## Testing

Verified `fetchPackedActionsFromTx`'s three-way classification against a standalone repro (not touching any live install), using the real `ethers.Interface` with the actual function signatures:

- Valid `processActions` calldata → `ok`, correct `packedActions` data extracted.
- Calldata for an unrelated function (e.g. `transfer`) → `not_applicable`, not thrown.
- `provider.getTransaction` throwing (RPC error) → `fetch_failed`.
- `provider.getTransaction` resolving to null/no data → `fetch_failed`.
- Malformed calldata (right selector, corrupted params) → `fetch_failed` (via the `parseTransaction` catch block).

`tsc --noEmit` on the changed file passes except for one pre-existing, unrelated error (`Cannot find module '@ethersproject/abstract-provider'`) — confirmed this predates this change by stashing it and re-running the same check against the original file.

---

zinsanjp