### PR TITLE
fix(watchdog): don't kill a service for a slow cold start or a failing upstream

### DIFF
--- a/client/src/Service.ts
+++ b/client/src/Service.ts
@@ -17,6 +17,7 @@ export type HeartbeatContext = {
    * @param loopName Optional loop identifier. Defaults to 'main'.
    */
   heartbeat(loopName?: string): void;
+  heartbeatDegraded(loopName?: string, reason?: string): void;
 
   /**
    * Declare a loop and its max-staleness timeout. The watchdog treats any

--- a/client/src/runServices.ts
+++ b/client/src/runServices.ts
@@ -140,6 +140,15 @@ export default function runServices(fullConfig: RunServicesConfig) {
 // override this by calling ctx.declareLoop(name, timeoutMs).
 const DEFAULT_HEARTBEAT_TIMEOUT_MS = 5 * 60_000; // 5 minutes
 
+// A loop that reports degraded for this many multiples of its own timeout
+// is no longer having a transient problem. Past this point heartbeatDegraded
+// stops vouching for it, so the watchdog can reach its restart path again --
+// a fresh start() rebuilds the RPC providers, which is a real (if blunt)
+// recovery for a wedged connection. Chosen from measured stall lengths on
+// node2: transient degraded windows there topped out under 4 minutes, so 10x
+// (15 min for the 90s RawEventsGatherer loop) sits well clear of them.
+const DEGRADED_ESCALATE_FACTOR = 10;
+
 // How often the watchdog checks heartbeats.
 const HEARTBEAT_CHECK_INTERVAL_MS = 30_000;
 
@@ -150,7 +159,9 @@ type LoopState = {
    *  successful heartbeat. Recorded for the stats line, not for the watchdog. */
   degradedSince?: number;
   degradedReason?: string;
-  degradedWarned?: boolean;
+  /** Highest multiple of timeoutMs already warned about, so a long stall
+   *  keeps reporting as it grows instead of going quiet after one line. */
+  degradedWarnedMultiple?: number;
 };
 
 // Restart-rate alert (2026-07-10 auto-heal observability): if a service restarts
