### PR TITLE
Guard FollowButton against unresolved (0/undefined) targetUserId befo…

### DIFF
--- a/client/src/services/FrontEnd/src/hooks/useFollowButton.ts
+++ b/client/src/services/FrontEnd/src/hooks/useFollowButton.ts
@@ -307,6 +307,16 @@ export function useFollowButton({
   const handleFollowClick = async () => {
     console.log('[FollowButton] handleFollowClick', { wrongWallet, isPending, isSigning, targetUserId, activeTokenId, activeTokenOwner: activeToken?.owner, connectedAddress: address, hasActiveSession })
     const effectiveTokenId = activeTokenId || activeToken?.tokenId
+
+    // Guard against an unresolved receiver: if targetUserId is 0/undefined
+    // (tokenId not yet resolved, or a stale prop), bail before signing.
+    // Without this, receiverId:0 is baked into the payload and an invalid
+    // FOLLOW is signed + enqueued. All call sites pass user.tokenId with no
+    // >0 check, so this hook-level guard is the shared backstop.
+    if (!targetUserId || targetUserId <= 0) {
+      console.log('[FollowButton] Early return — invalid targetUserId', { targetUserId })
+      return
+    }
     // Don't do anything if wrong wallet
     if (wrongWallet) {
       console.log('[FollowButton] Early return — wrongWallet')

--- a/client/src/services/FrontEnd/src/hooks/useFollowButton.ts
+++ b/client/src/services/FrontEnd/src/hooks/useFollowButton.ts
@@ -143,6 +143,18 @@ export function useFollowButton({
     const actionType = pendingActionRef.current
     const effectiveTokenId = activeToken.tokenId
 
+    // Same receiver guard as handleFollowClick, but for the wallet-connect
+    // resubmit path: this effect reads targetUserId from its closure and never
+    // re-checks it. If it was valid at click time but went stale/0 during the
+    // awaiting-connection window, an invalid FOLLOW would still be signed here.
+    if (!targetUserId || targetUserId <= 0) {
+      console.log('[FollowButton] Skipping wallet-connect resubmit — invalid targetUserId', { targetUserId })
+      isSubmittingRef.current = false
+      setAwaitingConnection(false)
+      pendingActionRef.current = null
+      return
+    }
+
     // Clear awaiting state immediately to prevent re-runs
     setAwaitingConnection(false)
     pendingActionRef.current = null


### PR DESCRIPTION
# Guard FollowButton against an unresolved (0/undefined) targetUserId

## What

Add a one-line early-return guard at the top of `handleFollowClick` (in `useFollowButton.ts`) that bails out before signing when `targetUserId` is `0` or falsy:

```ts
if (!targetUserId || targetUserId <= 0) {
  console.log('[FollowButton] Early return — invalid targetUserId', { targetUserId })
  return
}
```

## Why

On my node (`v2.nyaromesama.com`) I found a single stored FOLLOW action with `receiverId: 0` baked into the payload — a structurally invalid follow. Tracing it (read-only) showed the receiver value was already `0` at payload-construction time, so ingestion/validator are not at fault; the `0` originated on the frontend.

Root cause: `handleFollowClick`'s existing early-return guards are all **sender-side** (`wrongWallet`, `isPending`, `effectiveTokenId`/`activeToken`). There is no check on `targetUserId` (the receiver). When a caller renders a FollowButton while `user.tokenId` is briefly unresolved (`0`/undefined — e.g. during data hydration or a stale prop), that `0` flows straight through to `signAndSubmit({ ..., receiverId: targetUserId })` and an invalid FOLLOW gets signed and enqueued.

All call sites (`UserCard`, `FollowListModal`, `UserHoverCard`, etc.) pass `user.tokenId` with no `> 0` check, so a **hook-level guard is the shared backstop** — it protects every caller at once rather than scattering the same check across each render site.

## Scope / safety

- Pure input validation at the entry of the click handler; no change to signing, submission, or any existing branch.
- Only affects the case where the receiver id is invalid — a case that can only produce a broken action today.
- The polling condition later in the hook already references `!targetUserId`, but that runs *after* signing (status check), so it isn't a submit-time guard; this closes that gap.

## Frequency note

I originally framed this as a rare/one-off. Correcting that: @zinsanjp checked both their nodes and found 10 such rows — 8 on V1 (`caw_default`, spanning 2026-05-14 → 08-04, 6 SUCCESS / 2 FAILED) and 2 on V2, mostly SUCCESS/on-chain. So this is a **persistent receiver-side guard gap** that gets hit whenever token data is briefly unresolved at submit time, not a rare race.

There are **two** sign paths and both are now guarded:
1. `handleFollowClick` — the direct click path (first commit).
2. The wallet-connect resubmit `useEffect` (~L128) — reads `targetUserId` from its closure and never re-checks it before `signAndSubmit`, so a value valid at click but stale/0 by the time the wallet connects would slip through. Guarded in the follow-up commit (per @zinsanjp's review), unwinding the mid-submit state (`isSubmittingRef` / `awaitingConnection` / `pendingActionRef`) on bail.

The hook is the shared backstop for all call sites (`UserCard`, `FollowListModal`, `UserHoverCard`, etc.), which pass `user.tokenId` with no `> 0` check. Happy to add a call-site render guard too if preferred, but with both sign paths covered the hook should be complete.