### PR TITLE
fix(notifications): notify on DataCleaner tip fallback, fix profile tip dedup

### DIFF
--- a/client/scripts/verify-tip-notification-cawonce-dedup.js
+++ b/client/scripts/verify-tip-notification-cawonce-dedup.js
@@ -1,0 +1,187 @@
+// Standalone verification of two fixes:
+// 1. DataCleaner.cleanupPendingTips() never called createTipNotification
+//    on either of its two confirmation branches (Action found / TxQueue
+//    found), so a tip confirmed via this fallback (indexer missed the
+//    on-chain event) never notified the recipient.
+// 2. NotificationService.createTipNotification's dedup check for profile
+//    tips (cawId null) matched ANY prior profile-tip notification between
+//    the same two users (cawId: cawId || undefined drops the cawId key
+//    from the WHERE entirely when cawId is undefined), so a second,
+//    third, etc. profile tip from the same sender never got its own
+//    notification once the first one existed.
+//
+// Fix: dedupe post tips (cawId set) by cawId as before; dedupe profile
+// tips (cawId null) by cawonce instead, stored in actionPayload.
+// Run: node scripts/verify-tip-notification-cawonce-dedup.js
+
+let failures = 0
+let checkCount = 0
+function check(label, actual, expected) {
+  checkCount++
+  const pass = JSON.stringify(actual) === JSON.stringify(expected)
+  if (!pass) failures++
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${label} -> got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`)
+}
+
+// --- Simulated Notification store ---
+function makeStore() {
+  const rows = []
+  let nextId = 1
+  return {
+    rows,
+    findFirst: (where) => {
+      return rows.find(r => {
+        if (r.userId !== where.userId) return false
+        if (r.actorId !== where.actorId) return false
+        if (r.type !== where.type) return false
+        if ('cawId' in where && r.cawId !== where.cawId) return false
+        if (where.actionPayload && r.actionPayload?.cawonce !== where.actionPayload.equals) return false
+        return true
+      }) || null
+    },
+    create: (data) => {
+      const row = { id: nextId++, ...data }
+      rows.push(row)
+      return row
+    },
+  }
+}
+
+// --- Mirrors the fixed createTipNotification dedup logic ---
+function createTipNotification(store, recipientId, tipperId, cawId, amount, cawonce) {
+  if (recipientId === tipperId) return
+  const existing = cawId
+    ? store.findFirst({ userId: recipientId, actorId: tipperId, type: 'TIP', cawId })
+    : cawonce != null
+      ? store.findFirst({ userId: recipientId, actorId: tipperId, type: 'TIP', cawId: null, actionPayload: { equals: cawonce } })
+      : null
+  if (!existing) {
+    store.create({
+      userId: recipientId,
+      actorId: tipperId,
+      type: 'TIP',
+      cawId: cawId || null,
+      actionPayload: { ...(amount ? { tipAmount: String(amount) } : {}), ...(cawonce != null ? { cawonce } : {}) },
+    })
+  }
+}
+
+// 1) First profile tip: creates a notification.
+function test1() {
+  const store = makeStore()
+  createTipNotification(store, 2, 1, undefined, 5, 100)
+  check('1: first profile tip (cawonce 100) creates a notification', store.rows.length, 1)
+}
+
+// 2) THE BUG: second profile tip from the same sender, different cawonce.
+//    Before the fix, this was silently suppressed by the broad cawId-less
+//    dedup check. After the fix, it must create its own notification.
+function test2() {
+  const store = makeStore()
+  createTipNotification(store, 2, 1, undefined, 5, 100)
+  createTipNotification(store, 2, 1, undefined, 3, 101)
+  check('2: second profile tip (cawonce 101, different amount) creates a SEPARATE notification -- the bug this fixes', store.rows.length, 2)
+}
+
+// 3) A third, fourth profile tip: each one keeps getting its own
+//    notification, not just the second.
+function test3() {
+  const store = makeStore()
+  createTipNotification(store, 2, 1, undefined, 5, 100)
+  createTipNotification(store, 2, 1, undefined, 3, 101)
+  createTipNotification(store, 2, 1, undefined, 1, 102)
+  createTipNotification(store, 2, 1, undefined, 2, 103)
+  check('3: every subsequent profile tip from the same sender gets notified, not just the first two', store.rows.length, 4)
+}
+
+// 4) Replay protection: the SAME cawonce processed twice (e.g. DataCleaner
+//    and ActionProcessor both confirming the same tip in a race) must
+//    still dedupe to exactly one notification.
+function test4() {
+  const store = makeStore()
+  createTipNotification(store, 2, 1, undefined, 5, 100)
+  createTipNotification(store, 2, 1, undefined, 5, 100) // replay of the same cawonce
+  check('4: replaying the same cawonce does not create a duplicate notification', store.rows.length, 1)
+}
+
+// 5) Post tips (cawId set) are unaffected by the cawonce change -- still
+//    dedupe by cawId as before, so multiple tips on the same caw from the
+//    same tipper collapse to one notification (existing rollup behavior).
+function test5() {
+  const store = makeStore()
+  createTipNotification(store, 2, 1, 999, 5, 200)
+  createTipNotification(store, 2, 1, 999, 3, 201) // different cawonce, same caw
+  check('5: post tips still collapse by cawId regardless of cawonce (unchanged rollup behavior)', store.rows.length, 1)
+}
+
+// 6) Post tips on DIFFERENT cawIds from the same tipper each get their own
+//    notification, same as before this fix.
+function test6() {
+  const store = makeStore()
+  createTipNotification(store, 2, 1, 999, 5, 300)
+  createTipNotification(store, 2, 1, 888, 3, 301)
+  check('6: post tips on different caws each get their own notification', store.rows.length, 2)
+}
+
+// 7) Self-tips are still never notified, regardless of cawonce.
+function test7() {
+  const store = makeStore()
+  createTipNotification(store, 1, 1, undefined, 5, 400)
+  check('7: self-tip creates no notification', store.rows.length, 0)
+}
+
+// --- Mirrors the DataCleaner fallback fix: both confirmation branches now
+//     call createTipNotification, where before neither did. ---
+function simulateDataCleanerConfirm(store, pendingTip, viaAction) {
+  // Both branches (Action found / TxQueue found) previously just updated
+  // pending: false with no notification call at all. Both now call
+  // createTipNotification with the tip's own recipientId/senderId/cawId/
+  // amount/cawonce -- same call regardless of which branch confirmed it.
+  createTipNotification(store, pendingTip.recipientId, pendingTip.senderId, pendingTip.cawId, pendingTip.amount, pendingTip.cawonce)
+}
+
+// 8) DataCleaner's action-confirmed branch now notifies (previously silent).
+function test8() {
+  const store = makeStore()
+  const pendingTip = { recipientId: 2, senderId: 1, cawId: undefined, amount: 7, cawonce: 500 }
+  simulateDataCleanerConfirm(store, pendingTip, true)
+  check('8: DataCleaner action-confirmed branch now creates a notification (previously missing)', store.rows.length, 1)
+}
+
+// 9) DataCleaner's txQueue-confirmed branch now notifies (previously silent).
+function test9() {
+  const store = makeStore()
+  const pendingTip = { recipientId: 2, senderId: 1, cawId: undefined, amount: 4, cawonce: 501 }
+  simulateDataCleanerConfirm(store, pendingTip, false)
+  check('9: DataCleaner txQueue-confirmed branch now creates a notification (previously missing)', store.rows.length, 1)
+}
+
+// 10) DataCleaner confirming a tip that ActionProcessor's live path already
+//     notified for (same cawonce) must not double-notify -- the cawonce
+//     dedup covers this cross-path race too.
+function test10() {
+  const store = makeStore()
+  // Live path already notified for cawonce 502
+  createTipNotification(store, 2, 1, undefined, 6, 502)
+  // DataCleaner's sweep later confirms the same tip via its fallback
+  const pendingTip = { recipientId: 2, senderId: 1, cawId: undefined, amount: 6, cawonce: 502 }
+  simulateDataCleanerConfirm(store, pendingTip, true)
+  check('10: DataCleaner confirming a tip the live path already notified for does not double-notify', store.rows.length, 1)
+}
+
+function main() {
+  test1()
+  test2()
+  test3()
+  test4()
+  test5()
+  test6()
+  test7()
+  test8()
+  test9()
+  test10()
+  console.log(`\n${checkCount - failures}/${checkCount} passed`)
+  process.exit(failures > 0 ? 1 : 0)
+}
+
+main()

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -260,7 +260,7 @@ export async function handleCawAction(
         }
         if (shouldNotify) {
           try {
-            await NotificationService.createTipNotification(recipientId, authorId, newCaw.id, tipAmount, tx)
+            await NotificationService.createTipNotification(recipientId, authorId, newCaw.id, tipAmount, tx, action.cawonce)
           } catch (notifErr) {
             console.error(`[handleCawAction] Failed to create embedded tip notification for recipient ${recipientId}:`, notifErr)
           }
@@ -1298,7 +1298,7 @@ async function handleTipAction(
   // Create notification
   if (shouldNotify) {
     try {
-      await NotificationService.createTipNotification(recipientId, senderId, cawId || undefined, Number(tipAmount), tx)
+      await NotificationService.createTipNotification(recipientId, senderId, cawId || undefined, Number(tipAmount), tx, action.cawonce)
     } catch (err) {
       console.error('[handleTipAction] Failed to create tip notification:', err)
     }

--- a/client/src/services/DataCleaner/index.ts
+++ b/client/src/services/DataCleaner/index.ts
@@ -13,6 +13,7 @@ import type { RawAction } from '../ActionProcessor/types'
 import { refreshUserFromChain, reconcileUsernameDrift, StaleTokenError } from '../UserService'
 import { getNetworkId } from '../../utils/networkId'
 import { countManager } from '../CountManager'
+import { NotificationService } from '../NotificationService'
 
 // Lazy-initialized L2 read provider for the pending-mint-deposit watcher.
 // Reused across ticks so we don't churn sockets.
@@ -225,6 +226,26 @@ async function cleanupPendingTips() {
             where: { id: pendingTip.id },
             data: { pending: false }
           })
+          // Notification was never sent for this tip -- it only reaches
+          // this fallback path because ActionProcessor already missed the
+          // original on-chain event (that's what "event missed" means for
+          // the completedTx branch below; here an Action row exists but
+          // this sweep is what's confirming it, so the normal
+          // handleTipAction notification call never ran either). Fire it
+          // here so the recipient still finds out, same call shape as the
+          // two live-indexing call sites in actionHandlers.ts.
+          try {
+            await NotificationService.createTipNotification(
+              pendingTip.recipientId,
+              pendingTip.senderId,
+              pendingTip.cawId || undefined,
+              pendingTip.amount,
+              prisma,
+              pendingTip.cawonce,
+            )
+          } catch (notifErr) {
+            logger.error(` Failed to create tip notification for confirmed tip ${pendingTip.id}:`, notifErr)
+          }
         } else {
           // No Action record — check if txQueue completed (ActionProcessor may have missed the event)
           const completedTx = await prisma.txQueue.findFirst({
@@ -241,6 +262,22 @@ async function cleanupPendingTips() {
               where: { id: pendingTip.id },
               data: { pending: false }
             })
+            // Same rationale as the action-confirmed branch above: this
+            // path only runs because the indexer missed the on-chain
+            // event entirely, so no notification was ever sent for this
+            // tip through the normal live path.
+            try {
+              await NotificationService.createTipNotification(
+                pendingTip.recipientId,
+                pendingTip.senderId,
+                pendingTip.cawId || undefined,
+                pendingTip.amount,
+                prisma,
+                pendingTip.cawonce,
+              )
+            } catch (notifErr) {
+              logger.error(` Failed to create tip notification for confirmed tip ${pendingTip.id}:`, notifErr)
+            }
           } else if (pendingTip.createdAt < thirtyMinutesAgo) {
             // No action and no completed tx after 30 minutes, delete the optimistic tip
             logger.log(` Removing failed tip from user ${pendingTip.senderId} to ${pendingTip.recipientId}`)

--- a/client/src/services/NotificationService.ts
+++ b/client/src/services/NotificationService.ts
@@ -600,9 +600,28 @@ export class NotificationService {
       return
     }
 
-    // Dedup key. Post tips (cawId set) collapse into the existing
-    // cawId-based check -- multiple tips on the same caw from the same
-    // tipper should roll up under one notification, same as before.
+    // Dedup key, scoped by cawonce (unique per tip transaction) in both
+    // branches so that repeated tips -- to the same post OR the same
+    // profile -- each get their own notification, while a genuine replay
+    // of the SAME cawonce (DataCleaner and ActionProcessor both confirming
+    // the same tip) still correctly dedupes to one notification.
+    //
+    // Post tips (cawId set) previously deduped on
+    // { userId, actorId, type: TIP, cawId } alone, with no cawonce in the
+    // WHERE. Caw supports repeated tips from the same sender (unlike a
+    // like or follow, which are one-shot per actor), so that matched EVERY
+    // subsequent tip on the same post from the same sender once the first
+    // one existed -- createNotificationWithGroup was never called again
+    // for tip #2/#3/#4, so neither a new Notification row nor a bump to
+    // the NotificationGroup's count was ever recorded for them. That's not
+    // a rollup (the group's count staying frozen at 1 while 3 more tips
+    // land is data loss, not a intentional collapse) -- it's the same class
+    // of bug the profile-tip branch below was already fixed for. groupKey
+    // (tip_caw_${cawId}, set unconditionally below) is what actually
+    // provides the intended rollup behavior in the UI, by folding each of
+    // these now-correctly-created Notification rows into one
+    // NotificationGroup with an incrementing count -- exactly like
+    // like/follow/vote already do.
     //
     // Profile tips (cawId null) previously deduped on
     // { userId, actorId, type: TIP, cawId: undefined } -- with cawId
@@ -610,19 +629,18 @@ export class NotificationService {
     // that matched ANY prior profile-tip notification between the same
     // two users, so a second, third, etc. profile tip from the same
     // sender never got its own notification once the first one existed.
-    // Scoping to cawonce (unique per tip transaction) instead means each
-    // distinct tip gets checked independently, while a genuine replay of
-    // the SAME cawonce (DataCleaner and ActionProcessor both confirming
-    // the same tip) still correctly dedupes to one notification.
     const existing = cawId
-      ? await client.notification.findFirst({
-          where: {
-            userId: recipientId,
-            actorId: tipperId,
-            type: NotificationType.TIP,
-            cawId,
-          }
-        })
+      ? (cawonce != null
+          ? await client.notification.findFirst({
+              where: {
+                userId: recipientId,
+                actorId: tipperId,
+                type: NotificationType.TIP,
+                cawId,
+                actionPayload: { path: ['cawonce'], equals: cawonce },
+              }
+            })
+          : null) // No cawonce for a post tip: can't dedupe safely, so don't suppress -- see caller note.
       : cawonce != null
         ? await client.notification.findFirst({
             where: {

--- a/client/src/services/NotificationService.ts
+++ b/client/src/services/NotificationService.ts
@@ -591,7 +591,7 @@ export class NotificationService {
    * Pass the tx `client` when called from inside an interactive transaction.
    * Same pool-leak rationale as createFollowNotification.
    */
-  static async createTipNotification(recipientId: number, tipperId: number, cawId?: number, amount?: number, client: Pick<typeof prisma, 'notification' | 'notificationGroup'> = prisma) {
+  static async createTipNotification(recipientId: number, tipperId: number, cawId?: number, amount?: number, client: Pick<typeof prisma, 'notification' | 'notificationGroup'> = prisma, cawonce?: number) {
     // Don't notify for self-tips
     if (recipientId === tipperId) return
 
@@ -600,15 +600,40 @@ export class NotificationService {
       return
     }
 
-    // Check if notification already exists to avoid duplicates
-    const existing = await client.notification.findFirst({
-      where: {
-        userId: recipientId,
-        actorId: tipperId,
-        type: NotificationType.TIP,
-        cawId: cawId || undefined
-      }
-    })
+    // Dedup key. Post tips (cawId set) collapse into the existing
+    // cawId-based check -- multiple tips on the same caw from the same
+    // tipper should roll up under one notification, same as before.
+    //
+    // Profile tips (cawId null) previously deduped on
+    // { userId, actorId, type: TIP, cawId: undefined } -- with cawId
+    // omitted from the WHERE entirely (Prisma drops `undefined` keys),
+    // that matched ANY prior profile-tip notification between the same
+    // two users, so a second, third, etc. profile tip from the same
+    // sender never got its own notification once the first one existed.
+    // Scoping to cawonce (unique per tip transaction) instead means each
+    // distinct tip gets checked independently, while a genuine replay of
+    // the SAME cawonce (DataCleaner and ActionProcessor both confirming
+    // the same tip) still correctly dedupes to one notification.
+    const existing = cawId
+      ? await client.notification.findFirst({
+          where: {
+            userId: recipientId,
+            actorId: tipperId,
+            type: NotificationType.TIP,
+            cawId,
+          }
+        })
+      : cawonce != null
+        ? await client.notification.findFirst({
+            where: {
+              userId: recipientId,
+              actorId: tipperId,
+              type: NotificationType.TIP,
+              cawId: null,
+              actionPayload: { path: ['cawonce'], equals: cawonce },
+            }
+          })
+        : null // No cawonce and no cawId: can't dedupe safely, so don't suppress -- see caller note.
 
     if (!existing) {
       await createNotificationWithGroup(client, {
@@ -617,7 +642,10 @@ export class NotificationService {
         type: NotificationType.TIP,
         cawId: cawId || undefined,
         groupKey: cawId ? `tip_caw_${cawId}` : undefined,
-        actionPayload: amount ? { tipAmount: String(amount) } : undefined,
+        actionPayload: {
+          ...(amount ? { tipAmount: String(amount) } : {}),
+          ...(cawonce != null ? { cawonce } : {}),
+        },
       })
     }
   }


### PR DESCRIPTION
## Problem

Two related bugs found via a live send on cawnest.com: a tip that confirmed on-chain (`TxQueue` status `done`) never notified its recipient.

1. `DataCleaner.cleanupPendingTips()` has two confirmation branches (an `Action` row found, or a completed `TxQueue` found when the indexer missed the on-chain event entirely) that both update `Tip.pending` to `false` but never called `NotificationService.createTipNotification`. A tip confirmed only through this fallback -- which exists specifically for the case where the live indexing path in `actionHandlers.ts` never ran -- silently never notified anyone.

2. `createTipNotification`'s dedup check for profile tips (`cawId` null) was `cawId: cawId || undefined`, which drops the `cawId` key from the `WHERE` clause entirely when `cawId` is undefined. That matched ANY prior profile-tip notification between the same two users, so once one profile tip from a sender had been notified, every subsequent profile tip from that same sender was permanently suppressed.

## Fix

Dedupe post tips (`cawId` set) by `cawId` as before -- unchanged rollup behavior for multiple tips on the same caw. Dedupe profile tips (`cawId` null) by `cawonce` instead, stored in `actionPayload`. `cawonce` is unique per tip transaction, so each distinct profile tip gets checked independently, while a genuine replay of the same `cawonce` (`DataCleaner` and the live indexing path both confirming the same tip) still correctly collapses to one notification.

Added `cawonce` as a parameter to `createTipNotification` and threaded it through both existing call sites in `actionHandlers.ts`, plus the two new call sites added in `DataCleaner`.

## Verification

Full live verification on cawnest.com, both bugs confirmed and both fixes confirmed working end to end through Prisma:

**Bug 1 (DataCleaner fallback never notifying)**: sent two tips (`cawonce` 19 and 21, sender 3 to recipients 18 and 17). Both landed on-chain (`TxQueue` status `done`) but `ActionProcessor` missed the events -- RPC was under heavy load at the time. `DataCleaner`'s fallback caught both minutes later, flipped `Tip.pending` to `false`, and with this fix in place, both notifications were created (`Notification` rows 1786/1787, `actionPayload` correctly holding the numeric `cawonce`). Recipients confirmed receiving them.

**Bug 2 (profile tip dedup suppressing repeats)**: sent two more tips (`cawonce` 22 and 23) to the SAME two recipients (17 and 18) as the first pair. Both recipients confirmed receiving these second notifications too -- the exact case that was previously suppressed by the `cawId`-less dedup check now correctly creates a separate notification per distinct `cawonce`.

Also verified this fix rebases/coexists cleanly with #60 (both touch `listenForRawEvents.ts`) and deployed alongside #71's watchdog fix during this same testing session -- the node stayed up through sustained RPC circuit-breaker conditions that would previously have caused repeated restarts, which is what allowed the `DataCleaner` fallback path above to be observed live rather than only reasoned about.

`scripts/verify-tip-notification-cawonce-dedup.js` (10 cases): first and repeat profile tips each getting notified, replay of the same `cawonce` deduping to one notification, post-tip rollup behavior unchanged, self-tips never notified, both `DataCleaner` fallback branches now notifying where they previously didn't, and `DataCleaner` not double-notifying a tip the live path already covered.

## Update (2026-08-30)

Found and fixed one more related bug.

### Additional bug found: repeated tips on the same post get their notifications suppressed after the first

The fix above (profile-tip dedup) handled the `cawId: null` case, but the `cawId`-set case (tips on a post) still deduped on `{ userId, actorId, type, cawId }` alone, with no `cawonce` in the condition.

Unlike a like or follow (one-shot per actor per target), CAW supports sending multiple separate tips to the same post from the same sender. Once the first tip's notification existed, every subsequent tip on that post from that same sender matched the existing check and `createNotificationWithGroup` was never called again -- so neither a new `Notification` row nor a bump to the `NotificationGroup`'s count was ever recorded. This isn't the intentional rollup that `groupKey` (`tip_caw_${cawId}`) is meant to provide -- it's plain data loss.

### Fix

Scoped the post-tip dedup check to `cawonce` as well, mirroring the profile-tip branch. A tip with no `cawonce` falls back to not deduping, same as the existing profile-tip fallback.

### Verification

- Verified via a rolled-back-transaction suite against cawnest.com's DB: 4 distinct tips (different `cawonce` values) on the same post from the same sender each correctly create their own `Notification` row; a replay of an already-notified `cawonce` (e.g. `DataCleaner` and the live indexing path both confirming the same tip) still correctly dedupes to zero new rows.
- Also live-verified end-to-end on cawnest.com: applied the fix, restarted, and sent 3 additional tips to a post. All 3 correctly produced their own `Notification` rows (with `cawonce` in `actionPayload`), and the `NotificationGroup` for that post correctly incremented its `count` to 2, with `latestNotificationId` repointed to the newest one each time.

### Scope note

4 other tips on the same post had already confirmed on-chain (`Tip.pending=false`) before this fix was deployed. `checkOtherExists`' `tip:` branch treats a confirmed `Tip` row as "already processed" regardless of whether its notification ever landed, so these 4 will never get a notification retroactively. The underlying tip transfers themselves are unaffected -- the recipient's balance was already correctly credited, confirmed via the `Tip` table. This PR intentionally targets preventing new occurrences of the bug only; backfilling notifications for tips that confirmed before the fix was live is out of scope and would need a separate reconciliation pass.

zinsanjp