@@ -182,7 +193,7 @@ function runInstance(instance: InstanceReady): {stop(): Promise<void>} {
             // Progress means recovery: drop any degraded marker.
             existing.degradedSince = undefined;
             existing.degradedReason = undefined;
-            existing.degradedWarned = undefined;
+            existing.degradedWarnedMultiple = undefined;
           } else {
             loops.set(loopName, {
               lastHeartbeat: Date.now(),
@@ -198,6 +209,16 @@ function runInstance(instance: InstanceReady): {stop(): Promise<void>} {
             // the dead-loop path (restarting doesn't fix an upstream that's
             // erroring, and on a service with a cold-start scan it makes
             // things worse) but record how long it's been stuck.
+            //
+            // ...up to a point. Past DEGRADED_ESCALATE_FACTOR x its own
+            // timeout this isn't a transient upstream problem any more, so
+            // stop vouching and let the watchdog reach its restart path: a
+            // fresh start() rebuilds the RPC providers, which is a real (if
+            // blunt) recovery for a wedged connection.
+            if (existing.degradedSince && now - existing.degradedSince > existing.timeoutMs * DEGRADED_ESCALATE_FACTOR) {
+              existing.degradedReason = reason;
+              return;
+            }
             existing.lastHeartbeat = now;
             existing.degradedSince ??= now;
             existing.degradedReason = reason;
@@ -262,9 +283,11 @@ function runInstance(instance: InstanceReady): {stop(): Promise<void>} {
           const loopEntries = Array.from(loops.entries());
           for (const [loopName, state] of loopEntries) {
             const age = now - state.lastHeartbeat;
-            if (state.degradedSince && now - state.degradedSince > state.timeoutMs && !state.degradedWarned) {
-              console.warn(`[runServices] ${instance.instance} loop '${loopName}' alive but not progressing for ${Math.round((now - state.degradedSince) / 1000)}s: ${state.degradedReason ?? 'unknown'}`);
-              state.degradedWarned = true;
+            const degradedFor = state.degradedSince ? now - state.degradedSince : 0;
+            const degradedMultiple = Math.floor(degradedFor / state.timeoutMs);
+            if (degradedMultiple > (state.degradedWarnedMultiple ?? 0)) {
+              console.warn(`[runServices] ${instance.instance} loop '${loopName}' alive but not progressing for ${Math.round(degradedFor / 1000)}s: ${state.degradedReason ?? 'unknown'}`);
+              state.degradedWarnedMultiple = degradedMultiple;
             }
             if (age > state.timeoutMs) {
               throw new Error(

--- a/client/src/runServices.ts
+++ b/client/src/runServices.ts
@@ -146,6 +146,11 @@ const HEARTBEAT_CHECK_INTERVAL_MS = 30_000;
 type LoopState = {
   lastHeartbeat: number;
   timeoutMs: number;
+  /** Set when a loop reports it ran but could not progress; cleared on the next
+   *  successful heartbeat. Recorded for the stats line, not for the watchdog. */
+  degradedSince?: number;
+  degradedReason?: string;
+  degradedWarned?: boolean;
 };
 
 // Restart-rate alert (2026-07-10 auto-heal observability): if a service restarts
@@ -174,10 +179,34 @@ function runInstance(instance: InstanceReady): {stop(): Promise<void>} {
           const existing = loops.get(loopName);
           if (existing) {
             existing.lastHeartbeat = Date.now();
+            // Progress means recovery: drop any degraded marker.
+            existing.degradedSince = undefined;
+            existing.degradedReason = undefined;
+            existing.degradedWarned = undefined;
           } else {
             loops.set(loopName, {
               lastHeartbeat: Date.now(),
               timeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
+            });
+          }
+        },
+        heartbeatDegraded(loopName = 'main', reason) {
+          const now = Date.now();
+          const existing = loops.get(loopName);
+          if (existing) {
+            // The loop ran — it just couldn't make progress. Keep it out of
+            // the dead-loop path (restarting doesn't fix an upstream that's
+            // erroring, and on a service with a cold-start scan it makes
+            // things worse) but record how long it's been stuck.
+            existing.lastHeartbeat = now;
+            existing.degradedSince ??= now;
+            existing.degradedReason = reason;
+          } else {
+            loops.set(loopName, {
+              lastHeartbeat: now,
+              timeoutMs: DEFAULT_HEARTBEAT_TIMEOUT_MS,
+              degradedSince: now,
+              degradedReason: reason,
             });
           }
         },
@@ -222,6 +251,8 @@ function runInstance(instance: InstanceReady): {stop(): Promise<void>} {
       try {
         // Grace period on first start so services have time to run their
         // first loop iteration before we expect heartbeats.
+        const readyAt = Date.now();
+        for (const state of loops.values()) state.lastHeartbeat = readyAt;
         await delay(HEARTBEAT_CHECK_INTERVAL_MS);
 
         let statsCountdown = 0; // Count ticks until we log stats
@@ -231,6 +262,10 @@ function runInstance(instance: InstanceReady): {stop(): Promise<void>} {
           const loopEntries = Array.from(loops.entries());
           for (const [loopName, state] of loopEntries) {
             const age = now - state.lastHeartbeat;
+            if (state.degradedSince && now - state.degradedSince > state.timeoutMs && !state.degradedWarned) {
+              console.warn(`[runServices] ${instance.instance} loop '${loopName}' alive but not progressing for ${Math.round((now - state.degradedSince) / 1000)}s: ${state.degradedReason ?? 'unknown'}`);
+              state.degradedWarned = true;
+            }
             if (age > state.timeoutMs) {
               throw new Error(
                 `heartbeat stale for loop '${loopName}': ${Math.round(age / 1000)}s > ${Math.round(state.timeoutMs / 1000)}s`,
@@ -245,7 +280,7 @@ function runInstance(instance: InstanceReady): {stop(): Promise<void>} {
           // Log stats less often than we check heartbeats, to avoid log spam
           if (statsCountdown <= 0) {
             const loopSummary = Array.from(loops.entries())
-              .map(([name, s]) => `${name}=${Math.round((now - s.lastHeartbeat) / 1000)}s`)
+              .map(([name, s]) => `${name}=${Math.round((now - s.lastHeartbeat) / 1000)}s` + (s.degradedSince ? ` degraded ${Math.round((now - s.degradedSince) / 1000)}s${s.degradedReason ? ` (${s.degradedReason})` : ``}` : ``))
               .join(', ');
             console.log(
               `stats for ${instance.instance}:`,

--- a/client/src/services/RawEventsGatherer/index.ts
+++ b/client/src/services/RawEventsGatherer/index.ts
@@ -208,6 +208,7 @@ export const rawEventsGathererService: Service = {
           storeBatch:            storeBatchAndPublish,
         },
         onTick: () => ctx.heartbeat('poll'),
+        onStall: (reason) => ctx.heartbeatDegraded('poll', reason),
       })
 
       stopListener = listener.stop

--- a/client/src/services/RawEventsGatherer/listenForRawEvents.ts
+++ b/client/src/services/RawEventsGatherer/listenForRawEvents.ts
@@ -127,6 +127,8 @@ export default async function listenForRawEvents(
     }
     /** Optional callback to signal liveness — called at the end of each successful poll */
     onTick?: () => void
+    /** Called when a poll iteration ran but could not make progress. */
+    onStall?: (reason: string) => void
   }
 ): Promise<{ stop(): void }> {
   let wsProvider: WebSocketProvider | null = null
@@ -668,6 +670,7 @@ export default async function listenForRawEvents(
     } catch (err) {
       console.error('[RawEventsGatherer] Polling error:', err)
       // Don't update lastSyncedBlock on error, will retry on next schedule
+      config.onStall?.(String((err as any)?.error?.message || (err as any)?.shortMessage || (err instanceof Error ? err.message : 'poll failed')).slice(0, 60))
     } finally {
       scheduleNextPoll()
     }


### PR DESCRIPTION
The heartbeat watchdog restarts a service when a declared loop stops
reporting within its timeout. Two situations reach that path without the
loop being dead, and on `RawEventsGatherer` the restart makes the next one
more likely.

## What happens today

`declareLoop('poll', 90_000)` stamps its clock at the top of `start()`.
`RawEventsGatherer` then does its cold-start scan — and can't run a single
poll iteration, so can't heartbeat, until that scan finishes. Phase 2
begins after `started` resolves, waits out the grace period, and the first
staleness check measures the whole scan.

Separately, `heartbeat()` is documented as "every **successful** iteration".
A poll that runs but can't make progress — upstream returning errors —
therefore looks identical to a poll loop that stopped.

Neither is fixed by restarting. And a restart re-runs the floor scan
(`Math.min(last.blockNumber, config.startBlock)`), which on my node means
walking ~250k blocks again — so the next timeout is *more* likely than the
last.

## Measured on node2 (Base Sepolia, public RPC)

2026-08-20, one day:

    Flooring scan (full rescan)     108
    RawEventsGatherer crashed       102
    reseed cron restarts              8

102 + 8 ≈ 108: essentially every rescan that day was a restart, and 94% of
them were the watchdog.

Cold-start cost, measured 2026-08-22 while the upstream was struggling:

    16:38:40   Flooring scan
    16:59:25   log walk done          (20m45s, ~167 getLogs)
    17:23:08   first poll             (23m43s of tx fetches, 115 events)

**44 minutes.** Against a 90s timeout, that start can never complete: it
gets killed roughly 29 times over, restarting the same scan each time. This
isn't only wasteful — with a slow enough upstream the service cannot reach
its poll loop at all.

Each cold start is ~280 RPC calls (167 `getLogs` + 115
`getTransactionByHash`). At 108 rescans/day that's ~30k calls, against
~4,600 for a day of normal polling (2,290 ticks, two calls each).

## What this changes

1. **`runServices`** — reset loop clocks when the service becomes ready.
   The timeout then measures time since the loop *could* run, which is what
   the 30s grace comment already assumes ("services have time to run their
   first loop iteration"). Services that start in milliseconds are
   unaffected.

2. **`Service` / `runServices`** — add `heartbeatDegraded(loopName, reason)`.
   It keeps `lastHeartbeat` fresh (the loop is running) but records
   `degradedSince` and the reason. `heartbeat()` clears it — progress means
   recovery. `heartbeat()`'s own meaning is unchanged, and the method is
   optional, so no existing service is affected.

3. **`runServices`** — when a loop stays degraded past its *existing*
   timeout, warn once. The 90s threshold isn't discarded; it now fires a log
   line instead of a restart, and the stats line carries the state
   continuously.

4. **`RawEventsGatherer`** — report poll failures through `onStall`.

## After (same node, 2026-08-22, production 90s threshold)

    17:33:08  loop 'poll' alive but not progressing for 117s: server response 503 Service Unavailable
    17:43:08  loop 'poll' alive but not progressing for 110s: server response 503 Service Unavailable
    17:56:08  loop 'poll' alive but not progressing for 118s: block range extends beyond current head block

Three stalls over 90s. Under the old behaviour each is a kill plus a full
rescan; here each is one line, and the service kept polling. Zero watchdog
restarts since the change, with RPC errors continuing throughout.

The stats line shows both numbers at once:

    [loops: poll=22s degraded 84s (server response 503 Service Unavailable)]

Beat 22s ago, no progress for 84s — a state the old code had no way to
express.

## What this gives up

The old behaviour was a blunt signal that something was wrong: a
permanently broken upstream produced a visible restart loop. That signal is
gone. `getIndexerStats` exists but its only consumer is the validator's
`tolerableLag` calculation, not an alert — so the degraded warning is now
the only operator-facing indication. I'd rather that be stated than
discovered.

## Not in scope

- The `-32602 block range extends beyond current head` errors themselves.
  They come from `getBlockNumber` and `getLogs` landing on upstreams at
  different heights, and would be better addressed by not polling to the
  tip. Separate change.
- Whether the floor rescan needs to re-walk from `startBlock` every restart.
- Choice of RPC provider — my node runs on public endpoints, which is where
  these numbers come from.

## Note on #60

Both touch `listenForRawEvents.ts`, in different places (this adds one line
in the poll `catch`; #60 works around the historical `processEvents` call).
Either order should rebase cleanly; happy to go second if that's easier.