### PR TITLE
fix(dm-relay): add timeout to peer outbound fetch requests

### DIFF
--- a/client/scripts/verify-dm-relay-timeout.js
+++ b/client/scripts/verify-dm-relay-timeout.js
@@ -1,0 +1,101 @@
+// Standalone verification of the DM relay outbound fetch timeout.
+// Uses a real `fetch()` against a local TCP server that intentionally
+// never responds, so this exercises the actual fetch()+AbortSignal
+// combination used in DmRelayService, not a simulated abort.
+// Run: node scripts/verify-dm-relay-timeout.js
+
+const http = require('http')
+const net = require('net')
+
+const DM_RELAY_TIMEOUT_MS = 300 // short for test speed; production uses 5_000
+
+async function withHangingServer(fn) {
+  // A raw TCP server that accepts the connection but never writes a
+  // response — this is what an unresponsive/hung peer looks like from
+  // the relaying node's side (as opposed to ECONNREFUSED, which fails
+  // instantly and isn't the case this timeout protects against).
+  const server = net.createServer((socket) => {
+    // Deliberately do nothing — hold the connection open.
+  })
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = server.address().port
+  try {
+    return await fn(`http://127.0.0.1:${port}/`)
+  } finally {
+    server.close()
+  }
+}
+
+async function withRefusingPort(fn) {
+  // A port nothing is listening on — fails fast (ECONNREFUSED), the
+  // routine-failure case that must NOT be delayed by the timeout.
+  return fn('http://127.0.0.1:1/') // port 1 is reserved, always refused
+}
+
+async function relayAttempt(url) {
+  const start = Date.now()
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+      signal: AbortSignal.timeout(DM_RELAY_TIMEOUT_MS),
+    })
+    return { outcome: 'ok', elapsedMs: Date.now() - start }
+  } catch (err) {
+    return { outcome: 'caught', error: err.message, elapsedMs: Date.now() - start }
+  }
+}
+
+let failures = 0
+function check(label, cond, detail) {
+  if (!cond) failures++
+  console.log(`[${cond ? 'PASS' : 'FAIL'}] ${label}${detail ? ' -> ' + detail : ''}`)
+}
+
+async function run() {
+  // 1) A peer that accepts the connection but never responds must be
+  //    aborted at ~DM_RELAY_TIMEOUT_MS, not hang indefinitely.
+  const hung = await withHangingServer(relayAttempt)
+  check(
+    'hung peer aborts near the timeout, not indefinitely',
+    hung.outcome === 'caught' && hung.elapsedMs >= DM_RELAY_TIMEOUT_MS && hung.elapsedMs < DM_RELAY_TIMEOUT_MS + 500,
+    `outcome=${hung.outcome} elapsed=${hung.elapsedMs}ms error=${hung.error}`
+  )
+
+  // 2) A peer that refuses the connection outright must be caught
+  //    quickly — the timeout must not delay routine failures.
+  const refused = await withRefusingPort(relayAttempt)
+  check(
+    'refused connection is caught quickly, not held until timeout',
+    refused.outcome === 'caught' && refused.elapsedMs < DM_RELAY_TIMEOUT_MS,
+    `outcome=${refused.outcome} elapsed=${refused.elapsedMs}ms error=${refused.error}`
+  )
+
+  // 3) N hung peers relayed concurrently (fire-and-forget, matching the
+  //    actual for-loop's non-awaited fetch calls) must all resolve
+  //    within roughly one timeout window, not N * timeout serially.
+  const N = 10
+  const servers = []
+  for (let i = 0; i < N; i++) {
+    const server = net.createServer(() => {})
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+    servers.push(server)
+  }
+  const concurrentStart = Date.now()
+  await Promise.all(
+    servers.map((s) => relayAttempt(`http://127.0.0.1:${s.address().port}/`))
+  )
+  const concurrentElapsed = Date.now() - concurrentStart
+  servers.forEach((s) => s.close())
+  check(
+    `${N} concurrent hung peers all resolve within ~1 timeout window (parallel, not serial)`,
+    concurrentElapsed < DM_RELAY_TIMEOUT_MS + 500,
+    `elapsed=${concurrentElapsed}ms for ${N} peers`
+  )
+
+  console.log(`\n${3 - failures}/3 passed`)
+  process.exit(failures > 0 ? 1 : 0)
+}
+
+run()

--- a/client/src/services/DmRelayService/index.ts
+++ b/client/src/services/DmRelayService/index.ts
@@ -42,6 +42,15 @@ import { canonicalizeEnvelope } from '../../api/routes/dm-relay'
 import crypto from 'crypto'
 import { getNetworkId } from '../../utils/networkId'
 
