### PR TITLE
fix(frontend): optimistic tip count update, same pattern as like/reca…

### DIFF
--- a/client/src/services/FrontEnd/src/components/FeedItem.tsx
+++ b/client/src/services/FrontEnd/src/components/FeedItem.tsx
@@ -99,9 +99,11 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
   const [likeCountAdj, setLikeCountAdj] = useState(0)
   const [recawCountAdj, setRecawCountAdj] = useState(0)
   const [replyCountAdj, setReplyCountAdj] = useState(0)
+  const [tipCountAdj, setTipCountAdj] = useState(0)
   const [likeCountBase, setLikeCountBase] = useState<number | null>(null)
   const [recawCountBase, setRecawCountBase] = useState<number | null>(null)
   const [replyCountBase, setReplyCountBase] = useState<number | null>(null)
+  const [tipCountBase, setTipCountBase] = useState<number | null>(null)
 
   // Polling for pending items is handled centrally by Feed.tsx (unified polling interval).
   // No per-item polling hooks needed here — avoids 5 timers × N items = cascading jank.
@@ -289,6 +291,7 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
   const effectiveReplyAdj = settled(replyCountAdj, useItem.commentCount, replyCountBase) ? 0 : replyCountAdj
   const effectiveRecawAdj = settled(recawCountAdj, useItem.recawCount, recawCountBase) ? 0 : recawCountAdj
   const effectiveLikeAdj  = settled(likeCountAdj,  useItem.likeCount,    likeCountBase)  ? 0 : likeCountAdj
+  const effectiveTipAdj   = settled(tipCountAdj, useItem.tipCount ?? 0, tipCountBase)    ? 0 : tipCountAdj
 
   // Auto-trigger like after wallet connection
   useEffect(() => {
@@ -2007,8 +2010,8 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
                 }`}
               >
                 <HiOutlineCurrencyDollar className={`${uiDensity === 'compact' ? 'w-4 h-4 mb-[4px]' : 'w-5 h-5 mb-[5px]'}`} />
-                {(useItem.tipCount ?? 0) > 0 && (
-                  <span className={`${uiDensity === 'compact' ? 'text-[11px] -translate-y-[2px]' : 'text-xs -translate-y-[3px]'}`}>{useItem.tipCount}</span>
+                {((useItem.tipCount ?? 0) + effectiveTipAdj) > 0 && (
+                  <span className={`${uiDensity === 'compact' ? 'text-[11px] -translate-y-[2px]' : 'text-xs -translate-y-[3px]'}`}>{(useItem.tipCount ?? 0) + effectiveTipAdj}</span>
                 )}
               </button></Tooltip>
               )}
@@ -2342,6 +2345,12 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
         onTipSubmitted={() => {
           setTipPending(true)
           onTipStateChange?.(item.id, true)
+          // Optimistic count bump, same pattern as like/recaw/reply above --
+          // TipModal confirms the tx client-side but the server's tipCount
+          // (SUCCESS-only aggregate) won't reflect it until the on-chain tip
+          // confirms, which otherwise required a hard refresh to see.
+          setTipCountBase(useItem.tipCount ?? 0)
+          setTipCountAdj(prev => prev + 1)
         }}
       />
 


### PR DESCRIPTION
## Summary

Fixes tip counts not updating in the UI without a hard refresh. Sending a tip worked correctly server-side, but the feed showed the stale count until the page was reloaded.

## Background

`FeedItem.tsx` already has an optimistic-count-adjustment pattern for likes, recaws, and replies: track a local `+1`/`-1` adjustment plus a snapshot of the server count at the moment it was applied, then stop applying the adjustment once the server value catches up (`settled()`). `TipModal`'s `onTipSubmitted` callback only set `tipPending` (a spinner flag) and never touched the displayed tip count, so a successful tip appeared to do nothing until the next full page load re-fetched `tipCount`.

## Fix

Added `tipCountAdj` / `tipCountBase` alongside the existing three, following the identical shape. Wired `onTipSubmitted` to bump the adjustment the same way `handleLike` etc. do.

`onTipSubmitted` only fires after `signAndSubmit` resolves without throwing (inside the `try` block, after the `await`) — a rejected signature or failed submission never reaches it, so there's no stuck `+1` left behind on failure.

## Verification

Verified live on `cawnest.com`: sent a tip and the displayed count incremented immediately in the UI, with no reload needed.

## Notes for reviewers

This surfaced while verifying PR #79 (feed `tipCount` aggregate fix) — after that fix landed, the API was returning the correct count, but the UI still needed a hard refresh to show it. Separate layer, separate PR.

No unit tests added — this is a small UI-state change following an existing, already-tested pattern in the same file (`likeCountAdj`/`recawCountAdj`/`replyCountAdj`).

---

zinsanjp