### PR TITLE
fix(instance-registry): use fallback-aware L1 provider to avoid single-RPC startup dependency

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -9,9 +9,19 @@ DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/caw_v2_local
 L1_RPC_URL="wss://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY"
 L1_RPC_URL_HTTP="https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY"
 
+# Optional comma-separated fallback L1 HTTP RPC URLs, tried in order if the
+# primary above is unreachable (used by RawEventsGatherer, ValidatorService,
+# and InstanceRegistryService). Positional L1_RPC_SECRET_FALLBACK (comma-
+# separated) supplies matching auth secrets if the fallback URLs need them.
+# L1_RPC_URL_HTTP_FALLBACK="https://ethereum-sepolia-rpc.publicnode.com"
+
 # L2 RPC URLs (Base Sepolia for testnet, Base Mainnet for production)
 L2_RPC_URL="wss://base-sepolia.infura.io/ws/v3/YOUR_API_KEY"
 L2_RPC_URL_HTTP="https://base-sepolia.infura.io/v3/YOUR_API_KEY"
+
+# Optional comma-separated fallback L2 HTTP RPC URLs (same mechanism as
+# L1_RPC_URL_HTTP_FALLBACK above).
+# L2_RPC_URL_HTTP_FALLBACK="https://base-sepolia-rpc.publicnode.com"
 
 # Ethereum Mainnet RPC (for Uniswap price feeds)
 ETH_MAINNET_RPC_URL="https://mainnet.infura.io/v3/YOUR_API_KEY"

--- a/client/src/services/InstanceRegistryService/index.ts
+++ b/client/src/services/InstanceRegistryService/index.ts
@@ -21,7 +21,7 @@ import { z } from 'zod'
 import 'dotenv/config'
 import { Service } from '../../Service'
 import { Contract, AbstractProvider, Interface } from 'ethers'
-import { makeVerifiedJsonRpcProvider, getL1HttpRpcUrl } from '../../utils/rpcProvider'
+import { makeVerifiedFallbackJsonRpcProvider, getL1HttpRpcUrls } from '../../utils/rpcProvider'
 import { getValidatorSigner, type ValidatorSigner } from '../../utils/signer'
 import { scanLogsBackward, findContractDeployBlock } from '../../utils/chunkedLogs'
 import { cawNetworkManagerAbi } from '../../abi/generated'
@@ -357,7 +357,8 @@ export const instanceRegistryService: Service = {
 
   start(rawCfg, _ctx) {
     const cfg = InstanceRegistryConfig.parse(rawCfg)
-    const l1RpcUrl = getL1HttpRpcUrl() || cfg.l1RpcUrl
+    const configuredL1RpcUrls = getL1HttpRpcUrls()
+    const l1RpcUrls = configuredL1RpcUrls.length > 0 ? configuredL1RpcUrls : [cfg.l1RpcUrl]
     const networkId = Number(getNetworkId() || cfg.networkId || cfg.clientId)
     const apiUrl = process.env.INSTANCE_API_URL || cfg.apiUrl
     const pollIntervalMs = cfg.pollIntervalMs ?? 60_000
@@ -471,7 +472,7 @@ export const instanceRegistryService: Service = {
     const started = (async () => {
       // Chain-ID-verified provider construction (async probe). Falls through
       // with a warning on transient RPC failure — service stays up.
-      _provider = await makeVerifiedJsonRpcProvider(l1RpcUrl, expectedL1ChainId)
+      _provider = await makeVerifiedFallbackJsonRpcProvider(l1RpcUrls, expectedL1ChainId)
       _signer = getValidatorSigner({ provider: _provider as any })
       _canRegister = !!(_signer && apiUrl)
       if (!_signer) {


### PR DESCRIPTION
## Summary

`InstanceRegistryService`'s L1 provider construction was the last caller still using the single-provider `makeVerifiedJsonRpcProvider` + singular `getL1HttpRpcUrl()`. A dead/throttled primary L1 RPC currently blocks this service's entire startup sequence, with no fallback -- real precedent: a dRPC free-tier Sepolia cutoff on 2026-08-06 caused repeated restarts across V1/V2 until an operator manually switched providers.

## Background

- `RawEventsGatherer` and `ValidatorService` already route through `makeVerifiedFallbackJsonRpcProvider` + `getL1HttpRpcUrls()` (plural), which build a `FallbackProvider` (quorum 1, first-success-wins) over the primary URL plus any `L1_RPC_URL_HTTP_FALLBACK` entries.
- `InstanceRegistryService` was the one service that hadn't picked this up -- still on `makeVerifiedJsonRpcProvider(l1RpcUrl, ...)` with a single hardcoded URL.
- No new failover mechanism needed; this is a switch to existing, already-proven infrastructure.

## Fix

- Swap `getL1HttpRpcUrl()` → `getL1HttpRpcUrls()` and `makeVerifiedJsonRpcProvider` → `makeVerifiedFallbackJsonRpcProvider` in `InstanceRegistryService.start()`.
- `configuredL1RpcUrls` falls back to `[cfg.l1RpcUrl]` only when `getL1HttpRpcUrls()` returns `[]` entirely (no env var set at all) -- preserves prior behavior for that case.
- Documented `L1_RPC_URL_HTTP_FALLBACK` / `L2_RPC_URL_HTTP_FALLBACK` in `.env.example` -- these already worked (read by `RawEventsGatherer`/`ValidatorService` before this branch) but were never mentioned there, easy to miss the mechanism exists at all.

## Verification

- `tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2` -- `@ethersproject/abstract-provider` in `listenForRawEvents.ts`, already fixed by #63 upstream but not yet landed on `v2`).
- Live-verified against this node's actual `L1_RPC_URL_HTTP`: with the primary made unreachable and `L1_RPC_URL_HTTP_FALLBACK` pointed at PublicNode, `makeVerifiedFallbackJsonRpcProvider` connected via the fallback and resolved the correct chainId (11155111).
- No unit tests exist for `rpcProvider.ts` / `InstanceRegistryService` currently -- the above was manual verification, not automated.

## Notes for reviewers

- **Quorum / cost check**: `makeFallbackJsonRpcProvider` uses `quorum: 1` (first-success-wins), so normal operation with the primary healthy doesn't double RPC calls -- confirmed by reading the implementation, not just its doc comment.
- **Startup-time dead primary**: `verifyChainId`'s probe only targets `urls[0]` (the primary) and, on probe failure, logs a warning and returns rather than throwing -- so a primary that's dead *at startup* doesn't block construction; the actual RPC traffic goes through `FallbackProvider` regardless, which does route around it. This existing behavior (probe failure is non-fatal) predates this PR and applies equally to the single-provider path; not something this PR changes.
- This closes the gap noted in `PROJECT_BACKLOG.md`'s "RPC fallback support" item for `InstanceRegistryService` specifically -- the broader mechanism it describes (`makeFallbackJsonRpcProvider` et al.) was already implemented and in use elsewhere; the backlog entry predates that and is now stale for this part.
- No immediate behavior change for nodes that don't set `L1_RPC_URL_HTTP_FALLBACK` (this repo's own `.env` doesn't currently set it either) -- this PR only makes the fallback path available; operators opt in by setting the env var.

---

zinsanjp