### PR TITLE
fix(api): populate feed post tipCount from _count.tips aggregate

### DIFF
--- a/client/src/api/routes/hashtags.ts
+++ b/client/src/api/routes/hashtags.ts
@@ -60,13 +60,15 @@ router.get('/:tag/caws', async (req, res) => {
             hashtags: {
               include: { hashtag: { select: { name: true } } }
             },
+            _count: { select: { tips: { where: { pending: false } } } },
             parent: {
               include: {
                 user: { select: { tokenId: true, username: true, displayName: true, image: true, avatarUrl: true, defaultAvatarId: true } },
                 poll: { select: { id: true, options: true, optionImages: true, totalVotes: true } },
                 hashtags: {
                   include: { hashtag: { select: { name: true } } }
-                }
+                },
+                _count: { select: { tips: { where: { pending: false } } } }
               }
             }
           }

--- a/client/src/api/shared/cawUtils.ts
+++ b/client/src/api/shared/cawUtils.ts
@@ -214,7 +214,7 @@ export function shapeCaw(raw: CawRaw | any): ShapedCaw {
     hasReplied, // Only true if replied AND confirmed
     hasTipped,
     tipPending,
-    tipCount: raw.tipCount ?? 0,
+    tipCount: raw._count?.tips ?? raw.tipCount ?? 0,
     totalTipAmount: raw.totalTipAmount ?? 0,
     replyPending,
     isBookmarked: raw.bookmarks ? raw.bookmarks.length > 0 : undefined,

--- a/client/src/api/shared/cawUtils.ts
+++ b/client/src/api/shared/cawUtils.ts
@@ -332,6 +332,7 @@ export function getCawIncludeConfig(options: CawQueryOptions = {}) {
           ? { where: { userId: currentUserId }, select: { userId: true }, take: 1 }
           : false,
         poll: { select: { id: true, options: true, optionImages: true, totalVotes: true } },
+        _count: { select: { tips: { where: { pending: false } } } },
         ...(includeHashtags && {
           hashtags: {
             include: { hashtag: { select: { name: true } } }

--- a/client/src/api/shared/cawUtils.ts
+++ b/client/src/api/shared/cawUtils.ts
@@ -214,7 +214,7 @@ export function shapeCaw(raw: CawRaw | any): ShapedCaw {
     hasReplied, // Only true if replied AND confirmed
     hasTipped,
     tipPending,
-    tipCount: raw._count?.tips ?? raw.tipCount ?? 0,
+    tipCount: raw.tipCount ?? raw._count?.tips ?? 0,
     totalTipAmount: raw.totalTipAmount ?? 0,
     replyPending,
     isBookmarked: raw.bookmarks ? raw.bookmarks.length > 0 : undefined,
@@ -294,7 +294,7 @@ export function getCawIncludeConfig(options: CawQueryOptions = {}) {
     tips: currentUserId
       ? { where: { senderId: currentUserId }, select: { senderId: true, pending: true }, take: 1 }
       : false,
-    _count: { select: { tips: true } },
+    _count: { select: { tips: { where: { pending: false } } } },
     bookmarks: currentUserId
       ? { where: { userId: currentUserId }, select: { userId: true }, take: 1 }
       : false,


### PR DESCRIPTION
## Summary

Fixes `tipCount` always evaluating to `0` in feed responses (`/api/caws`), and along the way found and fixed two related gaps: a pending-tip inclusion bug that the original one-line fix would have introduced, and two other code paths (embedded parent caws, hashtag feed) that never picked up tip counts at all.

## Background & Root Cause

`getCawIncludeConfig` selects `_count: { select: { tips: true } }` on feed queries, but `shapeCaw` was reading the non-existent `raw.tipCount` instead of `raw._count?.tips`, so it always fell back to `0`. The single-post route (`/api/caws/:id`) worked correctly because it separately computes `tipAgg` (with `pending: false`) and assigns it onto `raw.tipCount` before calling `shapeCaw` — masking the bug there while feeds stayed broken.

## Fix

**1. Priority order (not just presence) matters:**
```typescript
tipCount: raw.tipCount ?? raw._count?.tips ?? 0,
```
The naive fix (`raw._count?.tips ?? raw.tipCount ?? 0`) would have shadowed the single-post route's explicit `pending`-excluded aggregate with `_count.tips`, which had no `pending` filter — silently counting unconfirmed tips on post-detail pages the moment any existed. Flipped the order so the explicit aggregate wins when present, and `_count.tips` only fills in for routes that never set `raw.tipCount`.

**2. `_count.tips` needs the same `pending: false` filter as the explicit aggregate:**
```typescript
_count: { select: { tips: { where: { pending: false } } } },
```
So feed-list results match single-post semantics regardless of which fallback branch is hit.

**3. Two more code paths had the same root gap (`_count.tips` missing entirely):**
- `getCawIncludeConfig`'s nested `parent` include (renders the quoted/replied-to post inline) — a parent's tip count was always `0` wherever shown embedded.
- `hashtags.ts` builds its own include from scratch instead of using `getCawIncludeConfig`, for both the caw and its parent — same gap.

Confirmed no other route file querying `Caw` rows (`og.ts`, `actions.ts`, `search.ts`, `notifications.ts`, `pins.ts`, `moderation.ts`, `sitemap.ts`) calls `shapeCaw`, so `tipCount` isn't in their response shape — no further gaps.

## Verification (live on `cawnest.com`)

- **Feed-list fix**: `/api/caws/313` (single-post) and `/api/caws` (feed) both return `tipCount: 3` → `4` after a new tip confirmed, matching throughout.
- **Pending-exclusion, specifically**: this node had 0 pending tips at the time, so ran a rolled-back transaction with 2 confirmed + 1 pending tip on a test post — both the feed-list `_count.tips` path and the single-post `tipAgg` path returned `2` (excluding pending) and matched. Zero rows persisted afterward (confirmed by direct count).
- **Parent case**: caw `314` quotes caw `313` (4 confirmed tips). Before the fix, `GET /api/caws/314` returned `parent.tipCount: 0`; after applying and restarting, returns `4`.
- **Hashtag case**: no existing tipped+hashtagged post on this node to test against directly, so ran a rolled-back transaction reproducing `hashtags.ts`'s exact include shape with a tagged post + 2 confirmed tips — returned `_count.tips: 2` as expected. Zero rows persisted afterward.

## Notes for reviewers

- A frontend issue was also surfaced while testing (tip count doesn't update in the UI without a hard refresh — looks like a React Query cache-invalidation gap after tip submission), but that's unrelated to this API-layer fix and is being tracked separately.
- No unit tests added; verification above was direct production DB / API testing, including rolled-back transactions for the two cases this node's live data couldn't exercise directly (pending tips, hashtag+tip overlap).

---

zinsanjp