### PR TITLE
fix(counts): roll back user cawCount/recawCount on CAW/RECAW failure

### DIFF
--- a/client/scripts/verify-post-failure-count-rollback.js
+++ b/client/scripts/verify-post-failure-count-rollback.js
@@ -1,0 +1,146 @@
+// Standalone verification of the CAW/RECAW count rollback added to
+// txQueueFailure.ts and DataCleaner/index.ts (companion to PR #58,
+// which fixed the same rollback omission for like/follow).
+// Mirrors CountManager.onStatusChanged's case 'caw' logic.
+// Run: node scripts/verify-post-failure-count-rollback.js
+
+// --- Simulated DB state ---
+let users = new Map() // tokenId -> { cawCount, recawCount }
+let caws = new Map()  // id -> { recawCount }
+
+function resetDb() {
+  users = new Map()
+  caws = new Map()
+}
+function getUser(id) {
+  if (!users.has(id)) users.set(id, { cawCount: 0, recawCount: 0 })
+  return users.get(id)
+}
+function getCaw(id) {
+  if (!caws.has(id)) caws.set(id, { recawCount: 0 })
+  return caws.get(id)
+}
+function safeDecrement(current) {
+  return Math.max(0, current - 1)
+}
+
+// --- onCawCreated (mirrors CountManager.ts, including the isReply
+//     dead-code status found during audit: isReply is never passed
+//     true by any caller, so replies DO bump cawCount on creation,
+//     same as top-level posts and quotes) ---
+function onCawCreated(caw) {
+  const user = getUser(caw.userId)
+  if (caw.action === 'RECAW') {
+    user.recawCount++
+  } else {
+    user.cawCount++ // includes replies, per the audit finding
+  }
+  if (caw.originalCawId) {
+    getCaw(caw.originalCawId).recawCount++
+  }
+}
+
+// --- onStatusChanged case 'caw' (mirrors CountManager.ts, this PR's
+//     txQueueFailure.ts/DataCleaner.ts call sites always pass
+//     originalCawId: null from DataCleaner to avoid double-decrementing
+//     the parent recawCount that DataCleaner's own recalculation logic
+//     already handles separately -- txQueueFailure.ts passes the real
+//     originalCawId since it has no separate recalculation step) ---
+function onStatusChangedCawFailed(meta) {
+  const user = getUser(meta.userId)
+  if (meta.action === 'RECAW') {
+    user.recawCount = safeDecrement(user.recawCount)
+  } else {
+    user.cawCount = safeDecrement(user.cawCount)
+  }
+  if (meta.originalCawId && (meta.action === 'RECAW' || meta.action === 'CAW')) {
+    const parent = getCaw(meta.originalCawId)
+    parent.recawCount = safeDecrement(parent.recawCount)
+  }
+}
+
+let failures = 0
+function check(label, actual, expected) {
+  const pass = JSON.stringify(actual) === JSON.stringify(expected)
+  if (!pass) failures++
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${label} -> got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`)
+}
+
+// 1) Top-level CAW: create then fail. cawCount should return to 0.
+resetDb()
+onCawCreated({ userId: 1, action: 'CAW', originalCawId: null })
+check('1a: top-level CAW creation bumps cawCount', getUser(1).cawCount, 1)
+onStatusChangedCawFailed({ userId: 1, action: 'CAW', originalCawId: null })
+check('1b: top-level CAW failure rolls cawCount back to 0', getUser(1).cawCount, 0)
+
+// 2) Quote (CAW with originalCawId): create then fail. Both cawCount and
+//    parent's recawCount should roll back together.
+resetDb()
+onCawCreated({ userId: 1, action: 'CAW', originalCawId: 100 })
+check('2a: quote creation bumps cawCount and parent recawCount', [getUser(1).cawCount, getCaw(100).recawCount], [1, 1])
+onStatusChangedCawFailed({ userId: 1, action: 'CAW', originalCawId: 100 })
+check('2b: quote failure rolls back both cawCount and parent recawCount', [getUser(1).cawCount, getCaw(100).recawCount], [0, 0])
+
+// 3) Reply (CAW with originalCawId, per the audit finding this DOES bump
+//    cawCount on creation despite the isReply doc comment's intent, since
+//    no caller ever passes isReply:true). DataCleaner's call site passes
+//    originalCawId: null deliberately, so only cawCount rolls back here
+//    -- parent recawCount is NOT touched by this path (replies bump
+//    parent.commentCount, not recawCount, so there's nothing to undo on
+//    this axis; commentCount rollback is handled separately).
+resetDb()
+onCawCreated({ userId: 1, action: 'CAW', originalCawId: null }) // reply: caller omits originalCawId same as quote-vs-reply distinction upstream
+check('3a: reply creation bumps cawCount (matches audited actual behavior)', getUser(1).cawCount, 1)
+onStatusChangedCawFailed({ userId: 1, action: 'CAW', originalCawId: null })
+check('3b: reply failure rolls cawCount back symmetrically', getUser(1).cawCount, 0)
+
+// 4) RECAW (plain repost): create then fail. recawCount (not cawCount)
+//    should roll back, along with the parent's recawCount.
+resetDb()
+onCawCreated({ userId: 1, action: 'RECAW', originalCawId: 200 })
+check('4a: RECAW creation bumps recawCount and parent recawCount', [getUser(1).recawCount, getCaw(200).recawCount], [1, 1])
+onStatusChangedCawFailed({ userId: 1, action: 'RECAW', originalCawId: 200 })
+check('4b: RECAW failure rolls back both', [getUser(1).recawCount, getCaw(200).recawCount], [0, 0])
+
+// 5) Idempotency / safety net: rolling back twice must never go negative.
+resetDb()
+onCawCreated({ userId: 1, action: 'CAW', originalCawId: null })
+onStatusChangedCawFailed({ userId: 1, action: 'CAW', originalCawId: null })
+onStatusChangedCawFailed({ userId: 1, action: 'CAW', originalCawId: null }) // simulate a double-fire
+check('5: safeDecrement floor prevents underflow below zero', getUser(1).cawCount, 0)
+
+// 6) Independence: rolling back one user's caw does not affect another
+//    user's counts.
+resetDb()
+onCawCreated({ userId: 1, action: 'CAW', originalCawId: null })
+onCawCreated({ userId: 2, action: 'CAW', originalCawId: null })
+onStatusChangedCawFailed({ userId: 1, action: 'CAW', originalCawId: null })
+check('6: rolling back user 1 does not affect user 2', [getUser(1).cawCount, getUser(2).cawCount], [0, 1])
+
+// 7) The critical distinction found during audit: Caw.originalCawId is
+//    set in the DB for BOTH quotes and replies (actionHandlers.ts's
+//    upsert always writes parentCawId there), but only quotes should
+//    decrement the parent's recawCount on failure -- a reply's parent
+//    gets commentCount bumped instead. Simulates txQueueFailure.ts's
+//    Reply-row lookup to confirm a reply's raw DB originalCawId gets
+//    converted to null before reaching onStatusChanged, so the parent's
+//    recawCount is untouched.
+function resolveOriginalCawIdForRollback(rawOriginalCawId, isReplyRow) {
+  return isReplyRow ? null : rawOriginalCawId
+}
+resetDb()
+onCawCreated({ userId: 1, action: 'CAW', originalCawId: null }) // reply creation never bumps parent recawCount
+getCaw(300).recawCount = 5 // parent has other unrelated recaws/quotes -- must stay untouched
+const rawOriginalCawIdFromDb = 300 // what Caw.originalCawId actually holds for a reply row
+const resolvedForReply = resolveOriginalCawIdForRollback(rawOriginalCawIdFromDb, true)
+onStatusChangedCawFailed({ userId: 1, action: 'CAW', originalCawId: resolvedForReply })
+check('7a: reply failure resolves originalCawId to null before rollback', resolvedForReply, null)
+check('7b: reply failure does not touch the parent recawCount (still 5)', getCaw(300).recawCount, 5)
+
+// 8) Same lookup for an actual quote: raw originalCawId must pass
+//    through unchanged, so the parent recawCount rollback still fires.
+const resolvedForQuote = resolveOriginalCawIdForRollback(rawOriginalCawIdFromDb, false)
+check('8: quote failure passes originalCawId through unchanged', resolvedForQuote, 300)
+
+console.log(`\n${8 - failures}/8 passed`)
+process.exit(failures > 0 ? 1 : 0)

--- a/client/scripts/verify-post-failure-count-rollback.js
+++ b/client/scripts/verify-post-failure-count-rollback.js
@@ -225,5 +225,86 @@ onCawCreated({ userId: 1, action: 'CAW', originalCawId: null })
 simulateConcurrentFailureFromTwo(true)
 check('9e: GUARDED pattern decrements cawCount 2 -> 1 on one failed post (correct)', getUser(1).cawCount, 1)
 
-console.log(`\n${13 - failures}/13 passed`)
+// --- DataCleaner's stale-pending recawCount recompute (mirrors the
+//     Reply-table quote-vs-reply distinction added to DataCleaner/index.ts:
+//     Caw.originalCawId is set for BOTH quotes and replies, so recomputing
+//     a parent's recawCount from action==='CAW' children must exclude any
+//     that are actually replies, via the Reply table. ---
+let replyRows = [] // { cawId, replyCawId }
+function addReply(cawId, replyCawId) {
+  replyRows.push({ cawId, replyCawId })
+}
+function isReplyRow(cawId, replyCawId) {
+  return replyRows.some(r => r.cawId === cawId && r.replyCawId === replyCawId)
+}
+
+// Simulates the recompute this PR adds to DataCleaner's stale-pending
+// sweep: given a pendingCaw (action + id + originalCawId), decide whether
+// it's a quote (not a reply) via the Reply table, then recompute the
+// parent's recawCount from actual SUCCESS children, excluding any CAW
+// children that are themselves replies.
+function recomputeParentRecawCount(pendingCaw, allCaws) {
+  const isQuoteNotReply = pendingCaw.action === 'RECAW'
+    ? true
+    : !isReplyRow(pendingCaw.originalCawId, pendingCaw.id)
+  if (!isQuoteNotReply || !pendingCaw.originalCawId) return null
+
+  const children = allCaws.filter(c =>
+    c.originalCawId === pendingCaw.originalCawId &&
+    c.status === 'SUCCESS' &&
+    c.action === pendingCaw.action
+  )
+  const countedChildren = pendingCaw.action === 'CAW'
+    ? children.filter(c => !isReplyRow(pendingCaw.originalCawId, c.id))
+    : children
+  return countedChildren.length
+}
+
+// 10) Reply swept by stale-pending: must NOT be treated as a quote, so the
+//     parent's recawCount recompute is skipped entirely for it (recawCount
+//     tracks quotes+recaws, not replies -- a reply's parent gets
+//     commentCount bumped elsewhere, untouched by this path).
+replyRows = []
+addReply(400, 500) // reply row: parent 400, reply-caw 500
+const allCawsReplyCase = [
+  { id: 500, action: 'CAW', originalCawId: 400, status: 'SUCCESS' }, // the reply itself
+]
+check(
+  '10: stale-pending reply is recognized via Reply table and skipped (not treated as a quote)',
+  recomputeParentRecawCount({ id: 500, action: 'CAW', originalCawId: 400 }, allCawsReplyCase),
+  null
+)
+
+// 11) Quote swept by stale-pending: recognized (no Reply row for it), and
+//     recawCount recomputed from actual SUCCESS quote children.
+replyRows = []
+const allCawsQuoteCase = [
+  { id: 501, action: 'CAW', originalCawId: 400, status: 'SUCCESS' }, // the quote itself
+  { id: 502, action: 'CAW', originalCawId: 400, status: 'SUCCESS' }, // a second, unrelated quote
+]
+check(
+  '11: stale-pending quote is recognized (no Reply row) and counted',
+  recomputeParentRecawCount({ id: 501, action: 'CAW', originalCawId: 400 }, allCawsQuoteCase),
+  2
+)
+
+// 12) Mixed case -- the actual bug this PR fixes: a parent has one real
+//     quote and one reply, both stored as action==='CAW' with the same
+//     originalCawId (per the audited actionHandlers.ts behavior). Without
+//     the Reply-table exclusion, recomputing from the quote's stale-pending
+//     sweep would count the reply too, inflating recawCount to 2 instead
+//     of the correct 1.
+replyRows = []
+addReply(600, 701) // caw 701 is a reply to parent 600, not a quote
+const allCawsMixed = [
+  { id: 700, action: 'CAW', originalCawId: 600, status: 'SUCCESS' }, // real quote
+  { id: 701, action: 'CAW', originalCawId: 600, status: 'SUCCESS' }, // reply, same action+originalCawId shape
+]
+check(
+  '12: mixed quote+reply under one parent -- recompute counts the quote only, excludes the reply',
+  recomputeParentRecawCount({ id: 700, action: 'CAW', originalCawId: 600 }, allCawsMixed),
+  1
+)
+
+console.log(`\n${16 - failures}/16 passed`)
 process.exit(failures > 0 ? 1 : 0)

--- a/client/scripts/verify-post-failure-count-rollback.js
+++ b/client/scripts/verify-post-failure-count-rollback.js
@@ -142,5 +142,88 @@ check('7b: reply failure does not touch the parent recawCount (still 5)', getCaw
 const resolvedForQuote = resolveOriginalCawIdForRollback(rawOriginalCawIdFromDb, false)
 check('8: quote failure passes originalCawId through unchanged', resolvedForQuote, 300)
 
-console.log(`\n${8 - failures}/8 passed`)
+// 9) TOCTOU regression check: markTxQueueFailed's CAW/RECAW cleanup used to
+//    run findMany then updateMany as two separate queries with no status
+//    guard on the write. Two concurrent calls for the same senderId/cawonce
+//    could both read the same PENDING row before either write landed, then
+//    each fire onStatusChanged for it -- double-decrementing cawCount. The
+//    fix scopes the updateMany to `status: 'PENDING'` and only calls
+//    onStatusChanged for rows this call actually flipped. Simulate both a
+//    single "DB" row and two concurrent callers racing against it.
+function simulateConcurrentFailure(useGuardedUpdate) {
+  resetDb()
+  onCawCreated({ userId: 1, action: 'CAW', originalCawId: null })
+  const row = { status: 'PENDING' }
+
+  function callerAttempt() {
+    // findMany-equivalent: read current status
+    const sawPending = row.status === 'PENDING'
+    if (!sawPending) return // guarded path: row already FAILED, nothing to do
+    if (useGuardedUpdate) {
+      // updateMany WHERE status = 'PENDING': only the first caller to
+      // reach this line actually transitions the row.
+      if (row.status !== 'PENDING') return
+      row.status = 'FAILED'
+    } else {
+      // old behavior: unconditional write, no guard against a concurrent
+      // caller having already transitioned it.
+      row.status = 'FAILED'
+    }
+    onStatusChangedCawFailed({ userId: 1, action: 'CAW', originalCawId: null })
+  }
+
+  // Simulate caller A's findMany happening, then caller B's findMany
+  // happening (both see PENDING) before either write lands.
+  callerAttempt()
+  callerAttempt()
+  return getUser(1).cawCount
+}
+
+check('9a: old unguarded pattern double-decrements under concurrent calls (regression demo, expected 0 via floor but only after already going below the correct 1-decrement result)', simulateConcurrentFailure(false), 0)
+check('9b: guarded pattern (status: PENDING on updateMany) prevents double-decrement', simulateConcurrentFailure(true), 0)
+// Note: 9a and 9b land on the same floored value (0) because safeDecrement's
+// floor masks the double-decrement when starting from cawCount=1. The real
+// regression is visible starting from cawCount=2 -- see 9c/9d.
+resetDb()
+onCawCreated({ userId: 1, action: 'CAW', originalCawId: null })
+onCawCreated({ userId: 1, action: 'CAW', originalCawId: null })
+check('9c: baseline cawCount before concurrent failure of one post', getUser(1).cawCount, 2)
+
+function simulateConcurrentFailureFromTwo(useGuardedUpdate) {
+  const row = { status: 'PENDING' }
+  // Phase 1: both concurrent callers' findMany-equivalent reads happen
+  // BEFORE either one's write lands -- this is the actual TOCTOU window.
+  const callerASawPending = row.status === 'PENDING'
+  const callerBSawPending = row.status === 'PENDING'
+
+  function writeAttempt(sawPending) {
+    if (!sawPending) return
+    if (useGuardedUpdate) {
+      // updateMany WHERE status = 'PENDING': only the first writer to
+      // reach this line actually transitions the row; the second one's
+      // updateMany affects 0 rows and it must not call onStatusChanged.
+      if (row.status !== 'PENDING') return
+      row.status = 'FAILED'
+    } else {
+      // old behavior: unconditional write, no re-check against the
+      // row's current status.
+      row.status = 'FAILED'
+    }
+    onStatusChangedCawFailed({ userId: 1, action: 'CAW', originalCawId: null })
+  }
+
+  // Phase 2: both callers now attempt their writes.
+  writeAttempt(callerASawPending)
+  writeAttempt(callerBSawPending)
+}
+simulateConcurrentFailureFromTwo(false)
+check('9d: UNGUARDED pattern double-decrements cawCount 2 -> 0 on one failed post (bug)', getUser(1).cawCount, 0)
+
+resetDb()
+onCawCreated({ userId: 1, action: 'CAW', originalCawId: null })
+onCawCreated({ userId: 1, action: 'CAW', originalCawId: null })
+simulateConcurrentFailureFromTwo(true)
+check('9e: GUARDED pattern decrements cawCount 2 -> 1 on one failed post (correct)', getUser(1).cawCount, 1)
+
+console.log(`\n${13 - failures}/13 passed`)
 process.exit(failures > 0 ? 1 : 0)

--- a/client/scripts/verify-post-failure-count-rollback.js
+++ b/client/scripts/verify-post-failure-count-rollback.js
@@ -249,14 +249,15 @@ function recomputeParentRecawCount(pendingCaw, allCaws) {
     : !isReplyRow(pendingCaw.originalCawId, pendingCaw.id)
   if (!isQuoteNotReply || !pendingCaw.originalCawId) return null
 
-  const children = allCaws.filter(c =>
+  // Count union of plain RECAWs and real quotes (non-reply CAWs), per @nyaromesama's audit
+  const countedChildren = allCaws.filter(c =>
     c.originalCawId === pendingCaw.originalCawId &&
     c.status === 'SUCCESS' &&
-    c.action === pendingCaw.action
+    (
+      c.action === 'RECAW' ||
+      (c.action === 'CAW' && !isReplyRow(pendingCaw.originalCawId, c.id))
+    )
   )
-  const countedChildren = pendingCaw.action === 'CAW'
-    ? children.filter(c => !isReplyRow(pendingCaw.originalCawId, c.id))
-    : children
   return countedChildren.length
 }
 
@@ -306,5 +307,27 @@ check(
   1
 )
 
-console.log(`\n${16 - failures}/16 passed`)
+// 13) Mixed RECAW + quote + reply under one parent -- per @nyaromesama's audit:
+//     recomputing recawCount must count the union of both plain RECAWs and
+//     real quotes, while still excluding replies. A sweep of either category
+//     must not clobber the sibling category's count contribution.
+replyRows = []
+addReply(800, 903) // caw 903 is a reply to parent 800
+const allCawsMixedUnion = [
+  { id: 901, action: 'RECAW', originalCawId: 800, status: 'SUCCESS' }, // plain recaw
+  { id: 902, action: 'CAW', originalCawId: 800, status: 'SUCCESS' },   // real quote
+  { id: 903, action: 'CAW', originalCawId: 800, status: 'SUCCESS' },   // reply (must be excluded)
+]
+check(
+  '13a: stale-pending RECAW sweep counts union (1 RECAW + 1 quote = 2, excludes reply)',
+  recomputeParentRecawCount({ id: 901, action: 'RECAW', originalCawId: 800 }, allCawsMixedUnion),
+  2
+)
+check(
+  '13b: stale-pending quote sweep counts union (1 RECAW + 1 quote = 2, excludes reply)',
+  recomputeParentRecawCount({ id: 902, action: 'CAW', originalCawId: 800 }, allCawsMixedUnion),
+  2
+)
+
+console.log(`\n${18 - failures}/18 passed`)
 process.exit(failures > 0 ? 1 : 0)

--- a/client/src/api/routes/actions.ts
+++ b/client/src/api/routes/actions.ts
@@ -1108,6 +1108,21 @@ router.post('/', async (req, res) => {
             })
           } catch (err) {
             console.error('Failed to optimistically increment counts via CountManager:', err)
+            // Don't leave this row silently PENDING with a count that never
+            // landed -- there's no field marking whether the optimistic
+            // increment above succeeded, so a later PENDING->SUCCESS
+            // transition (actionHandlers.ts) has no way to tell it needs to
+            // recompute rather than trust the count is already there.
+            // Falling back to FAILED here routes this caw through the
+            // existing FAILED->SUCCESS recovery path instead (which already
+            // recomputes parent.recawCount from a live COUNT(*) when the
+            // chain later confirms it), rather than inventing a second
+            // recovery mechanism for this one failure mode.
+            try {
+              await prisma.caw.update({ where: { id: caw.id }, data: { status: 'FAILED' } })
+            } catch (statusErr) {
+              console.error(`Failed to mark caw ${caw.id} FAILED after count increment failure:`, statusErr)
+            }
           }
         }
 
@@ -2317,6 +2332,15 @@ router.post('/batch', async (req, res) => {
               })
             } catch (err) {
               console.warn(`[Actions/batch] onCawCreated failed for ${d.senderId}:${d.cawonce}:`, (err as any)?.message)
+              // Same fallback as the single-action path (actions.ts, single
+              // submit handler): route this caw through the existing
+              // FAILED->SUCCESS recovery instead of leaving it PENDING with
+              // no record that its optimistic increment never landed.
+              try {
+                await tx.caw.update({ where: { id: caw.id }, data: { status: 'FAILED' } })
+              } catch (statusErr) {
+                console.error(`[Actions/batch] Failed to mark caw ${caw.id} FAILED after count increment failure:`, statusErr)
+              }
             }
           }
 

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -550,10 +550,15 @@ export async function handleRecawAction(
       await countManager.onStatusChanged(tx, 'caw', recawCaw.id, existingRecaw!.status, 'SUCCESS', {
         userId, action: isQuoteRecaw ? 'CAW' : 'RECAW', originalCawId,
       })
-      if (existingRecaw!.status === 'FAILED' && !isQuoteRecaw && originalCawId) {
+      // Restore parent recawCount on FAILED->SUCCESS. Quotes need this
+      // exactly as much as plain RECAWs -- CountManager.onCawCreated bumps
+      // recawCount for both (see above), so excluding quotes here left them
+      // permanently under-counted whenever they'd passed through a FAILED
+      // state (e.g. DataCleaner's stale-pending sweep).
+      if (existingRecaw!.status === 'FAILED' && originalCawId) {
         try {
           const actualRecawCount = await tx.caw.count({
-            where: { originalCawId, action: 'RECAW', status: 'SUCCESS' },
+            where: { originalCawId, action: isQuoteRecaw ? 'CAW' : 'RECAW', status: 'SUCCESS' },
           })
           await tx.caw.update({
             where: { id: originalCawId },

--- a/client/src/services/DataCleaner/index.ts
+++ b/client/src/services/DataCleaner/index.ts
@@ -491,14 +491,45 @@ async function cleanupPendingCaws() {
               originalCawId: null,
             })
 
-            // If this was a recaw, decrement the parent's recawCount
-            if (pendingCaw.action === 'RECAW' && pendingCaw.originalCawId) {
+            // If this was a recaw or quote, decrement the parent's recawCount.
+            // CountManager.onCawCreated bumps recawCount for both RECAW and
+            // quote (CAW with originalCawId) -- the recompute here needs to
+            // match, or quotes swept by this stale-pending path never get
+            // their recawCount contribution restored on later confirm.
+            //
+            // action === 'CAW' && originalCawId is ambiguous between quote
+            // and reply -- actionHandlers.ts's upsert sets originalCawId
+            // unconditionally for both. A Reply row (cawId=parent,
+            // replyCawId=this row) is what actually distinguishes a reply;
+            // check that before treating a CAW row as a quote.
+            let isQuoteNotReply = pendingCaw.action === 'RECAW'
+            if (pendingCaw.action === 'CAW' && pendingCaw.originalCawId) {
+              const ownReplyRow = await prisma.reply.findFirst({
+                where: { cawId: pendingCaw.originalCawId, replyCawId: pendingCaw.id },
+                select: { id: true },
+              })
+              isQuoteNotReply = !ownReplyRow
+            }
+            if (isQuoteNotReply && pendingCaw.originalCawId) {
               try {
+                // When recomputing a quote parent's count, exclude any of
+                // its CAW-type children that are actually replies (same
+                // Reply-table distinction as above) so a reply never gets
+                // counted into recawCount alongside real quotes.
+                const replySiblingIds = pendingCaw.action === 'CAW'
+                  ? (await prisma.reply.findMany({
+                      where: { cawId: pendingCaw.originalCawId },
+                      select: { replyCawId: true },
+                    })).map(r => r.replyCawId)
+                  : []
                 const actualRecawCount = await prisma.caw.count({
                   where: {
                     originalCawId: pendingCaw.originalCawId,
-                    action: 'RECAW',
-                    status: 'SUCCESS'
+                    action: pendingCaw.action === 'RECAW' ? 'RECAW' : 'CAW',
+                    status: 'SUCCESS',
+                    ...(pendingCaw.action === 'CAW'
+                      ? { id: { notIn: replySiblingIds.length > 0 ? replySiblingIds : [-1] } }
+                      : {}),
                   }
                 })
                 await prisma.caw.update({
@@ -601,11 +632,35 @@ async function cleanupFailedTxQueue() {
             }
           })
 
-          // Decrement recawCount on parent if this was a pending recaw
-          if (pendingCaw && pendingCaw.action === 'RECAW' && pendingCaw.originalCawId) {
+          // Decrement recawCount on parent if this was a pending recaw or
+          // quote -- see the matching comment on the single-action path
+          // above for why quotes need the same treatment, and why the
+          // Reply-table check is required to tell a quote from a reply.
+          let isQuoteNotReplyBatch = pendingCaw ? pendingCaw.action === 'RECAW' : false
+          if (pendingCaw && pendingCaw.action === 'CAW' && pendingCaw.originalCawId) {
+            const ownReplyRow = await prisma.reply.findFirst({
+              where: { cawId: pendingCaw.originalCawId, replyCawId: pendingCaw.id },
+              select: { id: true },
+            })
+            isQuoteNotReplyBatch = !ownReplyRow
+          }
+          if (pendingCaw && isQuoteNotReplyBatch && pendingCaw.originalCawId) {
             try {
+              const replySiblingIdsBatch = pendingCaw.action === 'CAW'
+                ? (await prisma.reply.findMany({
+                    where: { cawId: pendingCaw.originalCawId },
+                    select: { replyCawId: true },
+                  })).map(r => r.replyCawId)
+                : []
               const actualRecawCount = await prisma.caw.count({
-                where: { originalCawId: pendingCaw.originalCawId, action: 'RECAW', status: 'SUCCESS' }
+                where: {
+                  originalCawId: pendingCaw.originalCawId,
+                  action: pendingCaw.action === 'RECAW' ? 'RECAW' : 'CAW',
+                  status: 'SUCCESS',
+                  ...(pendingCaw.action === 'CAW'
+                    ? { id: { notIn: replySiblingIdsBatch.length > 0 ? replySiblingIdsBatch : [-1] } }
+                    : {}),
+                }
               })
               await prisma.caw.update({
                 where: { id: pendingCaw.originalCawId },

--- a/client/src/services/DataCleaner/index.ts
+++ b/client/src/services/DataCleaner/index.ts
@@ -512,25 +512,29 @@ async function cleanupPendingCaws() {
             }
             if (isQuoteNotReply && pendingCaw.originalCawId) {
               try {
-                // When recomputing a quote parent's count, exclude any of
-                // its CAW-type children that are actually replies (same
-                // Reply-table distinction as above) so a reply never gets
-                // counted into recawCount alongside real quotes.
-                const replySiblingIds = pendingCaw.action === 'CAW'
-                  ? (await prisma.reply.findMany({
-                      where: { cawId: pendingCaw.originalCawId },
-                      select: { replyCawId: true },
-                    })).map(r => r.replyCawId)
-                  : []
+                // Recompute parent recawCount over the union of both plain RECAWs
+                // and quotes (non-reply CAWs), per @nyaromesama's audit. onCawCreated
+                // bumps recawCount for both, so recomputing only one category would
+                // clobber the sibling category on mixed parents.
+                const replySiblingIds = (await prisma.reply.findMany({
+                  where: { cawId: pendingCaw.originalCawId },
+                  select: { replyCawId: true },
+                })).map(r => r.replyCawId)
+
                 const actualRecawCount = await prisma.caw.count({
                   where: {
                     originalCawId: pendingCaw.originalCawId,
-                    action: pendingCaw.action === 'RECAW' ? 'RECAW' : 'CAW',
                     status: 'SUCCESS',
-                    ...(pendingCaw.action === 'CAW'
-                      ? { id: { notIn: replySiblingIds.length > 0 ? replySiblingIds : [-1] } }
-                      : {}),
-                  }
+                    OR: [
+                      { action: 'RECAW' },
+                      {
+                        action: 'CAW',
+                        ...(replySiblingIds.length > 0
+                          ? { id: { notIn: replySiblingIds } }
+                          : {}),
+                      },
+                    ],
+                  },
                 })
                 await prisma.caw.update({
                   where: { id: pendingCaw.originalCawId },

--- a/client/src/services/DataCleaner/index.ts
+++ b/client/src/services/DataCleaner/index.ts
@@ -477,6 +477,20 @@ async function cleanupPendingCaws() {
               data: { status: 'FAILED' }
             })
 
+            // Roll back the optimistic user.cawCount/recawCount bump from
+            // creation -- same PENDING->FAILED rollback path
+            // txQueueFailure.ts uses for CAW/RECAW, and the same gap PR
+            // #58 closed for like/follow (DataCleaner's 30-minute-timeout
+            // path predates CountManager and was never migrated onto it).
+            // This only touches the sender's own cawCount/recawCount; the
+            // parent's recawCount recalculation below is pre-existing and
+            // left as-is.
+            await countManager.onStatusChanged(prisma, 'caw', pendingCaw.id, 'PENDING', 'FAILED', {
+              userId: pendingCaw.userId,
+              action: pendingCaw.action,
+              originalCawId: null,
+            })
+
             // If this was a recaw, decrement the parent's recawCount
             if (pendingCaw.action === 'RECAW' && pendingCaw.originalCawId) {
               try {

--- a/client/src/utils/txQueueFailure.ts
+++ b/client/src/utils/txQueueFailure.ts
@@ -101,22 +101,47 @@ async function cleanupOptimisticRows(
     // CAW (0) / RECAW (3): mark the Caw row as FAILED so the feed shows it
     // with a failure indicator rather than lingering as "pending forever".
     if ((actionType === 0 || actionType === 3) && cawonce != null) {
-      // Fetch the pending rows before updateMany so we have userId/action/
-      // originalCawId for CountManager.onStatusChanged below -- updateMany
-      // itself doesn't return the affected rows. Companion to PR #58 (which
-      // fixed this same rollback omission for like/follow): CAW/RECAW never
-      // called onStatusChanged on failure at all, so the optimistic
-      // user.cawCount/recawCount bump from creation was never undone,
-      // leaving a permanent drift on every failed post.
-      const pendingCaws = await prisma.caw.findMany({
-        where: { userId: senderId, cawonce, status: 'PENDING' },
-        select: { id: true, userId: true, action: true, originalCawId: true },
+      // Fetch-then-update was previously two separate queries (a findMany
+      // followed by a single bulk updateMany), leaving a TOCTOU window: two
+      // concurrent calls to markTxQueueFailed for the same senderId/cawonce
+      // could both read the same PENDING rows before either write landed,
+      // then each call onStatusChanged for the same row -- double-
+      // decrementing user.cawCount/recawCount. The transaction below reads
+      // the candidate rows, then claims each one individually with a
+      // status: 'PENDING' guarded updateMany and keeps only the rows where
+      // that update actually affected one row. Exactly one concurrent
+      // caller can ever win that per-row guard, so pendingCaws ends up
+      // holding only rows this call transitioned -- the onStatusChanged
+      // loop below fires at most once per row across concurrent callers.
+      const pendingCaws = await prisma.$transaction(async (tx) => {
+        const rows = await tx.caw.findMany({
+          where: { userId: senderId, cawonce, status: 'PENDING' },
+          select: { id: true, userId: true, action: true, originalCawId: true },
+        })
+        if (rows.length === 0) return rows
+
+        // Claim each row individually via a status-guarded updateMany and
+        // check its affected count. This is deliberately NOT a single bulk
+        // updateMany re-filtered by matching `reason` afterward -- two
+        // concurrent callers racing the same PENDING row often share the
+        // same reason text (they're usually reacting to the same
+        // underlying on-chain revert), so a reason-based re-filter can't
+        // tell which caller actually won the write and would let both
+        // callers' onStatusChanged fire for the same row. Per-row count
+        // === 1 is the only signal that can't be spoofed by matching text:
+        // exactly one concurrent updateMany can ever flip a given row out
+        // of 'PENDING'.
+        const claimed: typeof rows = []
+        for (const r of rows) {
+          const result = await tx.caw.updateMany({
+            where: { id: r.id, status: 'PENDING' },
+            data: { status: 'FAILED', reason: reason.slice(0, 200) }
+          })
+          if (result.count === 1) claimed.push(r)
+        }
+        return claimed
       })
 
-      await prisma.caw.updateMany({
-        where: { userId: senderId, cawonce, status: 'PENDING' },
-        data: { status: 'FAILED', reason: reason.slice(0, 200) }
-      })
       // If this Caw originated from a ScheduledCaw, the scheduled record is
       // currently sitting at status='published' (the processor flips it the
       // moment it queues the tx, before broadcast). Demote it to 'failed' so

--- a/client/src/utils/txQueueFailure.ts
+++ b/client/src/utils/txQueueFailure.ts
@@ -101,6 +101,18 @@ async function cleanupOptimisticRows(
     // CAW (0) / RECAW (3): mark the Caw row as FAILED so the feed shows it
     // with a failure indicator rather than lingering as "pending forever".
     if ((actionType === 0 || actionType === 3) && cawonce != null) {
+      // Fetch the pending rows before updateMany so we have userId/action/
+      // originalCawId for CountManager.onStatusChanged below -- updateMany
+      // itself doesn't return the affected rows. Companion to PR #58 (which
+      // fixed this same rollback omission for like/follow): CAW/RECAW never
+      // called onStatusChanged on failure at all, so the optimistic
+      // user.cawCount/recawCount bump from creation was never undone,
+      // leaving a permanent drift on every failed post.
+      const pendingCaws = await prisma.caw.findMany({
+        where: { userId: senderId, cawonce, status: 'PENDING' },
+        select: { id: true, userId: true, action: true, originalCawId: true },
+      })
+
       await prisma.caw.updateMany({
         where: { userId: senderId, cawonce, status: 'PENDING' },
         data: { status: 'FAILED', reason: reason.slice(0, 200) }
@@ -113,6 +125,28 @@ async function cleanupOptimisticRows(
         where: { userId: senderId, cawonce, status: 'published' },
         data: { status: 'failed' },
       })
+
+      for (const pendingCaw of pendingCaws) {
+        // Caw.originalCawId is set for BOTH quotes and replies (see
+        // actionHandlers.ts's upsert) -- CountManager's rollback only
+        // wants it for quotes, where it also decrements the parent's
+        // recawCount. A reply's parent gets commentCount bumped instead
+        // (via Reply, not Caw.recawCount), so passing originalCawId
+        // through unconditionally here would incorrectly decrement a
+        // reply's parent's recawCount on failure. Check for a Reply row
+        // pointing at this caw, same distinction actionHandlers.ts's
+        // isReplyNotQuote already makes at creation time.
+        const replyRecord = pendingCaw.originalCawId != null
+          ? await prisma.reply.findFirst({ where: { replyCawId: pendingCaw.id }, select: { id: true } })
+          : null
+        const isReply = replyRecord != null
+
+        await countManager.onStatusChanged(prisma, 'caw', pendingCaw.id, 'PENDING', 'FAILED', {
+          userId: pendingCaw.userId,
+          action: pendingCaw.action,
+          originalCawId: isReply ? null : pendingCaw.originalCawId,
+        })
+      }
     }
 
     // FOLLOW (4) failed: mark the pending Follow row as FAILED so the UI


### PR DESCRIPTION
> **Status after the second review round:** the "Investigated but not changed" and "Verification" sections below describe earlier versions of this change. `isReply` is not dead code (the submit paths pass it, see "Update 2"), and the simulated script `verify-post-failure-count-rollback.js` was replaced by `tests/services/CountManager/postFailureCounts.test.ts`, which runs the real code.

## Summary
Direct companion to PR #58, which fixed the same rollback omission for like/follow. This PR addresses the corresponding gap for CAW and RECAW.

`txQueueFailure.ts` marks a failed CAW/RECAW's `Caw` row as `FAILED` but never called `countManager.onStatusChanged` the way it already does for follow and like, so the optimistic `user.cawCount`/`recawCount` bump from creation (`CountManager.onCawCreated`) was never undone on failure. `DataCleaner`'s 30-minute stale-pending sweep had the same gap for the sender's own `cawCount`/`recawCount`, though it already had separate logic recalculating the parent's `recawCount` for RECAW via a raw `COUNT(*)`.

## Investigated but not changed: a third claimed issue
An earlier draft claimed `CountManager.onStatusChanged`'s `case 'caw'` needed an `isReply` check, since `onCawCreated` skips the `user.cawCount` bump for replies. Investigation found the premise did not hold: grepped the whole codebase for `isReply: true` and found zero call sites — no caller ever actually sets it, so replies currently DO bump `user.cawCount` on creation, same as top-level posts and quotes (`GET /api/users` compensates for this by subtracting a dynamically-computed `replyCount` from `cawCount` in its response). Given that, `onStatusChanged` decrementing `cawCount` unconditionally on failure already mirrors the real creation-time behavior; adding an `isReply` check there would have introduced a NEW create/rollback asymmetry rather than fixed one. Not changed; noting `isReply`'s actual dead-code status here for whoever next touches this area.

## Found and fixed while implementing
`Caw.originalCawId` is set in the DB for both quotes and replies alike (`actionHandlers.ts`'s upsert always writes `parentCawId` there) but only quotes should decrement the parent's `recawCount` on rollback — a reply's parent gets `commentCount` bumped instead, not `recawCount`. Passing `originalCawId` through to `onStatusChanged` unconditionally would have decremented a reply's parent's `recawCount` incorrectly on failure. Both call sites now check for a `Reply` row pointing at the caw (same distinction `actionHandlers.ts` already makes at creation time via `isReplyNotQuote`) and pass `originalCawId: null` for replies.

## Evidence
Verified in V2's own database and logs before implementing, not just inferred from V1: zero `FAILED` `Caw` rows and zero `DataCleaner` stale-purge log lines found so far, so this gap has not yet visibly drifted any V2 counts — consistent with V2's shorter uptime, not evidence the gap is harmless. The underlying code path (`txQueueFailure` CAW/RECAW handling, `DataCleaner`'s 30-min sweep) is unchanged from V1, where 335 `FAILED` post records have accumulated (`CAW` 201 / `RECAW` 134). Note this bug's measurable impact is bounded to those 335 rows -- checking a few high-activity accounts directly, most of their cawCount-vs-actual-post gap comes from replies being counted toward `cawCount` at creation time (a separate, pre-existing behavior, already compensated for in `GET /api/users`), not from this rollback gap.

## Not addressed in this PR (pre-existing gaps, not introduced here)
- `DataCleaner`'s 30-min sweep has no parent-`recawCount` rollback for quotes at all (only RECAW gets the existing raw-recalculation path) — a quote left `FAILED` by the timeout sweep leaves its parent's `recawCount` permanently inflated by one. Scoped out to keep this PR to the user-count rollback it was written for.
- `txQueueFailure.ts`'s CAW/RECAW failure path has no equivalent of `DataCleaner`'s Reply-row cleanup — a `Reply` row can be left pointing at a caw that ends up `FAILED`. Also scoped out.

## Verification
`scripts/verify-post-failure-count-rollback.js` (13 cases): top-level CAW create/rollback, quote create/rollback (with parent recawCount), reply create/rollback (cawCount only, matching the audited actual creation behavior), RECAW create/rollback, the `safeDecrement` floor preventing underflow on a double-fire, rollback independence between users, the two cases confirming a reply's raw DB `originalCawId` resolves to `null` before reaching `onStatusChanged` while a quote's passes through unchanged, and five follow-up cases (9a-9e) added after a review comment flagged a TOCTOU risk in the CAW/RECAW cleanup: two concurrent calls racing the same PENDING row could both read it before either write landed and each fire `onStatusChanged`, double-decrementing `cawCount`. These cases simulate two concurrent callers racing one row starting from `cawCount=2`, confirming the unguarded pattern double-decrements (2 -> 0) and the per-row `status: 'PENDING'` guarded update does not (2 -> 1).

## Update 2 (second round of review feedback)

Review found two blocking problems. `FAILED -> SUCCESS` was a no-op for the user counters, so a caw that a sweep or `markTxQueueFailed` had rolled back and that later landed on chain stayed rolled back for good. And DataCleaner claimed a stale caw with an update by id and rolled back unconditionally, so it could roll back a row that `markTxQueueFailed` had already failed and rolled back. The discussion is in the comment thread.

Current behaviour:

- `CountManager`: `FAILED -> SUCCESS` for a caw re-applies the user counter that `PENDING -> FAILED` took off (the exact inverse, keyed on the row's own action, so a quote stored as `RECAW` + text lands on `recawCount`). A reply never bumped `user.cawCount`, so it is skipped both ways.
- `cleanupPendingCaws` and `cleanupFailedTxQueue` claim the row with `updateMany` and `status: 'PENDING'` and roll back only when exactly one row moved.
- One `recomputeParentRecawCount` (RECAWs and quotes, replies excluded through their Reply rows) is used by both DataCleaner sweeps and both handlers. Before, two of four copies counted one category only, and `handleCawAction` did not restore a rolled-back quote's parent.
- `isReply` is passed by both submit paths in `actions.ts` (the earlier statement that no caller passes it was wrong: the callers use the shorthand `isReply,`), so a reply from those paths never bumps `user.cawCount`, and the rollback and the restore skip replies. `ScheduledPostProcessor` does not pass it, so a scheduled reply still bumps at creation and keeps that +1 if it fails. That is left for the follow-up after #116.
- The comments that said DataCleaner does not roll back user counts are rewritten.

Verification: the new `tests/services/CountManager/postFailureCounts.test.ts` runs the real code against a disposable database, 12 passing. With the source changes stashed, 11 of the 12 fail. It reproduces the double rollback deterministically with a row lock. `tsc --noEmit` reports no errors from the changed files.

Limit: a row that went FAILED before this change (counters never rolled back) and confirms afterwards adds +1 to the user counter.

Not verified for this version: the HTTP routes, a live node, `ScheduledPostProcessor`, and `handleCawAction`'s wiring.

zinsanjp