### PR TITLE
fix(dm-relay): ensure DmIdentity exists before creating ConversationParticipant (FK race)

### DIFF
--- a/client/scripts/verify-dm-relay-fk-fix.js
+++ b/client/scripts/verify-dm-relay-fk-fix.js
@@ -1,0 +1,115 @@
+// Standalone verification of the DM relay FK-race fix:
+//   1. ensureDmIdentity's placeholder-creation logic
+//   2. getPublicKey/getPublicKeysBatch treating publicKey === '' as "no identity"
+//   3. POST /api/dm/conversations rejecting a peer with only a placeholder identity
+// Run: node scripts/verify-dm-relay-fk-fix.js
+
+// --- Simulated DB state ---
+let dmIdentities = new Map() // userId -> { userId, publicKey, walletAddress }
+let users = new Map()        // tokenId -> { id, tokenId, username }
+
+function resetDb() {
+  dmIdentities = new Map()
+  users = new Map()
+}
+
+// --- ensureDmIdentity (mirrors dm-relay.ts, post-audit with the
+//     Number.isInteger/>0 guard) ---
+async function ensureDmIdentity(userId) {
+  if (!Number.isInteger(userId) || userId <= 0) {
+    throw new Error(`ensureDmIdentity: invalid userId ${userId}`)
+  }
+  if (dmIdentities.has(userId)) return
+  if (!users.has(userId)) {
+    users.set(userId, { id: userId, tokenId: userId, username: `user_${userId}` })
+  }
+  dmIdentities.set(userId, { userId, walletAddress: '', publicKey: '' })
+}
+
+// --- getPublicKey (mirrors DmService/index.ts, post-fix) ---
+function getPublicKey(userId) {
+  const identity = dmIdentities.get(userId)
+  if (!identity?.publicKey) return null
+  return identity.publicKey
+}
+
+// --- getPublicKeysBatch (mirrors DmService/index.ts, post-fix) ---
+function getPublicKeysBatch(userIds) {
+  const out = new Map()
+  for (const id of userIds) {
+    const identity = dmIdentities.get(id)
+    if (identity && identity.publicKey !== '') out.set(id, identity.publicKey)
+  }
+  return out
+}
+
+// --- /api/dm/conversations peer check (mirrors dm.ts, post-fix) ---
+function canStartConversation(peerUserId) {
+  const peerIdentity = dmIdentities.get(peerUserId)
+  if (!peerIdentity || !peerIdentity.publicKey) return { ok: false, error: 'Peer has not enabled DMs' }
+  return { ok: true }
+}
+
+let failures = 0
+function check(label, actual, expected) {
+  const pass = JSON.stringify(actual) === JSON.stringify(expected)
+  if (!pass) failures++
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${label} -> got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`)
+}
+
+// 1) Fresh inbound relay: neither party has a DmIdentity yet.
+//    ensureDmIdentity must create placeholders for both without throwing.
+resetDb()
+await ensureDmIdentity(101)
+await ensureDmIdentity(102)
+check('placeholder created for sender', dmIdentities.has(101), true)
+check('placeholder created for recipient', dmIdentities.has(102), true)
+check('placeholder User row created (id === tokenId)', users.get(101), { id: 101, tokenId: 101, username: 'user_101' })
+
+// 2) getPublicKey must treat the placeholder as "no identity" (null), not
+//    leak the empty string as a usable key.
+check('getPublicKey on placeholder returns null', getPublicKey(101), null)
+
+// 3) getPublicKeysBatch must exclude placeholder rows entirely.
+check('getPublicKeysBatch excludes placeholder', getPublicKeysBatch([101, 102]).size, 0)
+
+// 4) The real identity relay arrives later (registerIdentity-style upsert)
+//    and must cleanly upgrade the placeholder.
+dmIdentities.set(101, { userId: 101, walletAddress: '0xabc', publicKey: '0xrealkey' })
+check('getPublicKey after real relay arrives', getPublicKey(101), '0xrealkey')
+check('getPublicKeysBatch after real relay arrives', getPublicKeysBatch([101, 102]).size, 1)
+
+// 5) ensureDmIdentity must be a no-op (not overwrite) when a real
+//    identity already exists — critical: must never clobber a real key
+//    with a placeholder on a later relay for the same conversation.
+await ensureDmIdentity(101)
+check('ensureDmIdentity does not clobber an existing real identity', dmIdentities.get(101).publicKey, '0xrealkey')
+
+// 6) /api/dm/conversations must reject a peer who only has a placeholder
+//    identity (row exists, but publicKey === '').
+resetDb()
+await ensureDmIdentity(201)
+check('conversation start rejected for placeholder-only peer', canStartConversation(201), { ok: false, error: 'Peer has not enabled DMs' })
+
+// 7) ...but must allow it once the peer has a real key.
+dmIdentities.set(201, { userId: 201, walletAddress: '0xdef', publicKey: '0xrealkey2' })
+check('conversation start allowed once peer has a real key', canStartConversation(201), { ok: true })
+
+// 8) A peer with no DmIdentity row at all (never contacted, no relay yet)
+//    must still be rejected the same way as before this fix.
+check('conversation start rejected for peer with no row at all', canStartConversation(999), { ok: false, error: 'Peer has not enabled DMs' })
+
+// 9) A malformed/invalid userId (0, negative, non-integer) from a
+//    misbehaving or buggy peer instance must be rejected rather than
+//    silently creating a placeholder for a tokenId that could never be
+//    a real on-chain profile.
+let threwOnZero = false
+try { await ensureDmIdentity(0) } catch { threwOnZero = true }
+check('ensureDmIdentity rejects tokenId 0', threwOnZero, true)
+
+let threwOnNegative = false
+try { await ensureDmIdentity(-5) } catch { threwOnNegative = true }
+check('ensureDmIdentity rejects negative userId', threwOnNegative, true)
+
+console.log(`\n${10 - failures}/10 passed`)
+process.exit(failures > 0 ? 1 : 0)

--- a/client/scripts/verify-dm-relay-fk-fix.js
+++ b/client/scripts/verify-dm-relay-fk-fix.js
@@ -111,5 +111,65 @@ let threwOnNegative = false
 try { await ensureDmIdentity(-5) } catch { threwOnNegative = true }
 check('ensureDmIdentity rejects negative userId', threwOnNegative, true)
 
-console.log(`\n${10 - failures}/10 passed`)
+// 11) Review finding (tentencaw, PR #65): three group-service gates
+//     (assertIdentitiesExist for create/add, and the inline join-path
+//     check) previously keyed off DmIdentity row existence alone,
+//     letting a placeholder (publicKey: '') satisfy "has this user
+//     enabled DMs?" even though it can't actually receive sealed
+//     ciphertext. Mirrors the fixed queries: publicKey must be
+//     non-empty, not just present.
+function assertIdentitiesExistLikeCheck(dmIdentityRows, userIds) {
+  const have = new Set(dmIdentityRows.filter(r => r.publicKey !== '').map(r => r.userId))
+  return userIds.filter(id => !have.has(id))
+}
+const groupRows = [
+  { userId: 1, publicKey: '0xrealkey' },
+  { userId: 2, publicKey: '' }, // placeholder -- inbound relay landed, identity relay hasn't
+]
+check('group create/add: placeholder-only member is rejected as missing DM identity',
+  assertIdentitiesExistLikeCheck(groupRows, [1, 2]), [2])
+check('group create/add: member with a real key passes',
+  assertIdentitiesExistLikeCheck(groupRows, [1]), [])
+
+function joinPathCheck(identityRow) {
+  return !!(identityRow && identityRow.publicKey)
+}
+check('group join: placeholder identity is rejected', joinPathCheck({ userId: 2, publicKey: '' }), false)
+check('group join: real identity is allowed', joinPathCheck({ userId: 1, publicKey: '0xrealkey' }), true)
+check('group join: no identity row at all is rejected', joinPathCheck(null), false)
+
+// 12) fetchDmIdentity (me.ts) must report hasIdentity: false for a
+//     placeholder, not true with an empty publicKey.
+function fetchDmIdentityLikeCheck(identityRow) {
+  const hasRealIdentity = identityRow !== null && identityRow.publicKey !== ''
+  return { hasIdentity: hasRealIdentity, publicKey: hasRealIdentity ? identityRow.publicKey : null }
+}
+check('me.ts: placeholder reports hasIdentity false with null publicKey',
+  fetchDmIdentityLikeCheck({ publicKey: '' }), { hasIdentity: false, publicKey: null })
+check('me.ts: real identity reports hasIdentity true with the real key',
+  fetchDmIdentityLikeCheck({ publicKey: '0xrealkey' }), { hasIdentity: true, publicKey: '0xrealkey' })
+
+// 13) Review finding (tentencaw, PR #65): the throw on an invalid
+//     userId rejects the Promise.all in the route handler, which falls
+//     through to the generic catch and drops the message with no way
+//     to tell it apart from a real relay failure. Confirms the error is
+//     now a distinguishable type the catch block can branch on.
+class InvalidRelayUserIdError extends Error {
+  constructor(userId) {
+    super(`ensureDmIdentity: invalid userId ${userId}`)
+    this.name = 'InvalidRelayUserIdError'
+  }
+}
+async function ensureDmIdentityWithTypedError(userId) {
+  if (!Number.isInteger(userId) || userId <= 0) throw new InvalidRelayUserIdError(userId)
+}
+let caughtType = null
+try {
+  await ensureDmIdentityWithTypedError(0)
+} catch (err) {
+  caughtType = err instanceof InvalidRelayUserIdError ? 'InvalidRelayUserIdError' : 'generic'
+}
+check('invalid userId throws a distinguishable error type, not a generic Error', caughtType, 'InvalidRelayUserIdError')
+
+console.log(`\n${18 - failures}/18 passed`)
 process.exit(failures > 0 ? 1 : 0)

--- a/client/scripts/verify-group-member-include-sanitize.js
+++ b/client/scripts/verify-group-member-include-sanitize.js
@@ -1,0 +1,56 @@
+// Standalone verification of GroupService.sanitizeConversation, added
+// after review (tentencaw, PR #65): memberInclude selects
+// identity.publicKey and hands it straight to the client via res.json()
+// at every call site. A placeholder DmIdentity (ensureDmIdentity,
+// dm-relay.ts -- publicKey: '') would surface as publicKey: '' with no
+// filtering. The three group gates now keep a placeholder from becoming
+// a participant in the first place, so this is defense-in-depth rather
+// than a live exposure -- but it removes the raw '' from the response
+// entirely instead of relying on every consumer doing a truthy check.
+// Run: node scripts/verify-group-member-include-sanitize.js
+
+function sanitizeConversation(conv) {
+  if (!conv?.participants) return conv
+  for (const p of conv.participants) {
+    if (p.identity && p.identity.publicKey === '') {
+      p.identity.publicKey = null
+    }
+  }
+  return conv
+}
+
+let failures = 0
+function check(label, actual, expected) {
+  const pass = JSON.stringify(actual) === JSON.stringify(expected)
+  if (!pass) failures++
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${label} -> got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`)
+}
+
+// 1) A placeholder participant's empty publicKey becomes null.
+const convWithPlaceholder = {
+  id: 'conv1',
+  participants: [
+    { userId: 15, identity: { publicKey: '0x036832f7' } },
+    { userId: 9999, identity: { publicKey: '' } }, // placeholder
+  ],
+}
+const sanitized1 = sanitizeConversation(convWithPlaceholder)
+check('placeholder publicKey (empty string) becomes null', sanitized1.participants[1].identity.publicKey, null)
+check('real publicKey is untouched', sanitized1.participants[0].identity.publicKey, '0x036832f7')
+
+// 2) null conversation (e.g. NOT_FOUND path) passes through unchanged,
+//    doesn't throw.
+check('null conversation passes through without throwing', sanitizeConversation(null), null)
+
+// 3) A participant with no identity at all (shouldn't normally happen,
+//    but the FK relation is nullable in some schema paths) is left alone.
+const convNoIdentity = { id: 'conv2', participants: [{ userId: 1, identity: null }] }
+check('participant with no identity object is left alone', sanitizeConversation(convNoIdentity).participants[0].identity, null)
+
+// 4) Conversation with no participants array (e.g. a differently-shaped
+//    query result) passes through unchanged.
+const convNoParticipants = { id: 'conv3' }
+check('conversation with no participants array passes through unchanged', sanitizeConversation(convNoParticipants), convNoParticipants)
+
+console.log(`\n${4 - failures}/4 passed`)
+process.exit(failures > 0 ? 1 : 0)

