### PR TITLE
fix(raw-events): poll to one block below the head

### DIFF
--- a/client/src/services/RawEventsGatherer/listenForRawEvents.ts
+++ b/client/src/services/RawEventsGatherer/listenForRawEvents.ts
@@ -596,6 +596,23 @@ export default async function listenForRawEvents(
   // capped-RPC operator bounds both the historical chunk and the per-poll
   // range with one setting.
   const MAX_POLL_BLOCKS = L2_LOG_CHUNK_BLOCKS
+  // Poll to one block below the head rather than to the head itself.
+  //
+  // getBlockNumber and getLogs are separate calls, and with a
+  // FallbackProvider (quorum 1, first success wins) they can be answered by
+  // different upstreams. Measured on Base Sepolia across two providers:
+  // heads differ by one block about 17% of the time, never more, always in
+  // the same direction. When the higher one answers getBlockNumber and the
+  // lower one serves the getLogs, the range overshoots and the provider
+  // rejects it with -32602 "block range extends beyond current head block".
+  //
+  // Nothing is lost when that happens — lastSyncedBlock doesn't advance and
+  // the next tick re-requests the same range — but it puts a recoverable
+  // error in the log at the same severity as a real one. This margin
+  // removes that class at the skew this codebase can currently observe; a
+  // wider skew would still overshoot, and the underlying issue is mixing
+  // heads from providers that don't agree.
+  const HEAD_MARGIN_BLOCKS = 1
   // 30s default — actions are already shown in the feed optimistically as
   // soon as the user signs (PostForm's optimistic insert path), so the
   // indexer only sets the SUCCESS status flag a beat later. Stretching
@@ -618,9 +635,10 @@ export default async function listenForRawEvents(
     if (isStopped) return
     try {
       const currentBlock = await httpProvider.getBlockNumber()
-      if (currentBlock > lastSyncedBlock) {
-        const toBlock = Math.min(currentBlock, lastSyncedBlock + MAX_POLL_BLOCKS)
-        if (toBlock < currentBlock) {
+      const head = currentBlock - HEAD_MARGIN_BLOCKS
+      if (head > lastSyncedBlock) {
+        const toBlock = Math.min(head, lastSyncedBlock + MAX_POLL_BLOCKS)
+        if (toBlock < head) {
           console.log(`[RawEventsGatherer] Catching up: polling ${lastSyncedBlock + 1}..${toBlock} (behind by ${currentBlock - toBlock} blocks)`)
         } else {
           console.log(`[RawEventsGatherer] Polling for events ${lastSyncedBlock + 1}..${toBlock}`)
@@ -661,7 +679,7 @@ export default async function listenForRawEvents(
         lastSyncedBlock = toBlock
       }
       // Always publish the current high-water mark — even on a quiet poll
-      // (no new events, toBlock equals currentBlock), the indexer is up
+      // (no new events, toBlock equals head), the indexer is up
       // to that block and that's the freshness signal the validator needs.
       recordIndexerProgress(config.chainId, lastSyncedBlock)
       config.onTick?.()

--- a/client/src/services/RawEventsGatherer/listenForRawEvents.ts
+++ b/client/src/services/RawEventsGatherer/listenForRawEvents.ts
@@ -10,6 +10,31 @@ import { unpackActions } from '../../utils/packActions'
 import { span } from '../../utils/trace'
 import { recordIndexerProgress } from '../../utils/indexerHealth'
 
+/**
+ * Decide the block range for one poll.
+ *
+ * `headMargin` keeps the request below the head that getBlockNumber
+ * reported: under a FallbackProvider (quorum 1) that call and the
+ * following getLogs can be served by different upstreams, and the one
+ * answering getLogs may be a block behind — which the provider rejects
+ * as -32602 "block range extends beyond current head block".
+ *
+ * Returns null when there is nothing to fetch. The margin has to apply
+ * to that decision as well as to `toBlock`: comparing lastSyncedBlock
+ * against the unadjusted head would let `from > to` through whenever the
+ * cursor sits inside the margin.
+ */
+export function computePollRange(
+  currentBlock: number,
+  lastSyncedBlock: number,
+  headMargin: number,
+  maxPollBlocks: number,
+): { head: number; toBlock: number } | null {
+  const head = currentBlock - headMargin
+  if (head <= lastSyncedBlock) return null
+  return { head, toBlock: Math.min(head, lastSyncedBlock + maxPollBlocks) }
+}
+
 // Calldata-decode interface. ActionsProcessed events now carry only
 // (networkId, validatorId, actionCount, batchHash) — the actual packedActions
 // bytes live in the originating tx's calldata. We fetch tx.input via
@@ -612,7 +637,11 @@ export default async function listenForRawEvents(
   // removes that class at the skew this codebase can currently observe; a
   // wider skew would still overshoot, and the underlying issue is mixing
   // heads from providers that don't agree.
-  const HEAD_MARGIN_BLOCKS = 1
+  // Default 1. Operators whose upstreams drift further apart can raise it;
+  // 0 restores the previous behaviour of polling to the head itself.
+  const envHeadMargin = Number(process.env.RAW_EVENTS_HEAD_MARGIN)
+  const HEAD_MARGIN_BLOCKS =
+    Number.isFinite(envHeadMargin) && envHeadMargin >= 0 ? envHeadMargin : 1
   // 30s default — actions are already shown in the feed optimistically as
   // soon as the user signs (PostForm's optimistic insert path), so the
   // indexer only sets the SUCCESS status flag a beat later. Stretching
@@ -635,9 +664,9 @@ export default async function listenForRawEvents(
     if (isStopped) return
     try {
       const currentBlock = await httpProvider.getBlockNumber()
-      const head = currentBlock - HEAD_MARGIN_BLOCKS
-      if (head > lastSyncedBlock) {
-        const toBlock = Math.min(head, lastSyncedBlock + MAX_POLL_BLOCKS)
+      const range = computePollRange(currentBlock, lastSyncedBlock, HEAD_MARGIN_BLOCKS, MAX_POLL_BLOCKS)
+      if (range) {
+        const { head, toBlock } = range
         if (toBlock < head) {
           console.log(`[RawEventsGatherer] Catching up: polling ${lastSyncedBlock + 1}..${toBlock} (behind by ${currentBlock - toBlock} blocks)`)
         } else {

--- a/client/tests/services/pollRange.test.ts
+++ b/client/tests/services/pollRange.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai'
+import { computePollRange } from '../../src/services/RawEventsGatherer/listenForRawEvents'
+
+// The poll asks getBlockNumber for the head, then getLogs for a range
+// ending at it. Under a FallbackProvider those two calls can land on
+// different upstreams, so the range is kept a margin below the reported
+// head. These cover the arithmetic that does it.
+describe('computePollRange', () => {
+  const MAX = 1500
+
+  it('polls to headMargin below the reported head', () => {
+    const r = computePollRange(1000, 900, 1, MAX)
+    expect(r).to.deep.equal({ head: 999, toBlock: 999 })
+  })
+
+  it('returns null when the cursor sits inside the margin', () => {
+    // Without applying the margin to this comparison too, the caller
+    // would build fromBlock=1000, toBlock=999 — an inverted range.
+    expect(computePollRange(1000, 999, 1, MAX)).to.equal(null)
+  })
+
+  it('returns null when already synced to the adjusted head', () => {
+    expect(computePollRange(1000, 1000, 1, MAX)).to.equal(null)
+    expect(computePollRange(1000, 1200, 1, MAX)).to.equal(null)
+  })
+
+  it('caps the range at maxPollBlocks when far behind', () => {
+    const r = computePollRange(1_000_000, 0, 1, MAX)
+    expect(r).to.deep.equal({ head: 999_999, toBlock: MAX })
+  })
+
+  it('margin 0 reproduces the pre-margin behaviour', () => {
+    expect(computePollRange(1000, 999, 0, MAX)).to.deep.equal({ head: 1000, toBlock: 1000 })
+  })
+
+  it('honours a wider margin', () => {
+    expect(computePollRange(1000, 900, 2, MAX)).to.deep.equal({ head: 998, toBlock: 998 })
+    expect(computePollRange(1000, 998, 2, MAX)).to.equal(null)
+  })
+})


### PR DESCRIPTION
`poll()` reads the head with `getBlockNumber` and then requests logs up to
it. Those are two calls, and under a `FallbackProvider` (quorum 1, first
success wins) they can be answered by different upstreams. When the one
that's ahead answers `getBlockNumber` and the one that's behind serves the
`getLogs`, the range overshoots:

    -32602 block range extends beyond current head block:
    requested 45839407, head 45839406

## How wide is the skew

I sampled both of my L2 upstreams two seconds apart, 18 times: 3 samples one
block apart, 15 identical, never wider, never in the other direction.

That measurement was falsified the same day by my own node. After deploying
the margin I still got one failure, `requested 45858099, head 45858098`,
which puts `currentBlock` at 45858100 — a two-block skew. So 36 seconds of
sampling doesn't characterise this, and one block is the skew I happened to
catch rather than a bound.

The margin is set from what I could measure while knowing that's a floor,
not a ceiling. `RAW_EVENTS_HEAD_MARGIN` overrides it for operators whose
upstreams drift further; `0` restores the previous behaviour.

## What it costs today

No data. `lastSyncedBlock` doesn't advance on the failure and the next tick
re-requests the same range, so nothing is lost — the poll is a few seconds
late.

The cost is the log. Before the change, on this node:

    127 occurrences in 17 hours    (roughly one every 8 minutes)

Each is a `[RawEventsGatherer] Polling error:` with a full ethers stack, at
the same severity as a genuine upstream failure. Operators diagnose these
nodes by grepping logs, and a recoverable error every 8 minutes makes the
real ones harder to find. It also reaches the stall path: one of the three
degraded-loop warnings I looked at this week was this error rather than an
actual RPC problem.

## After

    1 occurrence in 27 hours

Stating the obvious caveat: those are adjacent windows on one node, not a
controlled comparison. The "before" window includes a stretch where the
upstream was returning 503s, so some of the drop could be the upstreams
simply agreeing more often. What the mechanism guarantees is narrower and
provable from the code — a request that ends a block below the reported head
cannot overshoot a provider that is one block behind — and the counts are
consistent with that rather than evidence for it.

The extracted form has been running on my node for the past few hours today; poll ranges
are contiguous across ticks (`…45906088` → `45906089…` → `45906104…`) and no
`Catching up` line appears when the node is merely a block behind the tip.

## The change

`computePollRange` decides the range; `poll()` calls it. Extracted so the
arithmetic can be tested against the real function rather than a copy of it.

The margin applies to the "is there anything to fetch" comparison as well as
to `toBlock`. Without that, `lastSyncedBlock === currentBlock - 1` produces
`fromBlock > toBlock`. The `Catching up` log's condition moves to `head` too,
so a poll that's merely a block behind the tip isn't reported as catching up.

`pollRange.test.ts`, 6 cases: margin applied, the inverted-range guard,
already-synced, the `MAX_POLL_BLOCKS` cap, margin 0 reproducing the old
behaviour, and a wider margin.

They pass under `npx mocha --import=tsx tests/services/pollRange.test.ts`.
They do not run under `yarn test`, which is `tsc --noEmit && mocha` and
currently fails at the `tsc` step on a pre-existing unresolved import
(`@ethersproject/abstract-provider` at `listenForRawEvents.ts:3` — not in
`package.json`, not installed). That predates this branch and is on `v2`
too; I tried swapping it for ethers v6's own `Log` and it cascades
(`logIndex` missing, a readonly/mutable mismatch), so I left it alone rather
than widen this PR into a dependency change.

Indexing lands one block later, about two seconds on Base, against a 30s
poll interval.

`recordIndexerProgress` therefore publishes a high-water mark one block
lower. The only consumer is the validator's `tolerableLag`, which floors at
`600s × throughput × 1.5` — at least 450 blocks on this chain — so one block
is not near anything.

## Scope

Poll path only. The historical scan also walks to `latest` and has the same
structural exposure, but the failure surfaces differently: `scanLogsForward`
throws, and the `while` loop around it catches into

    console.error('[RawEventsGatherer] Error fetching past events, retrying in 5s', err)

with a 5s retry — so it never reaches a startup failure, and it doesn't
recur the way a per-tick poll does.

Checked that log line rather than the `-32602` text: 24 occurrences on my
node, none carrying `beyond current head`. 23 are `server response 503
Service Unavailable`, one a 504, and 20 of the 24 fall on a single day. So
the scan path isn't producing this error here — measured, not inferred — and
a once-per-startup occurrence that self-heals in 5s wouldn't justify widening
the change.

This doesn't address why a node mixes head values from providers that don't
agree with each other. It's a margin, not a fix for that.
