### PR TITLE
Scope orphan-reconciliation UNFOLLOW so it can't delete a re-followed…

### DIFF
--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -776,7 +776,8 @@ export async function handleFollowAction(
 export async function handleUnfollowAction(
   tx: PrismaTransactionClient,
   action: any,
-  rawAction: any
+  rawAction: any,
+  fromReconciliation = false
 ): Promise<void> {
   const followerId = await findOrCreateUser(action.senderId)
   const followingId = await findOrCreateUser(rawAction.receiverId)
@@ -787,6 +788,15 @@ export async function handleUnfollowAction(
 
   if (!existing) {
     console.log(`User ${followerId} was not following user ${followingId}`)
+    return
+  }
+
+  // Orphan-reconciliation idempotency guard: a SUCCESS+FOLLOW row seen during
+  // reconciliation replay may be a re-follow issued *after* this UNFOLLOW.
+  // The live path (fromReconciliation=false) still deletes it as before; only
+  // orphan replay skips. Legitimate unfollows resolve via the PENDING+UNFOLLOW
+  // optimistic-undo path, which this guard does not touch.
+  if (fromReconciliation && existing.status === 'SUCCESS' && existing.action === 'FOLLOW') {
     return
   }
 

--- a/client/src/services/ActionProcessor/domainProcessor.ts
+++ b/client/src/services/ActionProcessor/domainProcessor.ts
@@ -86,7 +86,8 @@ export async function processDomainEffects(
   tx: PrismaTransactionClient,
   action: any,
   rawAction: RawAction,
-  resolved: ResolvedUsers
+  resolved: ResolvedUsers,
+  fromReconciliation = false
 ): Promise<void> {
   const { authorId } = resolved
 
@@ -144,7 +145,7 @@ export async function processDomainEffects(
       break
 
     case 'UNFOLLOW':
-      await handleUnfollowAction(tx, action, rawAction)
+      await handleUnfollowAction(tx, action, rawAction, fromReconciliation)
       break
 
     case 'OTHER':

--- a/client/src/services/DataCleaner/index.ts
+++ b/client/src/services/DataCleaner/index.ts
@@ -813,7 +813,7 @@ async function cleanupOrphanActions() {
         // 5s tx budget) and re-run domain processing.
         const resolved = await resolveActionUsers(rawAction)
         await prisma.$transaction(
-          (tx) => processDomainEffects(tx, action, rawAction, resolved),
+          (tx) => processDomainEffects(tx, action, rawAction, resolved, /* fromReconciliation */ true),
           { timeout: 15_000 },
         )
         recovered++


### PR DESCRIPTION
# [Draft / RFC] Scope orphan-reconciliation UNFOLLOW so it can't delete a re-followed row

> **This is a Draft on purpose.** It touches the *intentional* `always-process` behavior of UNFOLLOW in `domainObjectChecks`, so I don't want to merge a behavior change unilaterally. The patch is applied and **verified live on my production V2 node** (see "Live verification" below — a re-follow survived 3+ orphan ticks), but I'm keeping this a Draft because the real ask is the design questions at the bottom: placement, the log noise, and one live-precedence assumption I couldn't fully close from the code. Tell me which direction you'd prefer and I'll finalize.

## Summary

On my node (`v2.nyaromesama.com`, instance #1, networkId=1) I traced a case where a **re-follow lands and then gets silently deleted** by orphan reconciliation replaying an older UNFOLLOW. Everything on-chain and in ingestion is correct — the interaction is purely in the reconciliation path replaying a still-in-window UNFOLLOW against a Follow row that a *newer* FOLLOW just recreated.

This is not a "bug in a single function" — each piece is behaving as designed. It's the **interaction** between (a) orphan reconciliation's time-window-only candidate selection and (b) UNFOLLOW's intentional `always-process`.

## Mechanism (all traced in code, read-only)

1. `cleanupOrphanActions` (`DataCleaner/index.ts`) selects candidates by **time window only** (`createdAt > now-1h && < now-2m`; LOOKBACK=1h, DEBOUNCE=2m). No actionType filter, no check for whether the domain row already exists at selection time.

2. For UNFOLLOW, `checkDomainObjectExists` → `domainObjectChecks.ts` returns "not done" **by design** (the code comment states: for unfollows, always process, because we need to delete the follow record if it exists). So a live UNFOLLOW action stays "not done" for its whole 1h window and is re-fed to `processDomainEffects` every tick.

3. `handleUnfollowAction` (`ActionProcessor/actionHandlers.ts`) looks up the pair and, if a row exists, **deletes it unconditionally** — it never checks *when* the UNFOLLOW was issued relative to the row it's about to delete. (If no row exists it logs "was not following" and returns — a harmless no-op.)

### Timeline that reproduces it
- `t0` UNFOLLOW issued (Action row, `createdAt = t0`), enters the 1h orphan window.
- `t0 + Δ` user re-follows → `handleFollowAction` recreates the Follow row as `status=SUCCESS, action=FOLLOW`.
- `t0 + Δ + (next tick)` orphan reconciliation replays the **old** UNFOLLOW → `handleUnfollowAction` deletes the freshly-recreated row.

The empty-lookup log line (`was not following`) is a *separate*, harmless symptom (fires when no row is present; it does not delete). The real damage is the delete when a row **is** present.

## Why the "obvious" fixes don't work (ruled out in code)

- **Filter candidates to "UNFOLLOW with no existing Follow row":** backwards. What reconciliation legitimately wants to fix is exactly the UNFOLLOW whose row still exists; excluding "row present" would gut the feature and still not target the replay case correctly.
- **Timestamp guard (skip if the Follow row is newer than the UNFOLLOW):** not reliable here. The `Follow` model has **no `cawonce`** (it's a 1-row-per-pair *current-state* table: `@@unique([followerId, followingId])`), so there's no absolute action ordering. And `handleFollowAction` recreates the row via **`upsert` (new `createdAt`) on a fresh follow** but via **`update` (keeps `createdAt`, bumps `updatedAt`) on a re-follow-after-unfollow** — so which timestamp moves is path-dependent. A time comparison is a shaky foundation.

## Proposed fix (the patch in this Draft)

`handleUnfollowAction` already branches on the row's `action`/`status`:
- `PENDING + UNFOLLOW` → optimistic-undo path (the normal, correct delete; `/api/actions` already flipped the row at submit time)
- `SUCCESS + FOLLOW` → legacy / cross-mirror path (delete a confirmed FOLLOW)

A **re-followed** row is `SUCCESS + FOLLOW` — which is also exactly the state we must **not** delete when we're merely replaying an old UNFOLLOW during reconciliation. Meanwhile the *legitimate* target of a real UNFOLLOW is handled through the optimistic-undo (`PENDING + UNFOLLOW`) path, which is untouched.

So: **pass a `fromReconciliation` flag down the reconciliation call only, and have `handleUnfollowAction` skip when `fromReconciliation && row is SUCCESS+FOLLOW`.**

```ts
// domainProcessor.ts — processDomainEffects signature
export async function processDomainEffects(
  tx: PrismaTransactionClient,
  action: any,
  rawAction: RawAction,
  resolved: ResolvedUsers,
  fromReconciliation = false,          // NEW, defaults false → live path unchanged
): Promise<void> {
  // ...
  case 'UNFOLLOW':
    await handleUnfollowAction(tx, action, rawAction, fromReconciliation)
    break
  // ...
}

// DataCleaner/index.ts — orphan path only (cleanupOrphanActions)
await prisma.$transaction(
  (tx) => processDomainEffects(tx, action, rawAction, resolved, /* fromReconciliation */ true),
  { timeout: 15_000 },
)

// actionHandlers.ts — handleUnfollowAction
export async function handleUnfollowAction(
  tx: PrismaTransactionClient,
  action: any,
  rawAction: any,
  fromReconciliation = false,
): Promise<void> {
  // ... existing findOrCreateUser + findUnique ...
  if (!existing) { console.log(`... was not following ...`); return }

  // Orphan-reconciliation idempotency guard: a SUCCESS+FOLLOW row seen during
  // reconciliation replay may be a re-follow issued *after* this UNFOLLOW.
  // The live path (fromReconciliation=false) still deletes it as before; only
  // orphan replay skips. Legitimate unfollows resolve via the PENDING+UNFOLLOW
  // optimistic-undo path, which this guard does not touch.
  if (fromReconciliation && existing.status === 'SUCCESS' && existing.action === 'FOLLOW') {
    return
  }

  await tx.follow.delete({ /* ... */ })
  // ...
}
```

**Only `handleUnfollowAction` consumes the flag.** The other branches in the `processDomainEffects` switch ignore the added argument; it changes nothing for them.

### Why this is safe (all from code, not assumption)
1. **Live path unchanged** — `processDomainEffects` has exactly two callers: the orphan transaction in `DataCleaner/index.ts` (now passes `true`) and the live path in `ActionProcessor/index.ts` (omits the arg → `false`). Every non-reconciliation UNFOLLOW still deletes confirmed FOLLOWs exactly as today.
2. **Only orphan replay is made idempotent** — the sole `true` caller is the reconciliation transaction.
3. **No legitimate unfollow is lost via the optimistic-undo path** — real unfollows resolve via `PENDING + UNFOLLOW`, which the skip doesn't touch. (One residual assumption about the *legacy/cross-mirror* path is called out as design question 3 below.)
4. **Live and orphan share `processDomainEffects`** (`domainProcessor` switch → `handleUnfollowAction`), so a single arg is the minimal seam to distinguish them.

## Live verification on my node (2026-08-22, production V2)

I applied this patch to my production V2 node and reproduced the exact scenario end-to-end. The re-followed row survived — it was **not** deleted by the orphan replay.

Timeline (all values from read-only DB probes + logs, UTC):

| Time | Event | Observed |
|---|---|---|
| 17:09 | Unfollow user3 (real device) | TxQueue `done`, UNFOLLOW Action row `cawonce=46 receiverId=3`, enters 1h orphan window (created 17:10:47) |
| 17:13:06 | orphan picks up cawonce46 while no Follow row exists | `User 1 was not following user 3` — confirms reconciliation **is** targeting this UNFOLLOW every tick |
| 17:14 | Re-follow user3 (real device) | TxQueue `done`, FOLLOW Action `cawonce=47 receiverId=3` |
| 17:15:51 | Follow row recreated `SUCCESS/FOLLOW` | `User 1 now follows user 3` |
| 17:16 → 17:19:48 | **orphan picks up cawonce46 across 3+ ticks (17:17 / 18 / 19:15)** | **Follow row `updated=17:15:51` unchanged, no `unfollowed user 3` log, still present** |

Without the guard, the 17:17:15 tick would have deleted the `SUCCESS/FOLLOW` row (the old behavior). With `fromReconciliation` in place, the skip fires silently (bare `return`, no log) and the row is preserved across every subsequent tick. The legitimate-unfollow path (`PENDING/UNFOLLOW`, optimistic-undo) is untouched — a normal unfollow still deletes as before, since `ActionProcessor/index.ts` calls `processDomainEffects` without the flag (defaults false).

Net: the patch stops the damage (re-follow no longer killed) while leaving `always-process` and the live delete path intact. The per-tick `was not following` log still prints until the UNFOLLOW ages out of the 1h window, which is design question 2 below.

## The design questions (this is the actual ask)

The `always-process` for UNFOLLOW is deliberate (per the comment in `domainObjectChecks.ts`), and I don't want to change that globally. My patch keeps `always-process` intact and only makes the **reconciliation context** idempotent for a re-followed row. Three things I'd like a ruling on:

**1. Placement.** Flag-through-`processDomainEffects` (what's here) vs. something you'd prefer at the `checkDomainObjectExists` layer. I avoided the latter because it would also short-circuit the **live** path (UNFOLLOW would stop working), but if there's a cleaner seam you have in mind, I'll move it.

**2. The empty-lookup log spam.** With this patch the *damage* stops, but the per-tick `was not following` log still prints until the UNFOLLOW ages out of the 1h window (self-stops — I've observed it stop at window close). I'd rather **leave the log to self-expire** than touch `checkDomainObjectExists` (which risks the live path). OK to leave it, or do you want the window-scoped noise addressed too?

**3. Live-precedence assumption.** This skip assumes any `SUCCESS+FOLLOW` row seen *during reconciliation* is a re-follow issued after the UNFOLLOW — i.e. a legitimate UNFOLLOW against a confirmed FOLLOW is always processed by the live path *first*, never reaching orphan replay as its initial processing. Is that guaranteed? If a legacy/cross-mirror UNFOLLOW could have orphan replay as its *first* processing, this guard would wrongly skip it. I couldn't fully rule that out from the code and didn't want to assume it — flagging for your read.

---

The full read-only trace is on my node if you want more — the reproduced UNFOLLOW was `cawonce=46` (tx `0x8051a816…`), the re-follow that survived was `cawonce=47`, and the follow row held at `updated=17:15:51` across every tick after. Happy to also share the tip/RPC side-quests that came up during testing (a stale session tip and an L2 upstream flap) if useful, though they're orthogonal to this change.

/cc @tentencaw @zinsanjp — Ten, you nailed the layer-③ mechanism on the IME side; curious whether the `SUCCESS+FOLLOW` skip reads right to you here. Zin, same question on whether this collides with anything on your node.
