### PR TITLE
fix(api): validate tokenIds are positive (> 0) in POST /api/actions to prevent ghost user creation

### DIFF
--- a/client/scripts/verify-token-zero-validation.js
+++ b/client/scripts/verify-token-zero-validation.js
@@ -1,0 +1,54 @@
+// Standalone verification of the tokenId>0 gating logic added to
+// POST /api/actions (client/src/api/routes/actions.ts).
+// This mirrors the exact logic inline (not imported) since the real
+// function lives inside an Express route handler. Run: node scripts/verify-token-zero-validation.js
+
+function validate(data) {
+  const senderTokenId = Number(data.senderId)
+  if (!Number.isInteger(senderTokenId) || senderTokenId <= 0) {
+    return { status: 400, error: 'Invalid senderId: tokenId must be a positive integer (> 0)' }
+  }
+
+  if (data.receiverId !== undefined && data.receiverId !== null) {
+    const receiverTokenId = Number(data.receiverId)
+    const targetRequiresReceiver = [1, 2, 3, 4, 5, 'like', 'unlike', 'recaw', 'follow', 'unfollow'].includes(data.actionType)
+    if (targetRequiresReceiver && (!Number.isInteger(receiverTokenId) || receiverTokenId <= 0)) {
+      return { status: 400, error: 'Invalid receiverId: target tokenId must be a positive integer (> 0)' }
+    }
+  }
+
+  if (Array.isArray(data.recipients) && data.recipients.length > 0) {
+    for (let i = 0; i < data.recipients.length; i++) {
+      const recId = Number(data.recipients[i])
+      if (!Number.isInteger(recId) || recId <= 0) {
+        return { status: 400, error: `Invalid recipient tokenId at index ${i}: must be a positive integer (> 0)` }
+      }
+    }
+  }
+
+  return { status: 'OK' }
+}
+
+const cases = [
+  // [label, payload, expectedStatus]
+  ['senderId = 0', { senderId: 0, actionType: 'like', receiverId: 5 }, 400],
+  ['LIKE with receiverId = 0 (string actionType)', { senderId: 3, actionType: 'like', receiverId: 0 }, 400],
+  ['LIKE with receiverId = 0 (numeric actionType 1)', { senderId: 3, actionType: 1, receiverId: 0 }, 400],
+  ['FOLLOW with receiverId = 0', { senderId: 3, actionType: 'follow', receiverId: 0 }, 400],
+  ['recipients contains 0', { senderId: 3, actionType: 'other', receiverId: 0, recipients: [5, 0] }, 400],
+  ['recipients contains negative', { senderId: 3, actionType: 'other', receiverId: 0, recipients: [-1] }, 400],
+  ['OTHER (pin) with receiverId = 0 — must PASS', { senderId: 3, actionType: 'other', receiverId: 0 }, 'OK'],
+  ['RECAW with valid receiverId — must PASS', { senderId: 3, actionType: 'recaw', receiverId: 7 }, 'OK'],
+  ['valid LIKE — must PASS', { senderId: 3, actionType: 'like', receiverId: 7 }, 'OK'],
+]
+
+let failures = 0
+for (const [label, payload, expected] of cases) {
+  const result = validate(payload)
+  const pass = result.status === expected
+  if (!pass) failures++
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${label} -> status=${result.status}${result.error ? ' ('+result.error+')' : ''}`)
+}
+
+console.log(`\n${cases.length - failures}/${cases.length} passed`)
+process.exit(failures > 0 ? 1 : 0)

--- a/client/src/api/routes/actions.ts
+++ b/client/src/api/routes/actions.ts
@@ -410,6 +410,46 @@ router.post('/', async (req, res) => {
       return res.status(400).json({ error: 'Missing required fields: data and signature' })
     }
 
+    // On-chain CawProfile NFT tokenIds are 1-indexed (tokenId 0 does not
+    // exist on-chain). Without this gate, a receiverId of 0 (e.g. an
+    // unselected/loading-race client value) reaches the optimistic
+    // pre-write upserts below and persists a ghost `user_0` row, which
+    // on-chain-synced nodes never create (resolveActionUsers treats a
+    // falsy receiverId as "no receiver" and skips it) — a source of
+    // cross-node User table divergence.
+    const senderTokenId = Number(data.senderId)
+    if (!Number.isInteger(senderTokenId) || senderTokenId <= 0) {
+      return res.status(400).json({ error: 'Invalid senderId: tokenId must be a positive integer (> 0)' })
+    }
+    data.senderId = senderTokenId
+
+    // Only actions that target a specific existing user need receiverId > 0.
+    // OTHER-type actions (pin, hide:caw/recaw, tip:, vote:, profile-update)
+    // legitimately send receiverId: 0 as "no target" and must not be gated
+    // here — see FeedItem.tsx pin/hide/delete handlers.
+    if (data.receiverId !== undefined && data.receiverId !== null) {
+      const receiverTokenId = Number(data.receiverId)
+      const targetRequiresReceiver = [1, 2, 3, 4, 5, 'like', 'unlike', 'recaw', 'follow', 'unfollow'].includes(data.actionType)
+      if (targetRequiresReceiver && (!Number.isInteger(receiverTokenId) || receiverTokenId <= 0)) {
+        return res.status(400).json({ error: 'Invalid receiverId: target tokenId must be a positive integer (> 0)' })
+      }
+      if (Number.isInteger(receiverTokenId)) {
+        data.receiverId = receiverTokenId
+      }
+    }
+
+    // recipients[] (embedded multi-recipient tips) must all be positive
+    // integers — a 0 or negative id would hit the same unguarded upsert
+    // path as receiverId.
+    if (Array.isArray(data.recipients) && data.recipients.length > 0) {
+      for (let i = 0; i < data.recipients.length; i++) {
+        const recId = Number(data.recipients[i])
+        if (!Number.isInteger(recId) || recId <= 0) {
+          return res.status(400).json({ error: `Invalid recipient tokenId at index ${i}: must be a positive integer (> 0)` })
+        }
+      }
+    }
+
     // Limit payload size — action text shouldn't need more than ~100KB
     const bodySize = JSON.stringify(req.body).length
     if (bodySize > 100 * 1024) {


### PR DESCRIPTION
## Summary
On-chain `CawProfile` NFT tokenIds are 1-indexed (tokenId 0 does not exist on-chain). `POST /api/actions` lacked positive-integer validation on `senderId`, `receiverId`, and `recipients[]`.

A `receiverId = 0` (e.g. an unselected/loading-race client value) reached the optimistic pre-write handler's unguarded `prisma.user.upsert`, persisting a ghost `user_0` row. On-chain-synced nodes never create this row — `resolveActionUsers` treats a falsy `receiverId` as "no receiver" and skips it — causing User-table divergence across the network.

## Design: targeted inbound gate, not a blanket one
`receiverId` is only required to be `> 0` for actionTypes that target a specific existing user: LIKE, UNLIKE, RECAW, FOLLOW, UNFOLLOW (both numeric and string forms — the codebase uses both interchangeably, e.g. `data.actionType === 1` and `data.actionType === 'like'`).

OTHER-type actions legitimately send `receiverId: 0` as "no target" (pin, hide:caw/recaw, tip:, vote:, profile-update — see `FeedItem.tsx`'s pin/hide/delete handlers) and are intentionally left ungated. A blanket `receiverId > 0` check would have broken all of these.

`senderId` is gated unconditionally. Every `recipients[]` entry (embedded multi-recipient tips) is gated `> 0` as well, since it hits the same unguarded upsert path.

## Verification
`scripts/verify-token-zero-validation.js` — 9 cases, all passing, including the two edge cases that mattered most:
- LIKE via numeric `actionType: 1` vs string `actionType: 'like'` (both must be rejected when `receiverId: 0`)
- OTHER actions must still pass through with `receiverId: 0`

## Root cause note
Traced to `actions.ts`'s FOLLOW handler (`prisma.user.upsert({ where: { tokenId: data.receiverId }, create: { id: data.receiverId, tokenId: data.receiverId, username: \`user_${data.receiverId}\` } })`), which had no guard against `receiverId <= 0`.

zinsanjp