### PR TITLE
fix(api): filter deleted/hidden posts and blocked authors from bookmarks

### DIFF
--- a/client/src/api/routes/bookmarks.ts
+++ b/client/src/api/routes/bookmarks.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import { prisma } from '../../prismaClient'
 import { extractSession } from '../middleware/auth'
 import { shapeCaw, getCawIncludeConfig, enrichWithPollVotes, enrichWithXBadges } from '../shared/cawUtils'
+import { getBlockedUserIds } from '../shared/blockUtils'
 
 const router = Router()
 
@@ -48,8 +49,17 @@ router.get('/', async (req, res) => {
     const cursor = req.query.cursor ? Number(req.query.cursor) : undefined
     const limit = Math.min(Number(req.query.limit) || 20, 50)
 
+    // Exclude bookmarks whose target caw was deleted/hidden after bookmarking,
+    // or whose author the current user has since blocked -- mirrors the
+    // status/blockedIds filtering the main feed routes apply (caws.ts).
+    const blockedIds = await getBlockedUserIds(userId)
+    const cawWhere: any = { status: 'SUCCESS' }
+    if (blockedIds.length > 0) {
+      cawWhere.userId = { notIn: blockedIds }
+    }
+
     const bookmarks = await prisma.bookmark.findMany({
-      where: { userId },
+      where: { userId, caw: cawWhere },
       orderBy: { createdAt: 'desc' },
       take: limit + 1,
       ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),


### PR DESCRIPTION
## Summary

Fixes `GET /api/bookmarks` returning bookmarks for posts that have since been deleted/hidden, or whose author the user has since blocked. Both cases are already correctly filtered in the main feed routes (`caws.ts`) — bookmarks never picked up the same filtering.

## Background

The bookmarks query only filtered on `Bookmark.userId`, with no filter on the joined caw's `status` or author. Bookmarking a post that later gets deleted (or blocking its author afterward) left it appearing in the bookmarks list indefinitely.

## Fix

```typescript
const blockedIds = await getBlockedUserIds(userId)
const cawWhere: any = { status: 'SUCCESS' }
if (blockedIds.length > 0) {
  cawWhere.userId = { notIn: blockedIds }
}

const bookmarks = await prisma.bookmark.findMany({
  where: { userId, caw: cawWhere },
  ...
```

Reuses `getBlockedUserIds` (same helper `caws.ts` uses) and mirrors its exact filtering pattern. `Bookmark` rows themselves are left untouched — only excluded from this listing — so if a hidden post is later restored, or a block is lifted, the bookmark reappears with no backfill needed.

## Verification

- **Live on `cawnest.com`**: found 3 real ghost bookmarks already present on this node (caw ids 267, 329, 331 — all `HIDDEN`; id 329 is the post deleted while verifying PR #81's Site 1). Before the fix, `GET /api/bookmarks` for that user returned all 3; after applying and restarting, the response is empty (correctly excluded).
- **Blocked-author case**: no live data to exercise this on the node, so verified via a rolled-back transaction — bookmarked a post, blocked its author, confirmed the query correctly omits it. Zero rows persisted afterward (confirmed by direct count).
- `tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

## Notes for reviewers

No unit tests added; verification was direct production DB / API testing plus a rolled-back transaction for the case this node's live data couldn't exercise (blocked authors).

---

zinsanjp