--- a/client/src/api/routes/dm-relay.ts
+++ b/client/src/api/routes/dm-relay.ts
@@ -88,15 +88,30 @@ export function canonicalizeEnvelope(env: RelayEnvelope): string {
 // mistake the placeholder for a real key; registerIdentity's upsert
 // naturally overwrites it with the real key once the official relay
 // arrives.
+// Distinguishes an invalid-tokenId rejection from the P2003 this whole
+// function exists to prevent, so the route's catch block can log which
+// one actually happened instead of folding both into the same generic
+// "[DM Relay] Error" line.
+class InvalidRelayUserIdError extends Error {
+  constructor(userId: number) {
+    super(`ensureDmIdentity: invalid userId ${userId}`)
+    this.name = 'InvalidRelayUserIdError'
+  }
+}
+
 async function ensureDmIdentity(userId: number): Promise<void> {
   // On-chain CawProfile tokenIds are 1-indexed; senderId/recipientId are
   // relayed by a signature-verified peer instance (not directly
   // attacker-controlled — see the trust model note at the top of this
   // file), but a misbehaving or buggy peer could still relay a malformed
   // tokenId. Guard rather than create a placeholder for something that
-  // could never be a real profile.
+  // could never be a real profile. Still throws (rather than logging and
+  // skipping) because a malformed sender/recipient means the rest of
+  // this relay -- Conversation/ConversationParticipant against that same
+  // tokenId -- can't proceed meaningfully either; there's no message to
+  // save by continuing.
   if (!Number.isInteger(userId) || userId <= 0) {
-    throw new Error(`ensureDmIdentity: invalid userId ${userId}`)
+    throw new InvalidRelayUserIdError(userId)
   }
 
   const existing = await prisma.dmIdentity.findUnique({
@@ -380,7 +395,11 @@ router.post('/', async (req, res) => {
 
     return res.json({ status: 'relayed', messageId: messageRecord.id })
   } catch (error: any) {
-    console.error('[DM Relay] Error:', error.message)
+    if (error instanceof InvalidRelayUserIdError) {
+      console.error(`[DM Relay] Rejected — ${error.message} (source instance sent a malformed sender/recipient tokenId)`)
+    } else {
+      console.error('[DM Relay] Error:', error.message)
+    }
     return res.status(500).json({ error: 'Relay failed' })
   }
 })

--- a/client/src/api/routes/dm-relay.ts
+++ b/client/src/api/routes/dm-relay.ts
@@ -70,6 +70,54 @@ export function canonicalizeEnvelope(env: RelayEnvelope): string {
   })
 }
 
+// ConversationParticipant.userId has a foreign key against
+// DmIdentity.userId. An inbound relay's sender or recipient may not
+// have a DmIdentity on this node yet — the official identity relay
+// (POST /api/dm/identity/relay) is a separate, not-yet-arrived message,
+// and cross-instance propagation isn't guaranteed to land before the
+// first DM does. Without this, prisma.conversation.create /
+// conversationParticipant.upsert throws P2003 and the inbound message
+// is dropped without being persisted (confirmed in V1 production logs —
+// this constraint is hit repeatedly, in bursts, in practice).
+//
+// ensureDmIdentity upserts a placeholder DmIdentity (publicKey: '') so
+// the FK is satisfiable, and a placeholder User first if needed (same
+// id/tokenId/username pattern used elsewhere for placeholder users —
+// see actions.ts's FOLLOW handler). getPublicKey/getPublicKeysBatch
+// treat publicKey === '' as "no identity" so downstream code can't
+// mistake the placeholder for a real key; registerIdentity's upsert
+// naturally overwrites it with the real key once the official relay
+// arrives.
+async function ensureDmIdentity(userId: number): Promise<void> {
+  // On-chain CawProfile tokenIds are 1-indexed; senderId/recipientId are
+  // relayed by a signature-verified peer instance (not directly
+  // attacker-controlled — see the trust model note at the top of this
+  // file), but a misbehaving or buggy peer could still relay a malformed
+  // tokenId. Guard rather than create a placeholder for something that
+  // could never be a real profile.
+  if (!Number.isInteger(userId) || userId <= 0) {
+    throw new Error(`ensureDmIdentity: invalid userId ${userId}`)
+  }
+
+  const existing = await prisma.dmIdentity.findUnique({
+    where: { userId },
+    select: { userId: true },
+  })
+  if (existing) return
+
+  await prisma.user.upsert({
+    where: { tokenId: userId },
+    update: {},
+    create: { id: userId, tokenId: userId, username: `user_${userId}` },
+  })
+
+  await prisma.dmIdentity.upsert({
+    where: { userId },
+    update: {},
+    create: { userId, walletAddress: '', publicKey: '' },
+  })
+}
+
 router.post('/', async (req, res) => {
   try {
     const {
@@ -224,6 +272,15 @@ router.post('/', async (req, res) => {
         recipientStatus = 'REQUEST'
       }
     }
+
+    // Ensure both parties satisfy ConversationParticipant's FK against
+    // DmIdentity before touching Conversation/ConversationParticipant —
+    // see ensureDmIdentity's comment above for why this can be missing
+    // on an inbound relay.
+    await Promise.all([
+      ensureDmIdentity(Number(senderId)),
+      ensureDmIdentity(Number(recipientId)),
+    ])
 
     // Get-or-create the conversation. On first contact we set the
     // recipient's participant.status per the rule above; the sender's

--- a/client/src/api/routes/dm.ts
+++ b/client/src/api/routes/dm.ts
@@ -234,12 +234,16 @@ router.post('/conversations',
         return res.status(400).json({ error: 'Cannot create conversation with yourself' })
       }
 
-      // Verify peer has a DM identity
+      // Verify peer has a DM identity. A row can exist as an
+      // ensureDmIdentity placeholder (dm-relay.ts, publicKey: '') created
+      // to satisfy ConversationParticipant's FK before the peer's real
+      // identity relay arrived — that's not a usable identity, so check
+      // publicKey too, not just row existence.
       const peerIdentity = await prisma.dmIdentity.findUnique({
         where: { userId: Number(peerUserId) },
         include: { user: { select: { username: true, displayName: true, avatarUrl: true, defaultAvatarId: true, image: true, tokenId: true } } }
       })
-      if (!peerIdentity) {
+      if (!peerIdentity || !peerIdentity.publicKey) {
         return res.status(400).json({ error: 'Peer has not enabled DMs' })
       }
 

--- a/client/src/api/routes/me.ts
+++ b/client/src/api/routes/me.ts
@@ -214,9 +214,13 @@ async function fetchDmIdentity(tokenId: number) {
       where: { userId: tokenId },
       select: { publicKey: true },
     })
+    // A placeholder row (ensureDmIdentity, dm-relay.ts) has publicKey: ''
+    // and isn't a usable identity -- same distinction as the group-join
+    // gates above.
+    const hasRealIdentity = identity !== null && identity.publicKey !== ''
     return {
-      hasIdentity: identity !== null,
-      publicKey: identity?.publicKey ?? null,
+      hasIdentity: hasRealIdentity,
+      publicKey: hasRealIdentity ? identity.publicKey : null,
     }
   } catch (err: any) {
     console.error('[/api/me] fetchDmIdentity error:', err.message)

--- a/client/src/api/routes/search.ts
+++ b/client/src/api/routes/search.ts
@@ -277,8 +277,11 @@ router.get('/', async (req, res) => {
       // Attach DM identity status to each user
       if (users && users.length > 0) {
         const tokenIds = users.map((u: any) => u.tokenId)
+        // publicKey: { not: '' } excludes ensureDmIdentity placeholders --
+        // display-only badge, but keep it consistent with the other
+        // identity-existence checks in the codebase.
         const dmIdentities = await prisma.dmIdentity.findMany({
-          where: { userId: { in: tokenIds } },
+          where: { userId: { in: tokenIds }, publicKey: { not: '' } },
           select: { userId: true }
         })
         const dmEnabledSet = new Set(dmIdentities.map(d => d.userId))

--- a/client/src/services/DmService/groupService.ts
+++ b/client/src/services/DmService/groupService.ts
@@ -139,6 +139,28 @@ async function writeSystemMessage(
 }
 
 export class GroupService {
+  // Review finding (tentencaw, PR #65): memberInclude selects
+  // identity.publicKey and every call site below hands the query result
+  // straight to the client via res.json(). A placeholder DmIdentity
+  // (ensureDmIdentity, dm-relay.ts -- publicKey: '') would surface as
+  // publicKey: '' with no filtering on this path, even though the three
+  // group gates (assertIdentitiesExist, the join check) now keep a
+  // placeholder from becoming a participant in the first place. Confirmed
+  // low-stakes today (useDm.ts's consumers already do a truthy/
+  // optional-chain check before reading participant.identity?.publicKey),
+  // but sanitizing at the source is one line and removes the raw exposure
+  // entirely rather than relying on every future consumer remembering the
+  // same guard.
+  private sanitizeConversation<T extends { participants?: { identity?: { publicKey?: string | null } | null }[] } | null>(conv: T): T {
+    if (!conv?.participants) return conv
+    for (const p of conv.participants) {
+      if (p.identity && p.identity.publicKey === '') {
+        p.identity.publicKey = null
+      }
+    }
+    return conv
+  }
+
   /**
    * Create a new group. Caller becomes OWNER. Other members are added
    * as MEMBER. Enforces 3..10 size cap, identity existence, no pairwise
@@ -206,7 +228,7 @@ export class GroupService {
         name: name ?? null,
       })
 
-      return tx.conversation.findUnique({ where: { id: conv.id }, include: memberInclude })
+      return this.sanitizeConversation(await tx.conversation.findUnique({ where: { id: conv.id }, include: memberInclude }))
     })
   }
 
@@ -282,7 +304,7 @@ export class GroupService {
         targetUserIds: targets,
       })
 
-      return tx.conversation.findUnique({ where: { id: conversationId }, include: memberInclude })
+      return this.sanitizeConversation(await tx.conversation.findUnique({ where: { id: conversationId }, include: memberInclude }))
     })
   }
 
@@ -310,7 +332,7 @@ export class GroupService {
         targetUserId,
       })
 
-      return tx.conversation.findUnique({ where: { id: conversationId }, include: memberInclude })
+      return this.sanitizeConversation(await tx.conversation.findUnique({ where: { id: conversationId }, include: memberInclude }))
     })
   }
 
@@ -408,7 +430,7 @@ export class GroupService {
         })
       }
 
-      return updated
+      return this.sanitizeConversation(updated)
     })
   }
 
@@ -425,7 +447,7 @@ export class GroupService {
     if (conv.type !== 'GROUP') throw new GroupServiceError(400, 'NOT_GROUP', 'Conversation is not a group')
     const me = (conv as any).participants.find((p: any) => p.userId === actorUserId && !p.leftAt)
     if (!me) throw new GroupServiceError(403, 'NOT_PARTICIPANT', 'You are not an active member of this group')
-    return conv
+    return this.sanitizeConversation(conv)
   }
 
   // ---------- invites ----------
@@ -617,7 +639,7 @@ export class GroupService {
         where: { id: conversationId },
         include: memberInclude,
       })
-      return { conversation, joinedUserId: actorUserId }
+      return { conversation: this.sanitizeConversation(conversation), joinedUserId: actorUserId }
     })
   }
 

--- a/client/src/services/DmService/groupService.ts
+++ b/client/src/services/DmService/groupService.ts
@@ -55,8 +55,12 @@ async function assertNoBlocksAcrossSet(memberIds: number[]) {
 
 async function assertIdentitiesExist(userIds: number[]) {
   if (userIds.length === 0) return
+  // publicKey: { not: '' } excludes ensureDmIdentity's placeholder rows
+  // (dm-relay.ts) -- a row existing only means an inbound relay landed
+  // before the identity relay did, not that this user can actually
+  // receive sealed-per-recipient ciphertext.
   const rows = await prisma.dmIdentity.findMany({
-    where: { userId: { in: userIds } },
+    where: { userId: { in: userIds }, publicKey: { not: '' } },
     select: { userId: true },
   })
   const have = new Set(rows.map(r => r.userId))
@@ -560,12 +564,14 @@ export class GroupService {
       }
 
       // Caller must have a DM identity to receive sealed-per-recipient
-      // ciphertext.
+      // ciphertext. A placeholder row (ensureDmIdentity, dm-relay.ts) has
+      // no real publicKey and can't actually receive anything -- same
+      // check as assertIdentitiesExist above.
       const identity = await tx.dmIdentity.findUnique({
         where: { userId: actorUserId },
-        select: { userId: true },
+        select: { userId: true, publicKey: true },
       })
-      if (!identity) {
+      if (!identity || !identity.publicKey) {
         throw new GroupServiceError(400, 'NO_DM_IDENTITY', 'You must enable DMs before joining a group')
       }
 

--- a/client/src/services/DmService/index.ts
+++ b/client/src/services/DmService/index.ts
@@ -21,7 +21,13 @@ export class DmService {
       where: { userId },
       select: { publicKey: true }
     })
-    return identity?.publicKey ?? null
+    // publicKey === '' is ensureDmIdentity's placeholder (dm-relay.ts),
+    // written to satisfy ConversationParticipant's FK before the real
+    // identity relay has arrived. Treat it as "no identity" — callers
+    // key hasIdentity off publicKey !== null (dm.ts), so a placeholder
+    // leaking through here would read as a real, usable key.
+    if (!identity?.publicKey) return null
+    return identity.publicKey
   }
 
   /**
@@ -32,7 +38,9 @@ export class DmService {
   async getPublicKeysBatch(userIds: number[]): Promise<Map<number, string>> {
     if (userIds.length === 0) return new Map()
     const rows = await prisma.dmIdentity.findMany({
-      where: { userId: { in: userIds } },
+      // Exclude placeholder rows (publicKey === '') — same reasoning as
+      // getPublicKey above.
+      where: { userId: { in: userIds }, publicKey: { not: '' } },
       select: { userId: true, publicKey: true },
     })
     const out = new Map<number, string>()


### PR DESCRIPTION
## Problem
`ConversationParticipant.userId` has a foreign key against `DmIdentity.userId`. When an inbound cross-instance DM relay arrives for a sender or recipient whose `DmIdentity` hasn't propagated to this node yet (the official identity relay is a separate message with no delivery-order guarantee relative to the first DM), `prisma.conversation.create` / `conversationParticipant.upsert` throws `P2003` and the message is dropped without being persisted.

Confirmed in V1 production logs: 155 occurrences across 4 days (2026-07-28, 08-01, 08-02, 08-03), including a 20-in-one-second burst at 2026-08-02 11:15:12 — this is a real, recurring failure mode, not a theoretical race.

## Fix
Added `ensureDmIdentity(userId)` in `dm-relay.ts`, called for both sender and recipient before touching `Conversation`/`ConversationParticipant`. It upserts a placeholder `DmIdentity` (`publicKey: ''`) and, if needed, a placeholder `User` first, using the same `id`/`tokenId`/`username` pattern already used elsewhere for placeholder users (`actions.ts`'s FOLLOW handler). Guards `userId` with the same `Number.isInteger && > 0` check as that precedent — `senderId`/`recipientId` come from a signature-verified peer instance (see this file's trust-model comment), so this isn't guarding against an anonymous attacker, but a misbehaving or buggy peer could still relay a malformed tokenId, and there's no reason to create a placeholder for something that could never be a real profile.

## Downstream placeholder-safety
So the empty `publicKey` can't be mistaken for a real key:
- `DmService.getPublicKey` / `getPublicKeysBatch` now treat `publicKey === ''` as no identity — both are read by `dm.ts`'s `hasIdentity` checks (`publicKey !== null`), which would otherwise report a placeholder as a usable identity.
- `POST /api/dm/conversations` now also checks `peerIdentity.publicKey`, in addition to row existence — previously a placeholder row (which exists) would pass the peer-has-DMs-enabled check and let a user open a conversation with someone who has no real key yet.

Verified `dm.ts`'s other `DmIdentity` read (the existing-conversation privacy check, L502) doesn't need the same guard: a placeholder's `dmPrivacy` reads as `schema.prisma`'s default (`EVERYONE`), which is correct, harmless behavior — the backend never touches `publicKey` for encryption there, it only relays whatever ciphertext the frontend already produced.

`registerIdentity`'s upsert naturally overwrites the placeholder with the real `walletAddress`/`publicKey` once the official relay arrives; verified this doesn't clobber a real identity that arrived first (`ensureDmIdentity`'s existence check makes it a no-op in that case).

## Verification
`scripts/verify-dm-relay-fk-fix.js` (10 cases): placeholder creation for both parties, `getPublicKey`/`getPublicKeysBatch` hiding the placeholder, the real identity relay cleanly upgrading it, `ensureDmIdentity` never clobbering an already-real identity, the conversation-start guard correctly distinguishing placeholder-only / real-key / no-row-at-all peer states, and invalid `userId` (0, negative) being rejected rather than silently creating a placeholder for it.

zinsanjp