+// Outbound relay fetches previously had no timeout: a hung/unreachable
+// peer would leave the request pending indefinitely, leaking a socket
+// per attempt. Both relay functions fire fetch() for every active peer
+// without awaiting or bounding concurrency, so a single unresponsive
+// peer (down for maintenance, network partition, overloaded) holds a
+// socket open indefinitely rather than failing fast. 5s is generous
+// for a same-network HTTP POST while still bounding the worst case.
+const DM_RELAY_TIMEOUT_MS = 5_000
+
 /**
  * Build a peer fetch URL using `new URL()` so path injection via a
  * maliciously-crafted apiUrl (e.g. "https://evil.com?x=") is blocked.
@@ -240,9 +249,11 @@ export async function relayDmToPeers(params: RelayParams): Promise<{ attempted: 
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body,
+      signal: AbortSignal.timeout(DM_RELAY_TIMEOUT_MS),
     }).catch(err => {
       // Fire-and-forget. Network errors are routine (peer down,
-      // unreachable). Don't spam the log on every failure.
+      // unreachable), and so is the abort from the timeout above.
+      // Don't spam the log on every failure.
       if (process.env.DM_RELAY_VERBOSE === '1') {
         console.warn(`[DmRelay] Failed to relay to ${peer.apiUrl}:`, err.message)
       }
@@ -342,7 +353,10 @@ export async function relayDmIdentityToPeers(params: {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body,
+      signal: AbortSignal.timeout(DM_RELAY_TIMEOUT_MS),
     }).catch(err => {
+      // Fire-and-forget, same as relayDmToPeers above — routine network
+      // errors and timeout aborts are both expected here.
       if (process.env.DM_RELAY_VERBOSE === '1') {
         console.warn(`[DmRelay] Failed to relay identity to ${peer.apiUrl}:`, err.message)
       }


### PR DESCRIPTION
## Problem
`relayDmToPeers` and `relayDmIdentityToPeers` fire `fetch()` for every active peer in a for-loop without awaiting or bounding concurrency, and neither had a timeout/signal. A peer that accepts the TCP connection but never responds (down for maintenance, network partition, overloaded) would leave that fetch pending indefinitely, holding a socket open with no way to recover.

## Fix
Added a 5s `AbortSignal.timeout(DM_RELAY_TIMEOUT_MS)` to both fetch calls. 5s compares reasonably against other same-codebase timeouts for proxied outbound requests (`rpc-proxy.ts` `UPSTREAM_TIMEOUT_MS`: 8s, `rpcProvider.ts` `PROBE_TIMEOUT_MS`: 10s, `ai-proxy.ts` `UPSTREAM_TIMEOUT_MS`: 60s) — this is same-network node-to-node, so shorter than any of those is reasonable. Both functions are already fire-and-forget with an existing `.catch()` that ignores routine network errors, so an abort from the timeout is caught the same way and needs no new error handling.

## What the evidence does and doesn't show
No direct evidence of this in V1 production logs: neither instance's send-side `[DmRelay]` log line appears at all in the logs checked (`DM_RELAY_VERBOSE=1` is set on V1, so failures would be logged if any occurred). That's not strong evidence of absence, though — a hung fetch with no timeout produces no log line either way, so a silent hang and a quiet period look identical from the logs. The receive side of DM relay (`dm-relay.ts`) does show real, repeated `P2003` failures in V1 logs (see the `ensureDmIdentity` PR), which confirms peers do reach unavailable/unready states in practice; this fix addresses the same category of problem from the sending side, where it currently can't be observed at all.

## Known limitations (pre-existing, not introduced by this change)
- The timeout only bounds how long the relaying node waits for a response. If a peer is simply slow rather than actually down, it may still receive and fully process the request after this node has already given up and moved on. Since the whole relay path is fire-and-forget with no retry or acknowledgment tracking today, the sender has no way to distinguish a peer that never received the request from a peer that received it but replied too slowly — both look identical from here.
- Concurrency is still unbounded (`fetch()` fires for every active peer with no cap), noting for completeness rather than as an active concern: the worst case is N concurrent 5s waits rather than N indefinite ones. This only matters at peer counts far above what the network currently has — the one time peer counts reached that scale (stale InstanceRegistry entries from a since-fixed cold-scan bug) isn't expected to recur.

Confirmed V1 has the identical unbounded `fetch()` in both functions (`DmRelayService/index.ts` L141, L236 on that tree) — same gap, not addressed here since V1 isn't receiving further changes.

## Verification
`scripts/verify-dm-relay-timeout.js`, using a real `fetch()` against a local TCP server that accepts connections but never writes a response:
- A hung peer aborts at ~timeout, not indefinitely.
- A refused connection (ECONNREFUSED-equivalent) is still caught immediately, not delayed until the timeout.
- 10 concurrent hung peers all resolve within roughly one timeout window, confirming the timeout doesn't serialize what was already concurrent, fire-and-forget behavior.

zinsanjp