### PR TITLE
fix(pins): unpin post and recompute pinnedCawCount when hiding a pinned caw

### DIFF
--- a/client/src/api/routes/caws.ts
+++ b/client/src/api/routes/caws.ts
@@ -248,18 +248,21 @@ router.get('/', async (req, res) => {
         // Suppress rows with a pending xpi: in flight so the optimistic
         // unpin is reflected on refresh, not just on the FE in-memory
         // state. The indexer deletes the row on confirm.
-        where: { userId: targetUserId, pendingUnpin: false },
+        // Also only fetch pins for active caws so ghost pins don't occlude visible ones.
+        where: {
+          userId: targetUserId,
+          pendingUnpin: false,
+          caw: { status: 'SUCCESS' },
+        },
         orderBy: { createdAt: 'desc' },
         take: 3,
         include: {
           caw: { include: getCawIncludeConfig({ currentUserId }) },
         },
       })
-      // Filter to caws still in SUCCESS status (a hidden / failed caw
-      // shouldn't show on the profile even if pinned).
       pinnedCaws = pins
         .map(p => p.caw)
-        .filter(c => c && c.status === 'SUCCESS')
+        .filter((c): c is NonNullable<typeof c> => c != null)
       if (pinnedCaws.length > 0) {
         const ids = pinnedCaws.map(c => c.id)
         if (where.AND) where.AND.push({ id: { notIn: ids } })

--- a/client/src/api/routes/pins.ts
+++ b/client/src/api/routes/pins.ts
@@ -64,9 +64,9 @@ router.post('/:cawId', async (req, res) => {
 
     const target = await prisma.caw.findUnique({
       where: { id: cawId },
-      select: { userId: true },
+      select: { userId: true, status: true },
     })
-    if (!target) return res.status(404).json({ error: 'Post not found' })
+    if (!target || target.status !== 'SUCCESS') return res.status(404).json({ error: 'Post not found' })
     if (target.userId !== userId) {
       return res.status(403).json({ error: 'You can only pin your own posts' })
     }

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -1568,12 +1568,11 @@ async function handleHideAction(
       return
     }
 
-    // Read imageData BEFORE flipping status so we know which URLs were
-    // attached to the post. These get queued for delayed deletion (7-day
-    // grace, see orphanedMedia.ts) so revertable hides don't lose data.
+    // Read target info (including id for pinned caw cleanup) BEFORE flipping
+    // status. ImageData gets queued for delayed deletion (7-day grace).
     const target = await tx.caw.findFirst({
       where:  { userId: senderId, cawonce, status: 'SUCCESS' },
-      select: { imageData: true },
+      select: { id: true, imageData: true },
     })
 
     const result = await tx.caw.updateMany({
@@ -1583,6 +1582,17 @@ async function handleHideAction(
 
     if (result.count > 0) {
       console.log(`[handleHideAction] Hidden caw: user=${senderId} cawonce=${cawonce}`)
+      // If the post was pinned to profile, remove the pin and recompute
+      // pinnedCawCount so the 3/3 slot isn't permanently deadlocked.
+      if (target?.id) {
+        const deletedPin = await tx.pinnedCaw.deleteMany({
+          where: { userId: senderId, cawId: target.id }
+        })
+        if (deletedPin.count > 0) {
+          await recomputePinnedCount(tx, senderId)
+          console.log(`[handleHideAction] Unpinned hidden caw: user=${senderId} cawId=${target.id}`)
+        }
+      }
       // Best-effort, fire-and-forget — Redis errors don't fail the hide.
       markOrphansInImageData(target?.imageData).catch(e =>
         console.warn('[handleHideAction] markOrphansInImageData failed:', e)
@@ -1657,10 +1667,10 @@ async function handlePinAction(
 
   const target = await tx.caw.findUnique({
     where: { id: cawId },
-    select: { userId: true },
+    select: { userId: true, status: true },
   })
-  if (!target) {
-    console.warn(`[handlePinAction] Caw not found: id=${cawId}`)
+  if (!target || target.status !== 'SUCCESS') {
+    console.warn(`[handlePinAction] Caw not found or not active: id=${cawId}`)
     return
   }
   if (target.userId !== senderId) {

--- a/client/src/utils/pinnedCount.ts
+++ b/client/src/utils/pinnedCount.ts
@@ -27,7 +27,12 @@ type Tx = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0]
  */
 export async function recomputePinnedCount(tx: Tx, userId: number): Promise<void> {
   const n = await tx.pinnedCaw.count({
-    where: { userId, pending: false, pendingUnpin: false },
+    where: {
+      userId,
+      pending: false,
+      pendingUnpin: false,
+      caw: { status: 'SUCCESS' },
+    },
   })
   await tx.user.update({
     where: { tokenId: userId },


### PR DESCRIPTION
## Summary

Fixes a deadlock where hiding/deleting a pinned post permanently occupies a `pinnedCawCount` slot (up to the 3/3 cap), because `PinnedCaw` rows were never removed on hide, and hidden posts are invisible on the UI — so there was no way to manually unpin them.

## Background

1. Deleting a post (`hide:caw:{cawonce}`) flips `Caw.status` to `HIDDEN`.
2. `handleHideAction` never deleted the corresponding `PinnedCaw` row or recomputed `pinnedCawCount`.
3. The UI only renders `status === 'SUCCESS'` posts, so the hidden post disappears entirely — including from the pin management UI.
4. `User.pinnedCawCount` stays incremented forever. After 3 such deletions, all pin slots are permanently stuck, and the frontend's `atCap` check (`FeedItem.tsx`) disables the pin button entirely, so there is no client-triggerable path to recovery.

## Fix

1. `handleHideAction`: in the same transaction as the status flip, delete the matching `PinnedCaw` row and call `recomputePinnedCount`.
2. `recomputePinnedCount`: only count rows where the target caw is `SUCCESS`, so future drift from any other code path self-corrects the next time a pin/unpin action runs for that user.
3. `handlePinAction` / `POST /api/pins/:cawId`: reject pinning a non-`SUCCESS` caw.
4. Profile feed query (`caws.ts`): filter `caw: { status: 'SUCCESS' }` at the DB level so a ghost pin can't occlude visible ones.

## Production Verification

- Reproduced on `cawnest.com`: pinned post `id: 307`, deleted it, confirmed `PinnedCaw` row persisted and `pinnedCawCount` stayed stuck at 1 (pre-fix).
- Applied fix live, created post `id: 309`, pinned + deleted it: `Caw` flipped to `HIDDEN`, `User.pinnedCawCount` automatically reset to `0` in the same transaction. Confirmed via direct DB query.

## Notes for reviewers

- **Scope of "self-healing"**: `recomputePinnedCount`'s `SUCCESS`-filter only fires when a pin/unpin action actually runs. A user already stuck at 3/3 with *all three* slots being ghosts cannot trigger it (frontend `atCap` disables the pin button). If at least one slot is a legitimate pin, unpinning it does trigger recompute and clears the ghosts too. Production audit (2026-08-26, both V1 and V2) found zero users in the fully-stuck state — no backfill included in this PR.
- **Known residual race (not fixed here)**: `handlePinAction` and `handleHideAction` run in separate transactions at default (READ COMMITTED) isolation. A pin and a hide racing on the same caw at the exact same moment could theoretically recreate a single ghost row. Judged low-probability / low-impact enough not to warrant a stricter isolation level or extra locking in this PR; flagging for visibility.
- **Pre-existing, unrelated `tsc --noEmit` error**: `origin/v2` currently fails `tsc --noEmit` with one pre-existing error (`Cannot find module '@ethersproject/abstract-provider'` in `listenForRawEvents.ts`), which PR #63 already fixes upstream but hasn't landed on `v2` yet. Verified this branch introduces zero additional type errors beyond that one.
- No new unit tests added; verification was direct production DB inspection (see above). Happy to add coverage for `recomputePinnedCount` / `handleHideAction` if preferred before merge.


zinsanjp