### PR TITLE
fix(services): resolve ethers v6 log index sorting to prevent NaN order corruption

### DIFF
--- a/client/scripts/verify-logindex-fix.js
+++ b/client/scripts/verify-logindex-fix.js
@@ -1,0 +1,51 @@
+// Standalone verification of the ethers v6 log-index sort fix.
+// Mirrors the fallback pattern (ev.index ?? ev.logIndex ?? 0) applied to
+// ChainSyncService, InstanceRegistryService, and RawEventsGatherer.
+// Run: node scripts/verify-logindex-fix.js
+
+function sortKey(ev) {
+  return (ev.index ?? ev.logIndex ?? 0)
+}
+
+function sortPair(a, b) {
+  return sortKey(a) - sortKey(b)
+}
+
+const cases = [
+  {
+    label: 'ethers v6 EventLog (has .index, no .logIndex) — must sort correctly',
+    events: [{ index: 3 }, { index: 1 }, { index: 2 }],
+    expectedOrder: [1, 2, 3],
+    key: 'index',
+  },
+  {
+    label: 'legacy-style object with only .logIndex — must still sort correctly (fallback)',
+    events: [{ logIndex: 3 }, { logIndex: 1 }, { logIndex: 2 }],
+    expectedOrder: [1, 2, 3],
+    key: 'logIndex',
+  },
+  {
+    label: 'old buggy behavior check: raw .logIndex on v6-style objects would be NaN',
+    events: [{ index: 3 }, { index: 1 }, { index: 2 }],
+    checkOldBug: true,
+  },
+]
+
+let failures = 0
+
+for (const c of cases) {
+  if (c.checkOldBug) {
+    const oldSorted = [...c.events].sort((a, b) => (a.logIndex) - (b.logIndex))
+    const isNaNSort = oldSorted.every((_, i) => oldSorted[i].index === c.events[i].index) // no-op sort check
+    console.log(`[INFO] ${c.label} -> old logic result order: ${oldSorted.map(e => e.index).join(',')} (unsorted/no-op, as expected of the bug)`)
+    continue
+  }
+  const sorted = [...c.events].sort(sortPair)
+  const actualOrder = sorted.map(e => e[c.key])
+  const pass = JSON.stringify(actualOrder) === JSON.stringify(c.expectedOrder)
+  if (!pass) failures++
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${c.label} -> got [${actualOrder}], expected [${c.expectedOrder}]`)
+}
+
+console.log(`\n${cases.filter(c => !c.checkOldBug).length - failures}/${cases.filter(c => !c.checkOldBug).length} passed`)
+process.exit(failures > 0 ? 1 : 0)

--- a/client/src/services/ChainSyncService/index.ts
+++ b/client/src/services/ChainSyncService/index.ts
@@ -920,7 +920,7 @@ async function syncL2Events(): Promise<void> {
         ...authed.map(e => ({ ev: e, kind: 'authed' as const })),
       ].sort((a, b) => {
         if (a.ev.blockNumber !== b.ev.blockNumber) return a.ev.blockNumber - b.ev.blockNumber
-        return (a.ev as any).logIndex - (b.ev as any).logIndex
+        return ((a.ev as any).index ?? (a.ev as any).logIndex ?? 0) - ((b.ev as any).index ?? (b.ev as any).logIndex ?? 0)
       })
 
       for (const { ev, kind } of combined) {
@@ -1140,7 +1140,7 @@ async function syncL1FeeEvents(): Promise<void> {
         ...mintCeiling.map(e     => ({ ev: e, kind: 'MintFeeCeilingLowered'     as const })),
       ].sort((a, b) => {
         if (a.ev.blockNumber !== b.ev.blockNumber) return a.ev.blockNumber - b.ev.blockNumber
-        return (a.ev as any).logIndex - (b.ev as any).logIndex
+        return ((a.ev as any).index ?? (a.ev as any).logIndex ?? 0) - ((b.ev as any).index ?? (b.ev as any).logIndex ?? 0)
       })
 
       for (const { ev, kind } of combined) {

--- a/client/src/services/InstanceRegistryService/index.ts
+++ b/client/src/services/InstanceRegistryService/index.ts
@@ -320,7 +320,7 @@ async function refreshPeers(
     if (!parsed) continue
     ordered.push({
       blockNumber: Number((log as any).blockNumber),
-      logIndex: Number((log as any).logIndex),
+      logIndex: Number((log as any).index ?? (log as any).logIndex ?? 0),
       instanceId: Number(parsed.args.instanceId),
       active: false,
     })
@@ -330,7 +330,7 @@ async function refreshPeers(
     if (!parsed) continue
     ordered.push({
       blockNumber: Number((log as any).blockNumber),
-      logIndex: Number((log as any).logIndex),
+      logIndex: Number((log as any).index ?? (log as any).logIndex ?? 0),
       instanceId: Number(parsed.args.instanceId),
       active: true,
     })

--- a/client/src/services/RawEventsGatherer/listenForRawEvents.ts
+++ b/client/src/services/RawEventsGatherer/listenForRawEvents.ts
@@ -1,6 +1,6 @@
 // src/services/RawEventsGatherer/listenForRawEvents.ts
 import { ContractEventPayload, WebSocketProvider, Contract, Interface, keccak256, toUtf8Bytes, getBytes, concat } from 'ethers'
-import type { Log } from '@ethersproject/abstract-provider'
+import type { Log } from 'ethers'
 import { CAW_ACTIONS_ADDRESS, CAW_ACTIONS_ERC1271_ADDRESS } from '../../abi/addresses'
 import { makeFallbackJsonRpcProvider, makeVerifiedFallbackJsonRpcProvider, makeWebSocketProvider, getL2HttpRpcUrls, getL2WsSecret, waitForRateLimit, redactRpcUrl } from '../../utils/rpcProvider'
 import { scanLogsForward } from '../../utils/chunkedLogs'
@@ -265,7 +265,7 @@ export default async function listenForRawEvents(
           transactionHash: ev.transactionHash,
           parentHash:      lastHash,
           data:            action,
-          topics:          ev.topics,
+          topics:          [ ...ev.topics ],
           contractAddress: ev.address
         })
       }

--- a/client/src/services/RawEventsGatherer/listenForRawEvents.ts
+++ b/client/src/services/RawEventsGatherer/listenForRawEvents.ts
@@ -256,7 +256,7 @@ export default async function listenForRawEvents(
         }
         // Offset logIndex by action position within the batch so each action
         // gets a unique (blockNumber, logIndex, transactionHash) key.
-        const logIndex = (ev.logIndex ?? 0) + i
+        const logIndex = ((ev as any).index ?? (ev as any).logIndex ?? 0) + i
         lastHash = hashNext(lastHash, action)
         batch.push({
           chainId:         config.chainId,
@@ -644,7 +644,7 @@ export default async function listenForRawEvents(
         const events: Log[] = [...sigEvents, ...erc1271Events].sort((a, b) =>
           (a as any).blockNumber !== (b as any).blockNumber
             ? (a as any).blockNumber - (b as any).blockNumber
-            : (a as any).logIndex - (b as any).logIndex
+            : ((a as any).index ?? (a as any).logIndex ?? 0) - ((b as any).index ?? (b as any).logIndex ?? 0)
         )
 
         if (events.length > 0) {


### PR DESCRIPTION
## Summary
ethers v6 renamed the event log's block-position property from `logIndex` (v5) to `index`; ethers v6's `Log` type has no `logIndex` field at all. Code doing `(a as any).logIndex - (b as any).logIndex` against a v6 `EventLog`/`Log` evaluates `undefined - undefined = NaN`, and `Array.prototype.sort()` treats a `NaN` comparator result as a no-op — same-block events keep whatever order they were concatenated in, not their actual on-chain order.

## Verified before touching anything
Confirmed each affected value really is a raw ethers v6 object:
- `ChainSyncService`'s `combined` array comes straight from `contract.queryFilter()` (`EventLog`)
- `InstanceRegistryService`'s `deactLogs`/`actLogs` come from `scanLogsBackward`/`scanLogsForward`'s raw `provider.getLogs()` results
- `RawEventsGatherer`'s `processEvents(events: Log[])` and the `poll()` `queryFilter()` result are both typed/cast as `Log`

Left `listenForRawEvents.ts`'s WebSocket handler (`ev.log.index`) alone — it already reads the correct field.

Also audited every other `.logIndex` reference in the codebase (`InstanceRegistryService:339`, `RawEventsGatherer/index.ts`, `ActionProcessor/index.ts:385`, `StakeLedger/index.ts:157`) — all resolved to be reading DB rows or already-normalized local fields, not raw ethers objects, so left untouched.

## Fix
Applied the `(ev.index ?? ev.logIndex ?? 0)` fallback already used by `DepositWatcher`, in 6 places:
- `ChainSyncService/index.ts`: session events (L923), fee config events (L1143)
- `InstanceRegistryService/index.ts`: instance activate/deactivate sort (L323, L333)
- `RawEventsGatherer/listenForRawEvents.ts`: batch offset calc (L259), HTTP-scan sort (L647)

## Impact
Same-block ordering only matters when multiple related events land in one block (e.g. a session revoke+create, or instance deactivate+activate) — low frequency on testnet today, more likely as tx volume grows toward mainnet.

## Verification
`scripts/verify-logindex-fix.js` confirms v6-style `.index` sorts correctly, the `.logIndex`-only fallback path still works, and reproduces the old NaN no-op behavior for reference.

## Follow-up: closed the last stale @ethersproject import

While running a full `tsc --noEmit` pass on this file, found the Log import still pointed at `@ethersproject/abstract-provider` -- a package this codebase no longer has installed since the ethers v6 migration. Since it was `import type` only, it had zero runtime effect (type-only imports are erased at compile time), but it meant every property access on `Log` values in this file was typed as `any` rather than checked against `ethers.Log`'s actual shape. This was the one pre-existing `Cannot find module` error every earlier PR in this project noted and worked around ("existing 1, no new errors").

Switching to `ethers`'s own `Log` type surfaced two spots this file was still written against the old `@ethersproject` shape:

1. `ev.logIndex` -- already correct via this PR's own `(ev as any).index ?? (ev as any).logIndex ?? 0` fix, confirmed still correct after the import switch.
2. `topics: ev.topics` assigned `ethers.Log`'s `readonly string[]` directly into `RawEventInput.topics` (mutable `string[]`) -- same readonly-to-mutable gap this PR's fix already handles elsewhere via `[ ...ev.log.topics ]`; applied the same spread here.

`tsc --noEmit` now completes with zero errors project-wide (previously always exactly one, tolerated everywhere). No behavior change -- both fixes correct type-checking accuracy, not runtime values.

zinsanjp

