### PR TITLE
fix(instance-registry): stop falling back to genesis when deploy block can't be resolved

### DIFF
--- a/client/src/services/InstanceRegistryService/index.ts
+++ b/client/src/services/InstanceRegistryService/index.ts
@@ -195,7 +195,7 @@ async function refreshPeers(
   provider: AbstractProvider,
   clientManagerAddress: string,
   networkId: number,
-): Promise<{ added: PeerInstance[]; changed: PeerInstance[] }> {
+): Promise<{ added: PeerInstance[]; changed: PeerInstance[]; skipped?: boolean }> {
   const iface = new Interface(cawNetworkManagerAbi)
   const regSig = iface.getEvent('InstanceRegistered')!.topicHash
   const updSig = iface.getEvent('InstanceUpdated')!.topicHash
@@ -224,15 +224,32 @@ async function refreshPeers(
     // Cold start: walk backward all the way to the NetworkManager deploy
     // block so we can't miss any historical registration (including this
     // node's own — see refreshPeers doc above). Resolve the deploy block
-    // once (binary search over eth_getCode); if it can't be resolved
-    // (transient RPC failure → 0), fall back to floor 0, which the
-    // maxWindows ceiling still bounds.
+    // once (binary search over eth_getCode).
+    //
+    // On failure, do NOT fall back to floor 0. That used to be the
+    // behavior here, and it silently turned a 7-window scan (deploy block
+    // to head, the normal case) into a 1000+ window scan from genesis --
+    // confirmed live on this node: managerDeployBlock resolves to
+    // 11,499,537 in steady state, but a transient upstream failure during
+    // the binary search (rate limit / circuit breaker mid-getCode) threw,
+    // landed here, and the resulting genesis walk is what a live eRPC
+    // capture actually caught -- requests as low as block ~4.1M, nowhere
+    // near the real deploy block. Firing ~600 requests at the RPC before
+    // it rate-limits and aborts (scanIncomplete = true) is itself likely
+    // to trigger the very failure that caused the fallback, so retrying
+    // immediately with the same bad managerDeployBlock=0 on every 60s tick
+    // repeats the same explosion indefinitely.
+    //
+    // Skip this tick's scan entirely instead: leave managerDeployBlock at
+    // -1 so the next tick's isCold branch retries resolution fresh, rather
+    // than caching a value this run couldn't actually establish.
     if (managerDeployBlock < 0) {
       try {
-        managerDeployBlock = await findContractDeployBlock(provider, clientManagerAddress, latestBlock)
+        const resolved = await findContractDeployBlock(provider, clientManagerAddress, latestBlock)
+        managerDeployBlock = resolved
       } catch (err: any) {
-        console.warn(`[InstanceRegistry] Could not resolve NetworkManager deploy block (${err?.message}); scanning from genesis floor`)
-        managerDeployBlock = 0
+        console.warn(`[InstanceRegistry] Could not resolve NetworkManager deploy block (${err?.message}); skipping this tick's scan, will retry next tick`)
+        return { added: [], changed: [], skipped: true }
       }
     }
     // maxWindows must be large enough to span deploy→head at the default
@@ -389,11 +406,31 @@ export const instanceRegistryService: Service = {
     let _signer: ValidatorSigner | null
     let _canRegister: boolean
     let _clientManager: Contract
+    // Set when the most recent refreshPeers() had to skip its scan
+    // (deploy-block resolution failed -- see refreshPeers). selfRegister()
+    // checks this before trusting an empty peerCache as "we're not
+    // registered yet": on the very first refresh, a skip means the cache
+    // was never actually populated, not that a genuinely-complete scan
+    // found nothing. Registering against an unpopulated cache is exactly
+    // the re-registration bug 2c1700b5 fixed (climbed from #3 to #22 in a
+    // day), so this flag exists to keep that fix intact through the
+    // skip-on-failure path added alongside it.
+    let _lastRefreshSkipped = false
+    // True until selfRegister() has actually run past its
+    // _lastRefreshSkipped guard once (i.e. run against a cache that was
+    // confirmed populated by a completed scan). Separate from instanceId
+    // being null, which can also be true after a completed, successful
+    // run (no prior registration found, about to register) -- this flag
+    // specifically tracks "has selfRegister ever had trustworthy data to
+    // act on", so the retry below fires exactly once the first time the
+    // cache becomes trustworthy, not on every tick while unregistered.
+    let _selfRegisterRanWithValidCache = false
 
     /** First refresh: populates the cache. Subsequent refreshes log diffs. */
     async function refreshAndLog() {
       try {
-        const { added, changed } = await refreshPeers(_provider, NETWORK_MANAGER_ADDRESS, networkId)
+        const { added, changed, skipped } = await refreshPeers(_provider, NETWORK_MANAGER_ADDRESS, networkId)
+        _lastRefreshSkipped = !!skipped
         for (const p of added) {
           console.log(
             `[InstanceRegistry] Peer discovered — instance #${p.instanceId} ` +
@@ -408,12 +445,27 @@ export const instanceRegistryService: Service = {
         }
       } catch (err: any) {
         console.warn(`[InstanceRegistry] Peer refresh failed (continuing): ${err.message}`)
+        // A thrown (rather than skipped) refresh also leaves the cache
+        // unconfirmed for the same reason -- treat it the same way.
+        _lastRefreshSkipped = true
       }
     }
 
     /** Self-registration. Reads the cache populated by refreshAndLog. */
     async function selfRegister() {
       if (!_canRegister || !_signer) return
+      // If the peer cache was never actually populated (the deploy-block
+      // resolution that would have scanned it failed or was skipped), an
+      // empty cache here doesn't mean "we're not registered" -- it means
+      // we don't know yet. Registering against that unconfirmed state is
+      // exactly the re-registration bug 2c1700b5 fixed. Bail and let the
+      // next periodic refresh (60s later, per pollIntervalMs) try again
+      // with a freshly-resolved deploy block.
+      if (_lastRefreshSkipped) {
+        console.warn('[InstanceRegistry] Skipping self-registration this tick — peer cache not yet confirmed complete (deploy block resolution failed); will retry next tick')
+        return
+      }
+      _selfRegisterRanWithValidCache = true
       const validatorAddress = _signer.getAddress()
       console.log(`[InstanceRegistry] Checking registration for network ${networkId}, validator ${validatorAddress}, url ${apiUrl}`)
 
@@ -501,9 +553,42 @@ export const instanceRegistryService: Service = {
       await selfRegister()
       // Kick off the periodic refresh. Subsequent ticks log only diffs
       // because the cache has the prior state.
+      //
+      // Also retries selfRegister() specifically when the startup call
+      // never got to run it (this tick's refreshAndLog() skipped its
+      // scan due to deploy-block resolution failure -- see the
+      // _lastRefreshSkipped guard in selfRegister, and the doc comment
+      // on _lastRefreshSkipped's declaration). selfRegister() was
+      // previously only ever called once, at startup, so a skip there
+      // meant this node would never retry registration for the rest of
+      // the process lifetime.
+      //
+      // Deliberately gated on _lastRefreshSkipped, not on instanceId
+      // alone: instanceId can legitimately stay null after a *completed*
+      // scan too (e.g. selfRegister found no existing entry and is about
+      // to registerInstance, or registration failed for an unrelated
+      // reason such as an RPC error on the transaction itself). Retrying
+      // selfRegister() on every tick in either of those cases would fire
+      // a fresh registerInstance() transaction each time -- the exact
+      // duplicate-registration bug 2c1700b5 fixed. Scoping this to "the
+      // scan that would have populated the cache never actually ran" is
+      // what makes the retry safe: it's not compensating for a real
+      // registration failure, only for the startup call never having had
+      // the data to act on in the first place.
       pollTimer = setInterval(() => {
         if (stopped) return
-        refreshAndLog().catch(() => { /* logged inside */ })
+        refreshAndLog()
+          .then(() => {
+            // Retry exactly once selfRegister() has never run against a
+            // confirmed-populated cache -- i.e. the startup call bailed
+            // via the _lastRefreshSkipped guard and no later tick has
+            // gotten past it yet. Once selfRegister() has run with valid
+            // data a single time (registered or not), this stops firing;
+            // whatever it decided then stands, same as the pre-existing
+            // startup-only behavior for every non-skip case.
+            if (!_selfRegisterRanWithValidCache && !_lastRefreshSkipped && _canRegister) return selfRegister()
+          })
+          .catch(() => { /* logged inside */ })
       }, pollIntervalMs)
     })()
 

--- a/client/src/services/InstanceRegistryService/index.ts
+++ b/client/src/services/InstanceRegistryService/index.ts
@@ -241,10 +241,24 @@ async function refreshPeers(
     // between registration clusters doesn't bail the walk early.
     const span = Math.max(0, latestBlock - managerDeployBlock)
     const neededWindows = Math.ceil(span / 10_000) + 2
+    // Spacing windows out (rather than firing ~600 eth_getLogs back-to-back
+    // as fast as the RPC responds, measured at ~150ms apart) meaningfully
+    // reduces the chance of self-inflicted rate limiting turning into a
+    // scanIncomplete abort. Deliberately kept small: refreshAndLog has no
+    // in-flight guard against the pollIntervalMs setInterval (default 60s),
+    // so a delay long enough to make one cold scan run past the next tick
+    // would let two scans overlap and race on managerDeployBlock/
+    // lastScannedBlock instead of just being slow. 50ms x a worst-case
+    // ~600 windows is ~30s, leaving headroom under the default 60s
+    // interval. Not measured against this node's actual rate limit
+    // threshold -- if scanIncomplete still fires regularly, raise this
+    // together with pollIntervalMs (or add an in-flight guard) rather than
+    // raising it alone.
     const allLogs = await scanLogsBackward(provider, clientManagerAddress, [allSigs], {
       fromBlock: managerDeployBlock,
       stopOnEmptyWindow: false,
       maxWindows: neededWindows,
+      delayMs: 50,
       onError: (from, to, err) => {
         scanIncomplete = true
         console.warn(`[InstanceRegistry] getLogs failed for ${from}..${to} during cold scan (peer list may be incomplete): ${(err as any)?.message ?? err}`)

--- a/client/src/services/InstanceRegistryService/index.ts
+++ b/client/src/services/InstanceRegistryService/index.ts
@@ -246,6 +246,30 @@ async function refreshPeers(
     if (managerDeployBlock < 0) {
       try {
         const resolved = await findContractDeployBlock(provider, clientManagerAddress, latestBlock)
+        // A 0 return here is a live signal, not just "genuinely
+        // undeployed": per @tentencaw's review, the caller can't actually
+        // tell those apart. findContractDeployBlock's own re-check (see
+        // its doc comment) already covers the transient-blip-at-head
+        // case, but a real answer of 0 for a contract we know is deployed
+        // (this whole function only runs because clientManagerAddress
+        // resolved to something) is not a state this scan should trust
+        // enough to walk genesis-to-head from. Treat it the same as the
+        // throw below: skip this tick rather than caching a value that
+        // would trigger the exact ~1,156-window explosion this fix exists
+        // to prevent.
+        if (resolved === 0) {
+          // Tradeoff worth being explicit about: if clientManagerAddress
+          // were ever genuinely misconfigured (pointing at a real address
+          // with no contract deployed there), this branch would skip
+          // forever rather than eventually accepting 0 as a real answer.
+          // Accepted deliberately -- clientManagerAddress is the protocol's
+          // core registry contract, expected to always exist in any real
+          // deployment, so treating an unexpected 0 as "still ambiguous"
+          // and refusing to act on it is the safer failure mode for a
+          // misconfiguration than silently walking genesis-to-head on it.
+          console.warn('[InstanceRegistry] NetworkManager deploy block resolved to 0 (ambiguous with a live RPC hiccup); skipping this tick\'s scan, will retry next tick')
+          return { added: [], changed: [], skipped: true }
+        }
         managerDeployBlock = resolved
       } catch (err: any) {
         console.warn(`[InstanceRegistry] Could not resolve NetworkManager deploy block (${err?.message}); skipping this tick's scan, will retry next tick`)
@@ -258,19 +282,29 @@ async function refreshPeers(
     // between registration clusters doesn't bail the walk early.
     const span = Math.max(0, latestBlock - managerDeployBlock)
     const neededWindows = Math.ceil(span / 10_000) + 2
-    // Spacing windows out (rather than firing ~600 eth_getLogs back-to-back
-    // as fast as the RPC responds, measured at ~150ms apart) meaningfully
+    // Spacing windows out (rather than firing eth_getLogs back-to-back as
+    // fast as the RPC responds, measured at ~150ms apart) meaningfully
     // reduces the chance of self-inflicted rate limiting turning into a
     // scanIncomplete abort. Deliberately kept small: refreshAndLog has no
     // in-flight guard against the pollIntervalMs setInterval (default 60s),
     // so a delay long enough to make one cold scan run past the next tick
     // would let two scans overlap and race on managerDeployBlock/
-    // lastScannedBlock instead of just being slow. 50ms x a worst-case
-    // ~600 windows is ~30s, leaving headroom under the default 60s
-    // interval. Not measured against this node's actual rate limit
-    // threshold -- if scanIncomplete still fires regularly, raise this
-    // together with pollIntervalMs (or add an in-flight guard) rather than
-    // raising it alone.
+    // lastScannedBlock instead of just being slow.
+    //
+    // The genesis-fallback fix above (skip rather than cache 0/incomplete
+    // state as managerDeployBlock) means the ~600-window case this
+    // constant was originally sized against (per @tentencaw's review,
+    // ~90s of scan time before delayMs is even added -- already past the
+    // 60s tick on its own) should no longer be reachable in the steady
+    // state. neededWindows is now ~7 in the common case (span ~50k blocks
+    // at the current deploy block), where 50ms of delay is negligible
+    // either way. Kept as a secondary safety margin for any other path
+    // that still reaches a large scan (e.g. a genuinely fresh deploy far
+    // from head) rather than as the primary defense it was originally
+    // written to be. Not measured against this node's actual rate limit
+    // threshold -- if scanIncomplete still fires regularly in that
+    // remaining case, raise this together with pollIntervalMs (or add an
+    // in-flight guard) rather than raising it alone.
     const allLogs = await scanLogsBackward(provider, clientManagerAddress, [allSigs], {
       fromBlock: managerDeployBlock,
       stopOnEmptyWindow: false,
@@ -371,7 +405,19 @@ async function refreshPeers(
   )
   const activations = ordered.map(o => ({ instanceId: o.instanceId, active: o.active }))
 
-  return await applyToCache(networkId, registered, updates, activations)
+  const applied = await applyToCache(networkId, registered, updates, activations)
+  // scanIncomplete means the log walk itself was cut short by an RPC
+  // error mid-scan (see onError above) -- applyToCache still writes
+  // whatever partial registered/updates/activations it received into
+  // peerCache unconditionally, so the cache silently ends up holding a
+  // truncated view rather than a complete one. That's precisely the
+  // 2c1700b5 shape ("a node re-registering because a truncated cold scan
+  // missed its own prior registration") in a different spot from the
+  // managerDeployBlock-resolution-failure case above. Folding it into the
+  // same skipped signal means selfRegister's _lastRefreshSkipped guard
+  // (which already exists for the resolution-failure case) covers this
+  // one too, without selfRegister needing to know the difference.
+  return { ...applied, skipped: scanIncomplete }
 }
 
 // =====================================================================

--- a/client/src/utils/chunkedLogs.ts
+++ b/client/src/utils/chunkedLogs.ts
@@ -56,6 +56,16 @@ export interface BackwardScanOptions extends ChunkedScanOptions {
    *  "genuinely zero events" — scanLogsBackward otherwise swallows the
    *  failure and returns whatever it has (possibly []). */
   onError?: (fromBlock: number, toBlock: number, err: unknown) => void
+  /** Backward scan only. Milliseconds to wait between windows. Default 0
+   *  (unchanged for existing callers). A cold-start walk over hundreds of
+   *  windows (e.g. the instance registry's deploy-block-to-head scan) can
+   *  otherwise fire eth_getLogs calls back-to-back as fast as the RPC
+   *  responds (~150ms apart on a fast provider), which is itself enough
+   *  request pressure to trigger the rate-limit errors that then abort the
+   *  walk via onError. Spacing windows out trades wall-clock time for a
+   *  meaningfully lower chance of self-inflicted rate limiting on a scan
+   *  this long. */
+  delayMs?: number
 }
 
 const DEFAULT_CHUNK = 10_000
@@ -144,6 +154,7 @@ export async function scanLogsBackward(
   const chunkBlocks = opts.chunkBlocks ?? DEFAULT_CHUNK
   const maxWindows = opts.maxWindows ?? DEFAULT_MAX_WINDOWS_BACKWARD
   const stopOnEmptyWindow = opts.stopOnEmptyWindow ?? true
+  const delayMs = opts.delayMs ?? 0
   const head = opts.toBlock ?? await provider.getBlockNumber()
   const floor = opts.fromBlock ?? 0
   const logs: Log[] = []
@@ -151,6 +162,9 @@ export async function scanLogsBackward(
   let toBlock = head
 
   for (let i = 0; i < maxWindows; i++) {
+    if (delayMs > 0 && i > 0) {
+      await new Promise(resolve => setTimeout(resolve, delayMs))
+    }
     const fromBlock = Math.max(floor, toBlock - chunkBlocks + 1)
     let windowLogs: Log[]
     try {

--- a/client/src/utils/chunkedLogs.ts
+++ b/client/src/utils/chunkedLogs.ts
@@ -221,7 +221,22 @@ export async function findContractDeployBlock(
   // Sanity check: contract must currently have code. If it doesn't, the
   // address was never deployed (or self-destructed) — return 0 so the
   // caller can decide what to do.
-  const headCode = await provider.getCode(address, head)
+  //
+  // Confirmed live: a single '0x' response here isn't reliable enough to
+  // conclude "never deployed" -- an RPC hiccup (stale/lagging node,
+  // momentary bad response) can return the same shape as a genuinely
+  // undeployed contract, and the only caller of this function
+  // (InstanceRegistryService) treats a 0 return as "deploy block is
+  // genesis" and scans the entire chain history as a result. Re-checking
+  // once before accepting '0x' costs one extra eth_getCode call in the
+  // common case (contract exists, first call already returns real code)
+  // and catches the transient-blip case without adding real latency to
+  // the genuinely-undeployed case (rare, and this function is only called
+  // once per process lifetime while managerDeployBlock is unresolved).
+  let headCode = await provider.getCode(address, head)
+  if (!headCode || headCode === '0x') {
+    headCode = await provider.getCode(address, head)
+  }
   if (!headCode || headCode === '0x') return 0
 
   // Standard binary search for the leftmost block where code !== '0x'.

--- a/client/tests/services/chunkedLogsBackward.test.ts
+++ b/client/tests/services/chunkedLogsBackward.test.ts
@@ -116,6 +116,39 @@ describe('scanLogsBackward — sparse-scatter fix', () => {
     const logs = await scanLogsBackward(provider, ADDR, TOPICS, { chunkBlocks: 10_000 })
     expect(logs.map((l: any) => l.blockNumber)).to.deep.equal([95_000])
   })
+
+  it('delayMs (default 0) does not add wall-clock time for existing callers', async () => {
+    const provider = makeProvider({
+      head: 30_000,
+      events: [{ block: 25_000 }, { block: 15_000 }, { block: 5_000 }],
+    })
+    const start = Date.now()
+    await scanLogsBackward(provider, ADDR, TOPICS, { chunkBlocks: 10_000, fromBlock: 0, stopOnEmptyWindow: false })
+    const elapsed = Date.now() - start
+    // 3 windows, no delayMs specified -- should complete near-instantly
+    // (fake provider has no real I/O latency). Generous bound to avoid
+    // flaking on a loaded CI box while still catching a regression that
+    // accidentally defaults delayMs to something nonzero.
+    expect(elapsed).to.be.lessThan(50)
+  })
+
+  it('delayMs spaces out windows by the given amount', async () => {
+    const provider = makeProvider({
+      head: 30_000,
+      events: [{ block: 25_000 }, { block: 15_000 }, { block: 5_000 }],
+    })
+    const start = Date.now()
+    await scanLogsBackward(provider, ADDR, TOPICS, {
+      chunkBlocks: 10_000,
+      fromBlock: 0,
+      stopOnEmptyWindow: false,
+      delayMs: 30,
+    })
+    const elapsed = Date.now() - start
+    // 3 windows -> 2 gaps between them (no delay before the first window,
+    // per the i > 0 guard) -> at least ~60ms of enforced delay.
+    expect(elapsed).to.be.gte(55)
+  })
 })
 
 describe('findContractDeployBlock', () => {

--- a/client/tests/services/chunkedLogsBackward.test.ts
+++ b/client/tests/services/chunkedLogsBackward.test.ts
@@ -163,4 +163,45 @@ describe('findContractDeployBlock', () => {
     const block = await findContractDeployBlock(provider, '0xManager', 100_000)
     expect(block).to.equal(0)
   })
+
+  it('re-checks a 0x-at-head response before concluding undeployed -- recovers from a single flaky reply', async () => {
+    // Live regression: a transient upstream blip returning '0x' for a
+    // contract that genuinely exists caused managerDeployBlock to resolve
+    // to 0, which then made InstanceRegistryService scan the entire chain
+    // history (1000+ windows) instead of the real ~7-window range. The
+    // fix re-checks getCode once before accepting '0x' as "never deployed".
+    let headCallCount = 0
+    const flaky = {
+      async getBlockNumber() { return 100_000 },
+      async getCode(_addr: string, block: number) {
+        if (block === 100_000) {
+          headCallCount++
+          // First call: simulate the transient blip (empty code).
+          // Second call: the real answer -- contract exists.
+          return headCallCount === 1 ? '0x' : '0xdeadbeef'
+        }
+        return block >= 42_000 ? '0xdeadbeef' : '0x'
+      },
+    } as any
+    const block = await findContractDeployBlock(flaky, '0xManager', 100_000)
+    expect(headCallCount).to.equal(2)
+    expect(block).to.equal(42_000)
+  })
+
+  it('still returns 0 when both head checks agree the contract is genuinely undeployed', async () => {
+    const provider = makeProvider({ head: 100_000, events: [], deployBlock: 200_000 })
+    let getCodeCalls = 0
+    const wrapped = {
+      ...provider,
+      async getCode(addr: string, block: number) {
+        getCodeCalls++
+        return provider.getCode(addr, block)
+      },
+    }
+    const block = await findContractDeployBlock(wrapped, '0xManager', 100_000)
+    expect(block).to.equal(0)
+    // Two calls at head (both '0x'), no binary search since the sanity
+    // check short-circuits before the loop.
+    expect(getCodeCalls).to.equal(2)
+  })
 })


### PR DESCRIPTION
## Root cause found (see thread below for the discovery process)

@tentencaw pointed out that a normal deploy-block resolution should only need ~7 windows, not the ~600 originally measured. That discrepancy led to the real root cause:

`managerDeployBlock` resolves cleanly to `11,499,537` in steady state (7 windows to head, confirmed by direct binary search against this node). But when `findContractDeployBlock` throws during its binary search -- confirmed live via this node's own error logs, `[InstanceRegistry] Could not resolve NetworkManager deploy block ... scanning from genesis floor`, fired by a circuit-breaker-open or rate-limit error mid `getCode` call -- the code fell into a `catch` block that set `managerDeployBlock = 0`. That turned `neededWindows` from 7 into roughly **1,156** (span to genesis instead of span to the real deploy block). A live eRPC capture during one of these episodes confirmed it directly: requests as low as block ~4.1M, nowhere near the real deploy block or the head.

Firing ~600 `getLogs` calls at the RPC before it rate-limits and aborts (`scanIncomplete = true`) is itself likely to trigger the same kind of failure that caused the fallback in the first place, so every subsequent 60s tick repeated the same explosion with `managerDeployBlock` cached at `0` in memory -- a self-sustaining loop until the process happened to restart into a moment where the RPC was briefly healthy.

## Fix (three changes, found and fixed in sequence while auditing this)

1. **`refreshPeers`**: on a resolution failure, skip this tick's scan entirely instead of caching `managerDeployBlock` as `0`. It stays at `-1`, so the next tick retries resolution fresh.

2. **`findContractDeployBlock`**: a single `0x` response at head is no longer enough to conclude "never deployed" -- re-checks once before returning `0`, since a transient upstream blip is indistinguishable from real non-deployment on a single call.

3. **`selfRegister` safety** (found during audit, not originally in scope): skipping the scan on failure means the peer cache might never get populated on the very first `refreshAndLog()` at startup -- `selfRegister()` was previously called exactly once, right after that first refresh, so an empty-because-skipped cache would have looked identical to "genuinely no prior registration" and re-registered a new instance. That's the exact duplicate-registration bug `2c1700b5` fixed (climbed from #3 to #22 in a day). Added a guard plus a bounded, one-time retry in the poll loop for the first tick that actually completes a scan.

None of these touch the retry-the-whole-scan-on-any-error design from `2c1700b5` -- all three are about not caching or acting on unconfirmed state, not about accepting incomplete scan results.

Keeping `delayMs: 50` from earlier commits as a secondary safety margin, layered on top rather than replaced -- it's a no-op in the common 7-window case, and still helps in any other path that legitimately reaches a large scan.

## Verification

`chunkedLogsBackward.test.ts` (12 cases, up from 10): two new cases cover `findContractDeployBlock`'s re-check behavior. The `selfRegister`/poll-retry logic isn't covered by a test -- `refreshPeers`/`selfRegister` are module-private with no test harness today; flagging the gap rather than leaving it silently uncovered.

zinsanjp