### PR TITLE
fix(marketplace): send SALE_SOLD/SALE_BOUGHT notifications on OfferAccepted

### DIFF
--- a/client/scripts/verify-offer-accepted-notifications.js
+++ b/client/scripts/verify-offer-accepted-notifications.js
@@ -1,0 +1,77 @@
+// Standalone verification of the OfferAccepted seller/buyer notification
+// logic added to MarketplaceIndexerService (SALE_SOLD / SALE_BOUGHT).
+// Simulates the idempotency guard and payload construction without a DB.
+// Run: node scripts/verify-offer-accepted-notifications.js
+
+function buildNotificationPlan(event, existingNotifications) {
+  // existingNotifications: array of { type, userId, groupKey } already "in the DB"
+  const onChainOfferId = event.offerId
+  const sellerUser = event.sellerUser
+  const buyerUser = event.buyerUser
+
+  const payload = {
+    offerId: onChainOfferId,
+    username: event.username,
+    tokenId: event.tokenId,
+    price: event.price,
+    paymentToken: event.paymentTokenLabel,
+  }
+
+  const sellerGroupKey = `offer_accepted_sold_${onChainOfferId}`
+  const buyerGroupKey = `offer_accepted_bought_${onChainOfferId}`
+
+  const toCreate = []
+
+  const exists = (type, userId, groupKey) =>
+    existingNotifications.some(n => n.type === type && n.userId === userId && n.groupKey === groupKey)
+
+  if (sellerUser && !exists('SALE_SOLD', sellerUser.tokenId, sellerGroupKey)) {
+    toCreate.push({ userId: sellerUser.tokenId, actorId: buyerUser?.tokenId ?? sellerUser.tokenId, type: 'SALE_SOLD', groupKey: sellerGroupKey, actionPayload: payload })
+  }
+  if (buyerUser && !exists('SALE_BOUGHT', buyerUser.tokenId, buyerGroupKey)) {
+    toCreate.push({ userId: buyerUser.tokenId, actorId: sellerUser?.tokenId ?? buyerUser.tokenId, type: 'SALE_BOUGHT', groupKey: buyerGroupKey, actionPayload: payload })
+  }
+  return toCreate
+}
+
+let failures = 0
+function check(label, actualLen, expectedLen) {
+  const pass = actualLen === expectedLen
+  if (!pass) failures++
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${label} -> created ${actualLen}, expected ${expectedLen}`)
+}
+
+const baseEvent = {
+  offerId: 42,
+  tokenId: 7,
+  username: 'alice',
+  price: '1000000',
+  paymentTokenLabel: 'USDC',
+  sellerUser: { tokenId: 7 },
+  buyerUser: { tokenId: 9 },
+}
+
+// 1) Fresh event, no prior notifications — must create exactly 2 (seller + buyer)
+check('fresh OfferAccepted event -> 2 notifications', buildNotificationPlan(baseEvent, []).length, 2)
+
+// 2) Re-processed event (e.g. DB rebuild rescans same block) — must create 0 (idempotent)
+const already = [
+  { type: 'SALE_SOLD', userId: 7, groupKey: 'offer_accepted_sold_42' },
+  { type: 'SALE_BOUGHT', userId: 9, groupKey: 'offer_accepted_bought_42' },
+]
+check('re-processed event -> 0 notifications (idempotent)', buildNotificationPlan(baseEvent, already).length, 0)
+
+// 3) Only seller has a User row (buyer unregistered on this mirror) — must create 1
+const sellerOnly = { ...baseEvent, buyerUser: null }
+check('buyer has no User row -> 1 notification (seller only)', buildNotificationPlan(sellerOnly, []).length, 1)
+
+// 4) Wash sale: seller === buyer (same tokenId) — must still create both rows (distinct groupKeys)
+const washSale = { ...baseEvent, buyerUser: { tokenId: 7 } }
+check('wash sale (seller===buyer) -> 2 notifications (distinct groupKeys)', buildNotificationPlan(washSale, []).length, 2)
+
+// 5) Different offerId -> distinct groupKey, must NOT be deduped by offer 42's history
+const otherOffer = { ...baseEvent, offerId: 99 }
+check('different offerId -> 2 notifications (not deduped against offer 42)', buildNotificationPlan(otherOffer, already).length, 2)
+
+console.log(`\n${5 - failures}/5 passed`)
+process.exit(failures > 0 ? 1 : 0)

--- a/client/scripts/verify-offer-accepted-notifications.js
+++ b/client/scripts/verify-offer-accepted-notifications.js
@@ -5,6 +5,17 @@
 
 function buildNotificationPlan(event, existingNotifications) {
   // existingNotifications: array of { type, userId, groupKey } already "in the DB"
+  //
+  // Review finding (tentencaw, PR #64): the original code fell back to
+  // `#<tokenId>` when tokenId's own User row was missing, and nothing
+  // repairs that placeholder later (unlike MarketplaceListing.username,
+  // which has a one-shot backfill) -- it freezes into the notification's
+  // actionPayload permanently. Fixed by skipping the notification
+  // entirely when the User row is missing, same best-effort posture as
+  // the seller/buyer lookup below. event.tokenIdUser === null simulates
+  // that missing-row case.
+  if (event.tokenIdUser === null) return []
+
   const onChainOfferId = event.offerId
   const sellerUser = event.sellerUser
   const buyerUser = event.buyerUser
@@ -49,6 +60,7 @@ const baseEvent = {
   paymentTokenLabel: 'USDC',
   sellerUser: { tokenId: 7 },
   buyerUser: { tokenId: 9 },
+  tokenIdUser: { username: 'alice' }, // present -> normal path
 }
 
 // 1) Fresh event, no prior notifications — must create exactly 2 (seller + buyer)
@@ -73,5 +85,12 @@ check('wash sale (seller===buyer) -> 2 notifications (distinct groupKeys)', buil
 const otherOffer = { ...baseEvent, offerId: 99 }
 check('different offerId -> 2 notifications (not deduped against offer 42)', buildNotificationPlan(otherOffer, already).length, 2)
 
-console.log(`\n${5 - failures}/5 passed`)
+// 6) Review finding (tentencaw, PR #64): tokenId's own User row missing
+//    must skip the notification entirely, not fall back to `#<tokenId>`
+//    and freeze that placeholder into actionPayload forever.
+const missingTokenIdUser = { ...baseEvent, tokenIdUser: null }
+check('tokenId has no User row -> notification skipped entirely (no #<tokenId> placeholder)',
+  buildNotificationPlan(missingTokenIdUser, []).length, 0)
+
+console.log(`\n${6 - failures}/6 passed`)
 process.exit(failures > 0 ? 1 : 0)

--- a/client/src/services/MarketplaceIndexerService/index.ts
+++ b/client/src/services/MarketplaceIndexerService/index.ts
@@ -601,11 +601,92 @@ export const marketplaceIndexerService: Service = {
           // Process OfferAccepted events
           for (const event of offersAccepted) {
             const ev = event as ethers.EventLog
-            const onChainOfferId = Number(ev.args[0])
+            const args = ev.args
+            const onChainOfferId = Number(args[0])
+            const tokenId = Number(args[1])
+            const seller = String(args[2]).toLowerCase()
+            const buyer = String(args[3]).toLowerCase()
+            const price = args[4].toString()
+            const paymentToken = String(args[5])
+
             await prisma.marketplaceOffer.updateMany({
               where: { offerId: onChainOfferId, status: 'ACTIVE' },
               data: { status: 'ACCEPTED' },
             })
+
+            // Notify seller and buyer. Mirrors the Sale-event SALE_SOLD/
+            // SALE_BOUGHT pair above (L289-347) — an accepted offer is a
+            // completed sale too, it just has no MarketplaceListing/Sale
+            // row (offers aren't tied to a listing), so there's nowhere
+            // else in the indexer this notification would come from.
+            // Lookup is best-effort: if either party doesn't have a User
+            // row on this mirror, we just skip their notification.
+            try {
+              const user = await prisma.user.findUnique({ where: { tokenId } })
+              const username = user?.username || `#${tokenId}`
+
+              const [sellerUser, buyerUser] = await Promise.all([
+                prisma.user.findFirst({
+                  where: { address: { equals: seller, mode: 'insensitive' } },
+                  select: { tokenId: true },
+                }),
+                prisma.user.findFirst({
+                  where: { address: { equals: buyer, mode: 'insensitive' } },
+                  select: { tokenId: true },
+                }),
+              ])
+
+              const payload = {
+                offerId: onChainOfferId,
+                username,
+                tokenId,
+                price,
+                paymentToken: getPaymentLabel(paymentToken),
+              }
+
+              // Idempotency: same rationale as the Sale-event pair — a
+              // regressed lastBlock or DB rebuild would re-process this
+              // event, and groupKey is namespaced per-offer-per-side so
+              // a wash sale (seller == buyer) still gets both rows.
+              const sellerGroupKey = `offer_accepted_sold_${onChainOfferId}`
+              const buyerGroupKey = `offer_accepted_bought_${onChainOfferId}`
+
+              if (sellerUser) {
+                const existing = await prisma.notification.findFirst({
+                  where: { type: 'SALE_SOLD', userId: sellerUser.tokenId, groupKey: sellerGroupKey },
+                  select: { id: true },
+                })
+                if (!existing) {
+                  await createNotificationWithGroup(prisma, {
+                    userId: sellerUser.tokenId,
+                    actorId: buyerUser?.tokenId ?? sellerUser.tokenId,
+                    type: 'SALE_SOLD',
+                    groupKey: sellerGroupKey,
+                    actionPayload: payload,
+                  })
+                  console.log(`[Marketplace] Sent SALE_SOLD notification to seller tokenId=${sellerUser.tokenId} for offer ${onChainOfferId}`)
+                }
+              }
+
+              if (buyerUser) {
+                const existing = await prisma.notification.findFirst({
+                  where: { type: 'SALE_BOUGHT', userId: buyerUser.tokenId, groupKey: buyerGroupKey },
+                  select: { id: true },
+                })
+                if (!existing) {
+                  await createNotificationWithGroup(prisma, {
+                    userId: buyerUser.tokenId,
+                    actorId: sellerUser?.tokenId ?? buyerUser.tokenId,
+                    type: 'SALE_BOUGHT',
+                    groupKey: buyerGroupKey,
+                    actionPayload: payload,
+                  })
+                  console.log(`[Marketplace] Sent SALE_BOUGHT notification to buyer tokenId=${buyerUser.tokenId} for offer ${onChainOfferId}`)
+                }
+              }
+            } catch (err) {
+              console.warn('[Marketplace] Failed to create offer acceptance sale notifications:', err)
+            }
           }
 
           // Process OfferCancelled events

--- a/client/src/services/MarketplaceIndexerService/index.ts
+++ b/client/src/services/MarketplaceIndexerService/index.ts
@@ -621,9 +621,23 @@ export const marketplaceIndexerService: Service = {
             // else in the indexer this notification would come from.
             // Lookup is best-effort: if either party doesn't have a User
             // row on this mirror, we just skip their notification.
+            //
+            // If tokenId's own User row hasn't landed yet either, skip the
+            // whole notification rather than falling back to `#<tokenId>`:
+            // that placeholder gets frozen into actionPayload permanently
+            // (nothing repairs it later, unlike MarketplaceListing.username
+            // above, which has a one-shot backfill for the same shape of
+            // gap). Same best-effort posture as the seller/buyer lookup
+            // right below -- this event will not be replayed once the
+            // block is past, so a skipped notification here is silent,
+            // same as a skipped seller/buyer notification would be.
             try {
-              const user = await prisma.user.findUnique({ where: { tokenId } })
-              const username = user?.username || `#${tokenId}`
+              const user = await prisma.user.findUnique({ where: { tokenId }, select: { username: true } })
+              if (!user) {
+                console.warn(`[Marketplace] Skipping offer acceptance notifications for offer ${onChainOfferId} — tokenId ${tokenId} has no User row yet`)
+                continue
+              }
+              const username = user.username
 
               const [sellerUser, buyerUser] = await Promise.all([
                 prisma.user.findFirst({


### PR DESCRIPTION
## Summary
When a seller accepts an offer via `acceptOffer`, the contract emits `OfferAccepted(offerId, tokenId, seller, buyer, price, paymentToken)`. The indexer only read `args[0]` (offerId) to flip the offer's status to `ACCEPTED`, ignoring `seller`/`buyer`/`price`/`paymentToken`/`tokenId` entirely — neither party got a sale-completion notification.

The frontend already has full `SALE_SOLD`/`SALE_BOUGHT` rendering (`Notifications.tsx`, price/currency/USD formatting) and the enum values exist in `schema.prisma`; this was purely a missing indexer-side emit.

## Approach
Mirrors the existing Sale-event `SALE_SOLD`/`SALE_BOUGHT` pair (L289-347, same file) almost verbatim: same `groupKey`-based idempotency guard (here `offer_accepted_sold_<id>` / `offer_accepted_bought_<id>` instead of `sale_sold_<listingId>` / `sale_bought_<listingId>`), same best-effort seller/buyer `User` lookup by address, same `actionPayload` shape. An accepted offer is a completed sale too, it just has no `MarketplaceListing`/`Sale` row to hang a notification off of — offers aren't tied to a listing — so this is the only place in the indexer this notification can originate from.

`Notification.offerId` is deliberately left unset: `notificationTargetKey()` only reads it for `NotificationType.OFFER` groupings, not `SALE_SOLD`/`SALE_BOUGHT` — matching how `OUTBID`/`AUCTION_WON` keep `listingId` in `actionPayload` rather than a dedicated column.

## Safety check
Confirmed `acceptOffer()` requires `cawProfile.ownerOf(tokenId) == msg.sender` (`CawProfileMarketplace.sol` L612), so the `tokenId`-resolved username can never diverge from the seller address the notification is sent to.

## Verification
`scripts/verify-offer-accepted-notifications.js`:
- fresh event creates both notifications
- a re-processed event (DB rebuild/rescan) creates zero (idempotent)
- a missing `User` row on either side degrades to a single notification instead of throwing
- a wash sale (seller === buyer) still produces both rows via distinct groupKeys
- a different offerId is never deduped against another offer's history

zinsanjp

