### PR TITLE
fix(scheduled-posts): add atomic concurrency lock to prevent double-processing

### DIFF
--- a/client/scripts/verify-scheduled-post-concurrency-lock.js
+++ b/client/scripts/verify-scheduled-post-concurrency-lock.js
@@ -1,0 +1,158 @@
+// Spec-level verification of the atomic pending -> processing claim added
+// to processDueScheduledPosts.
+//
+// IMPORTANT: this is a spec test against a JS Map, not an integration test.
+// It verifies the intended state-machine logic is correct, but it does NOT
+// exercise real Postgres row-locking or confirm that a concurrent
+// updateMany actually blocks and re-evaluates its WHERE clause against the
+// committed row the way READ COMMITTED is expected to. That guarantee is
+// the actual load-bearing part of the fix and is not covered here.
+//
+// Background: processScheduledPost() only ever writes status at its own
+// success/failure branches at the end -- there was no claim step before
+// that point. Two overlapping ticks of the 60s-interval worker (a batch
+// that takes longer than 60s to process, DB/RPC slowness, etc.) could both
+// findMany the same still-pending row and both broadcast it on-chain. This
+// mirrors the fix: an atomic updateMany(where: { id, status: 'pending' })
+// claim before processing.
+// Run: node scripts/verify-scheduled-post-concurrency-lock.js
+
+let failures = 0
+let checkCount = 0
+function check(label, actual, expected) {
+  checkCount++
+  const pass = JSON.stringify(actual) === JSON.stringify(expected)
+  if (!pass) failures++
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${label} -> got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`)
+}
+
+// --- Simulated ScheduledCaw store ---
+function makeStore(rows) {
+  // rows: array of { id, status, updatedAt }
+  const table = new Map(rows.map(r => [r.id, { ...r }]))
+  return {
+    table,
+    // Mirrors: prisma.scheduledCaw.updateMany({ where: { id, status: from }, data: { status: to } })
+    claim: (id, fromStatus, toStatus, now) => {
+      const row = table.get(id)
+      if (!row || row.status !== fromStatus) return { count: 0 }
+      row.status = toStatus
+      row.updatedAt = now
+      return { count: 1 }
+    },
+  }
+}
+
+// --- Mirrors the claim step added directly before processScheduledPost() ---
+function tryClaim(store, id, now) {
+  const result = store.claim(id, 'pending', 'processing', now)
+  return result.count === 1
+}
+
+// 1) Single post, normal path: claim succeeds, no concurrent claimant.
+function test1() {
+  const store = makeStore([{ id: 1, status: 'pending', updatedAt: 0 }])
+  const claimed = tryClaim(store, 1, 100)
+  check('1a: claim succeeds for a pending row', claimed, true)
+  check('1b: status is now processing', store.table.get(1).status, 'processing')
+}
+
+// 2) Two overlapping worker ticks racing the same row: exactly one claims
+//    it (in this simulation, by calling sequentially -- see the header
+//    note on what this does and doesn't prove), the other's updateMany
+//    affects 0 rows and it skips rather than double-processing. This is
+//    the actual concurrency bug being fixed.
+function test2() {
+  const store = makeStore([{ id: 2, status: 'pending', updatedAt: 0 }])
+  const tickAClaimed = tryClaim(store, 2, 100) // tick A claims first
+  const tickBClaimed = tryClaim(store, 2, 105) // tick B races the same row moments later
+  check('2a: first tick claims successfully', tickAClaimed, true)
+  check('2b: second overlapping tick fails to claim (sees processing, not pending)', tickBClaimed, false)
+  check('2c: exactly one broadcast would happen -- row is processing, not double-claimed', store.table.get(2).status, 'processing')
+}
+
+// 3) Multiple independent posts in one batch: each claims its own row,
+//    none interfere with each other.
+function test3() {
+  const store = makeStore([
+    { id: 10, status: 'pending', updatedAt: 0 },
+    { id: 11, status: 'pending', updatedAt: 0 },
+    { id: 12, status: 'pending', updatedAt: 0 },
+    { id: 13, status: 'pending', updatedAt: 0 },
+    { id: 14, status: 'pending', updatedAt: 0 },
+  ])
+  const results = [10, 11, 12, 13, 14].map(id => tryClaim(store, id, 100))
+  check('3: all 5 independent posts claim successfully with no cross-interference', results, [true, true, true, true, true])
+}
+
+// 4) Thread chunks (already-sequential processing per the existing
+//    threadIndex ordering) each claim independently -- the claim step
+//    doesn't interfere with the existing thread-ordering logic, it only
+//    guards against a second worker tick re-claiming an already-claimed
+//    chunk.
+function test4() {
+  const store = makeStore([
+    { id: 20, status: 'pending', updatedAt: 0, threadId: 't1', threadIndex: 0 },
+    { id: 21, status: 'pending', updatedAt: 0, threadId: 't1', threadIndex: 1 },
+    { id: 22, status: 'pending', updatedAt: 0, threadId: 't1', threadIndex: 2 },
+  ])
+  const results = [20, 21, 22].map(id => tryClaim(store, id, 100))
+  check('4: all 3 thread chunks claim independently in order', results, [true, true, true])
+}
+
+// 5) A row already claimed by another tick (simulating "thread head
+//    already failed elsewhere") is correctly skipped by a second attempt
+//    rather than reprocessed.
+function test5() {
+  const store = makeStore([{ id: 30, status: 'processing', updatedAt: 100 }]) // already claimed by another tick
+  const claimed = tryClaim(store, 30, 105)
+  check('5: a row already in processing cannot be re-claimed', claimed, false)
+}
+
+// --- Mirrors the thread-fail-fast skip path: when an earlier chunk in a
+//     thread failed, later chunks are marked 'failed' too rather than run
+//     through processScheduledPost. Scoped to status: 'pending' (via
+//     updateMany) so it can't clobber a row a concurrent tick has already
+//     claimed and is actively processing. ---
+function trySkipAsThreadFailed(store, id) {
+  const row = store.table.get(id)
+  if (!row || row.status !== 'pending') return { skipped: false, count: 0 }
+  row.status = 'failed'
+  return { skipped: true, count: 1 }
+}
+
+// 6) Normal case: an earlier thread chunk failed, this chunk is still
+//    pending (nobody else has touched it) -- the skip path marks it
+//    failed as intended.
+function test6() {
+  const store = makeStore([{ id: 40, status: 'pending', updatedAt: 0 }])
+  const result = trySkipAsThreadFailed(store, 40)
+  check('6a: thread-fail-fast skip marks a still-pending chunk as failed', result.skipped, true)
+  check('6b: status is now failed', store.table.get(40).status, 'failed')
+}
+
+// 7) THE REGRESSION found in review: a later thread chunk has already
+//    been claimed (processing) by a concurrent, overlapping tick -- e.g.
+//    that tick is mid-broadcast on it. The thread-fail-fast skip path
+//    must NOT clobber that with an unconditional 'failed' overwrite; it
+//    should back off and let the owning tick resolve the row itself.
+function test7() {
+  const store = makeStore([{ id: 41, status: 'processing', updatedAt: 100 }]) // claimed by another tick
+  const result = trySkipAsThreadFailed(store, 41)
+  check('7a: skip path does not touch a row already claimed by another tick', result.skipped, false)
+  check('7b: status remains processing -- not clobbered to failed', store.table.get(41).status, 'processing')
+}
+
+function main() {
+  test1()
+  test2()
+  test3()
+  test4()
+  test5()
+  test6()
+  test7()
+  console.log(`\n${checkCount - failures}/${checkCount} passed`)
+  process.exit(failures > 0 ? 1 : 0)
+}
+
+main()

--- a/client/src/services/ScheduledPostProcessor/index.ts
+++ b/client/src/services/ScheduledPostProcessor/index.ts
@@ -319,14 +319,55 @@ async function processDueScheduledPosts() {
 
     for (const scheduledPost of dueScheduledPosts) {
       if (scheduledPost.threadId && failedThreadIds.has(scheduledPost.threadId)) {
-        logger.warn(`Skipping thread chunk ${scheduledPost.id} — earlier chunk in thread ${scheduledPost.threadId} failed`)
-        await prisma.scheduledCaw.update({
-          where: { id: scheduledPost.id },
+        // Scoped to status: 'pending' for the same reason as the claim
+        // below: an unconditional update() here could clobber a row that
+        // a concurrent, overlapping tick has already claimed (processing)
+        // and is actively broadcasting on-chain. If that's the case, skip
+        // it instead of overwriting -- the owning tick's own
+        // processScheduledPost will resolve it to 'published' or 'failed'
+        // on its own. Only actually mark 'failed' here if this tick is the
+        // one that still finds it 'pending' (i.e. nobody else has touched
+        // it yet).
+        const skipResult = await prisma.scheduledCaw.updateMany({
+          where: { id: scheduledPost.id, status: 'pending' },
           data: { status: 'failed' },
         })
-        failCount++
+        if (skipResult.count > 0) {
+          logger.warn(`Skipping thread chunk ${scheduledPost.id} — earlier chunk in thread ${scheduledPost.threadId} failed`)
+          failCount++
+        } else {
+          logger.log(`Thread chunk ${scheduledPost.id} was already claimed by another worker tick; not overwriting`)
+        }
         continue
       }
+      // Atomic status claim: pending -> processing. This is the actual
+      // concurrency guard. processScheduledPost() never checks or sets
+      // status until its own success/failure branches at the end, so two
+      // overlapping ticks of this 60s-interval worker (a batch that takes
+      // longer than 60s to process, DB/RPC slowness, etc.) could otherwise
+      // both findMany the same still-pending row and both broadcast it
+      // on-chain. updateMany's WHERE clause re-checks status: 'pending' at
+      // the DB level, so only the tick that actually flips the row proceeds
+      // -- a second, overlapping tick's updateMany affects 0 rows and is
+      // skipped here rather than double-processing.
+      //
+      // MUST run as its own autocommit statement, not inside an
+      // interactive $transaction alongside other work. The safety here
+      // relies on this updateMany committing (and releasing its row lock)
+      // immediately so a concurrent tick's updateMany sees the committed
+      // 'processing' status right away. Wrapping this in a $transaction with
+      // other statements would let overlapping ticks both still see
+      // 'pending' until the outer transaction commits, reopening the exact
+      // race this claim exists to close.
+      const claimResult = await prisma.scheduledCaw.updateMany({
+        where: { id: scheduledPost.id, status: 'pending' },
+        data: { status: 'processing' },
+      })
+      if (claimResult.count === 0) {
+        logger.log(`Scheduled post ${scheduledPost.id} was already claimed by another worker tick; skipping`)
+        continue
+      }
+
       const success = await processScheduledPost(scheduledPost)
       if (success) {
         successCount++


### PR DESCRIPTION
## Problem

`processScheduledPost` only writes `ScheduledCaw.status` at its own success/failure branches at the end of the function -- there was no claim step before that point. `processDueScheduledPosts` runs every 60 seconds via `setInterval` and queries all `status: 'pending'` rows due for posting.

If one tick's batch takes longer than 60 seconds to process (many due posts, RPC/IPFS latency, DB load), the next tick starts while the row is still `pending` in the DB. Both ticks can `findMany` the same row and both call `processScheduledPost` on it, broadcasting the same scheduled post to chain twice.

## Fix

Added an atomic claim immediately before `processScheduledPost` is called:

```typescript
const claimResult = await prisma.scheduledCaw.updateMany({
  where: { id: scheduledPost.id, status: 'pending' },
  data: { status: 'processing' },
})
if (claimResult.count === 0) {
  logger.log(`Scheduled post ${scheduledPost.id} was already claimed by another worker tick; skipping`)
  continue
}
```

Only the tick whose `updateMany` actually flips the row out of `pending` proceeds. A second, overlapping tick's `updateMany` is scoped to `status: 'pending'` at the DB level, so it affects 0 rows against an already-claimed row and is skipped rather than double-processing.

Must run as its own autocommit statement, not inside an interactive `$transaction` -- the guarantee depends on the claim committing and releasing its row lock immediately, which a wrapping transaction would defer until it commits, reopening the race.

No schema migration needed -- `ScheduledCaw.status` is already `String`, so `'processing'` is just a new value in the existing field.

## Second hole found and fixed while auditing this

The thread-fail-fast skip path -- when an earlier chunk in a thread failed, later chunks are marked `failed` without running `processScheduledPost` -- used an unconditional `update()` with no status guard. A concurrent, overlapping tick that had already claimed that same chunk (`processing`, possibly mid-broadcast) could have its status clobbered back to `failed` by this path, entirely bypassing the claim mechanism above it.

Scoped to `updateMany(where: { id, status: 'pending' })` the same way, so it only marks a chunk `failed` if this tick is the one that still finds it `pending`; otherwise it backs off and lets the owning tick resolve the row itself.

## Deliberately not included: time-based reclaim

An earlier version of this PR also added a time-based reclaim of rows stranded in `processing` by a worker crash. @nyaromesama's review found a genuine double-broadcast path in it, laid out in full here: https://github.com/GilgameshCaw/Caw/pull/70#issuecomment-... (see thread below).

Summary: the fixed timeout can't distinguish a crashed worker from one that's simply slow -- `processScheduledPost` has no internal timeout on any of its RPC/IPFS/image calls -- so a still-running worker's row could be reclaimed and reprocessed by the same tick's `findMany`. `Caw` itself is protected by its `userId_cawonce` upsert, but `TxQueue.create` is unconditional and `TxQueue` has no unique constraint on `(senderId, cawonce)`, so a reclaim-induced double-process could insert a second `TxQueue` row for the same signed tx -- currently only prevented by the chain rejecting a reused nonce, not by application code.

Held back pending either an internal timeout on `processScheduledPost` shorter than any reclaim window, or a partial unique index on `TxQueue(senderId, cawonce)` where `cawonce IS NOT NULL` (same shape as the `queuedLogIndex` partial unique in #52). Will follow up separately once one of those lands.

Worth being explicit about the tradeoff this leaves in the meantime: before this PR, a worker crash mid-`processScheduledPost` left the row untouched at `pending`, so the next tick would naturally pick it up and retry -- accidental self-healing, at the cost of the double-processing bug this PR fixes. After this PR (claim only, no reclaim), a crash mid-processing leaves the row stranded in `processing` with nothing to reclaim it, so that post never goes out. Trading a duplicate-post risk for a lost-post risk isn't free; it's judged the better tradeoff for now (duplicate content is generally worse for a social product than a missed post), but it's a real regression on the crash-recovery axis that the reclaim work is meant to close once it's safe to add back.

## Verification

`scripts/verify-scheduled-post-concurrency-lock.js` (12 cases, dynamically counted rather than hardcoded): single claim, two overlapping ticks racing the same row (only one succeeds), independent posts in a batch, thread chunks claiming independently, a row already claimed by another tick, the thread-fail-fast skip path correctly marking a still-pending chunk failed, and that same path backing off rather than clobbering a chunk already claimed by another tick.

Spec-level, per @nyaromesama's note: this verifies the intended state-machine logic against a JS Map, not actual Postgres row-locking behavior under concurrency (READ COMMITTED re-evaluating the `WHERE` clause against the committed row). Worth promoting to an integration test against a real DB.

zinsanjp