### PR TITLE
compose: fix JA IME on iOS WebKit by going uncontrolled during composition

### DIFF
--- a/client/src/services/FrontEnd/src/components/HighlightedTextarea.tsx
+++ b/client/src/services/FrontEnd/src/components/HighlightedTextarea.tsx
@@ -83,12 +83,15 @@ interface HighlightedTextareaProps {
 // resets textarea.value back to the frozen prop after EVERY composition
 // keystroke on Blink — wiping the 変換中 text and killing the IME session,
 // which made Japanese input impossible on Chrome/Edge (measured on the live
-// bundle, 2026-07-30). Going uncontrolled on WebKit/Blink breaks their IME,
-// so the Gecko gate itself stays — exported because PostForm gates its
-// composition-freeze to Gecko with the same test.
+// bundle, 2026-07-30). Going uncontrolled was long believed to break the IME
+// on WebKit and Blink; measured on an iPhone 2026-08-26, it does not on iOS.
+// Exported because PostForm gates its composition-freeze with the same tests.
 // Firefox-for-iOS ("FxiOS") is WebKit, not Gecko, and correctly does NOT match.
 export const IS_GECKO =
   typeof navigator !== 'undefined' && /firefox/i.test(navigator.userAgent)
+
+export const IS_IOS =
+  typeof navigator !== 'undefined' && /iP(hone|ad|od)/.test(navigator.userAgent)
 
 const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
   value,
@@ -571,10 +574,10 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
         }}
         rows={rows}
         placeholder={placeholder}
-        // Uncontrolled during composition ONLY on Firefox (see IS_GECKO): there
-        // React's mid-composition value write aborts the IME. On WebKit/Blink we
-        // keep it controlled — going uncontrolled there breaks their IME.
-        value={isComposing && IS_GECKO ? undefined : value}
+        // Uncontrolled during composition on Firefox (IS_GECKO) and iOS WebKit
+        // (IS_IOS): there React's mid-composition value write aborts the IME.
+        // Both measured on device. On Blink we keep it controlled.
+        value={isComposing && (IS_GECKO || IS_IOS) ? undefined : value}
         onChange={onChange}
         onCompositionStart={handleCompositionStartInternal}
         onCompositionEnd={handleCompositionEndInternal}
@@ -590,7 +593,7 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
       />
 
       {/* Placeholder overlay when empty */}
-      {!value && placeholder && (
+      {!value && !isComposing && placeholder && (
         <div
           className={`absolute pointer-events-none ${textSizeClass} ${
             isDark ? 'text-gray-500' : 'text-gray-600'

--- a/client/src/services/FrontEnd/src/components/HighlightedTextarea.tsx
+++ b/client/src/services/FrontEnd/src/components/HighlightedTextarea.tsx
@@ -163,6 +163,14 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
   // changes on viewport-rotate / browser-resize / virtual-keyboard-show
   // leave the textarea at its old height.
   const [resizeTick, setResizeTick] = useState(0)
+  // While uncontrolled during composition (IS_GECKO/IS_IOS below) the `value`
+  // prop is frozen at its pre-composition text, so the autoResize effect and
+  // the measurement mirror would size the box for the OLD content and the
+  // composing lines fall outside the visible box. Read the live DOM value
+  // instead; compositionupdate bumps resizeTick so this re-evaluates.
+  const measuredValue = isComposing && (IS_GECKO || IS_IOS)
+    ? (internalRef.current?.value ?? value)
+    : value
   useEffect(() => {
     if (!autoResize) return
     const onResize = () => setResizeTick(t => t + 1)
@@ -260,7 +268,7 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
       setOverlayHeight(next)
     })
     return () => cancelAnimationFrame(rafId)
-  }, [autoResize, value, compact, lineHeight, fontSize, resizeTick])
+  }, [autoResize, measuredValue, compact, lineHeight, fontSize, resizeTick])
 
   // Apply mention/hashtag/URL highlighting to a single text slice. Used both
   // for the whole `value` (no chunk boundaries) and for each between-boundary
@@ -376,6 +384,13 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
   // aborts composition on Firefox. The declarative styles stay static
   // (transparent / opacity:1); React won't overwrite our imperative values on
   // an unrelated re-render because it only writes style props that changed.
+  // Bump resizeTick on every composition keystroke. While uncontrolled the
+  // `value` prop never changes, so nothing else would re-render and the
+  // autoResize effect (which now reads measuredValue) would never re-run.
+  const handleCompositionUpdateInternal = (e: React.CompositionEvent<HTMLTextAreaElement>) => {
+    if (autoResize) setResizeTick(t => t + 1)
+    onCompositionUpdate?.(e)
+  }
   const handleCompositionStartInternal = (e: React.CompositionEvent<HTMLTextAreaElement>) => {
     composingRef.current = true
     setIsComposing(true)
@@ -581,7 +596,7 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
         onChange={onChange}
         onCompositionStart={handleCompositionStartInternal}
         onCompositionEnd={handleCompositionEndInternal}
-        onCompositionUpdate={onCompositionUpdate}
+        onCompositionUpdate={handleCompositionUpdateInternal}
         onClick={onClick}
         onKeyUp={onKeyUp}
         onKeyDown={onKeyDown}
@@ -633,8 +648,8 @@ const HighlightedTextarea: React.FC<HighlightedTextareaProps> = ({
         >
           {/* Trailing space + zero-width joiner so a value ending in
               \n still counts the trailing empty line in offsetHeight. */}
-          {value || '.'}
-          {value.endsWith('\n') ? '​' : ''}
+          {measuredValue || '.'}
+          {measuredValue.endsWith('\n') ? '​' : ''}
         </div>
       )}
     </div>

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -89,7 +89,7 @@ function gifSearchQuery(text: string): string {
     .filter(w => w.length > 1 && !stopWords.has(w))
   return words.slice(-5).join(' ')
 }
-import HighlightedTextarea, { IS_GECKO } from './HighlightedTextarea'
+import HighlightedTextarea, { IS_GECKO, IS_IOS } from './HighlightedTextarea'
 import { useT } from '~/i18n/I18nProvider'
 import { acquireScrollLock, releaseScrollLock } from '~/utils/scrollLock'
 
@@ -962,13 +962,13 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
     // there), so committing interim text here would re-render the controlled
     // textarea mid-composition and abort the IME — the exact failure this
     // handler's Firefox-lag guard below also protects against. Bail early
-    // and let compositionend do the single commit. On Blink handleTextChange
-    // now commits every interim value anyway; on iOS WebKit (the engine this
-    // live commit exists for, since compositionend can be dropped there) the
-    // path below still runs.
-    if (IS_GECKO) return
+    // and let compositionend do the single commit. iOS WebKit (IS_IOS) is now
+    // uncontrolled during composition too, so it takes the same early exit.
+    // On Blink handleTextChange commits every interim value anyway; the path
+    // below still runs there and on desktop Safari.
+    if (IS_GECKO || IS_IOS) return
     const ta = e.currentTarget
-    // The live commit here exists only for iOS WebKit, which may not fire
+    // The live commit here exists for WebKit, which may not fire
     // compositionend, and which DOES reflect the composing text in ta.value at
     // this point. Firefox does NOT: ta.value still holds the pre-composition
     // value (the composing char lands only on the `input` event). Detect that
@@ -2790,10 +2790,10 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                         value={slice}
                         composedValueRef={lastComposedRef}
                         onChange={(e) => {
-                          // Gecko-only freeze — same reasoning as
+                          // Gecko/iOS freeze — same reasoning as
                           // handleTextChange (Blink wipes the composing
                           // text via controlled-state restore if skipped).
-                          if (isComposingRef.current && IS_GECKO) {
+                          if (isComposingRef.current && (IS_GECKO || IS_IOS)) {
                             lastComposedRef.current = { value: e.target.value, caret: e.target.selectionStart ?? e.target.value.length }
                             return
                           }
@@ -3405,10 +3405,10 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                     value={slice}
                     composedValueRef={lastComposedRef}
                     onChange={(e) => {
-                      // Gecko-only freeze — same reasoning as
+                      // Gecko/iOS freeze — same reasoning as
                       // handleTextChange (Blink wipes the composing
                       // text via controlled-state restore if skipped).
-                      if (isComposingRef.current && IS_GECKO) {
+                      if (isComposingRef.current && (IS_GECKO || IS_IOS)) {
                         lastComposedRef.current = { value: e.target.value, caret: e.target.selectionStart ?? e.target.value.length }
                         return
                       }

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -2763,7 +2763,6 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
           <div className="flex items-center space-x-3 w-full">
             {/* Input — single textarea (single-post) or N textareas (thread mode) */}
             <div className="flex-1 min-w-0 relative">
-              {true ? (
                 <div>
                   {chunkSlices.map((slice, i) => (
                     <React.Fragment key={i}>
@@ -2855,41 +2854,6 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                     textareaRef={{ current: chunkRefs.current[activeChunkIndex] ?? null }}
                   />
                 </div>
-              ) : (
-                <>
-                  <HighlightedTextarea
-                    value={text}
-                    composedValueRef={lastComposedRef}
-                    onChange={handleTextChange}
-                    onCompositionStart={handleCompositionStart}
-                    onCompositionEnd={handleCompositionEnd}
-                    onCompositionUpdate={handleCompositionUpdate}
-                    onClick={handleTextClick}
-                    onKeyUp={handleTextKeyUp}
-                    onDragOver={handleTextareaDragOver}
-                    onDragLeave={handleTextareaDragLeave}
-                    onDrop={handleTextareaDrop}
-                    rows={replyTo ? 3 : 1}
-                    placeholder={
-                      replyTo
-                        ? `Reply to @${replyTo.user.username}`
-                        : (
-                          placeholder ?? (quote ? t('post_form.placeholder_quote') : t('post_form.placeholder'))
-                        )
-                    }
-                    textareaRef={textareaRef}
-                    fontSize="base"
-                    compact={!!replyTo || hasMedia}
-                    autoResize
-                  />
-                  <MentionAutocomplete
-                    text={text}
-                    cursorPosition={cursorPosition}
-                    onSelect={handleMentionSelect}
-                    textareaRef={textareaRef}
-                  />
-                </>
-              )}
               {/* Drag overlay */}
               {isDragOverTextarea && (
                 <div className="absolute inset-0 flex items-center justify-center bg-yellow-500/10 border-2 border-dashed border-yellow-500 rounded-lg pointer-events-none">
@@ -3360,7 +3324,6 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
           onMouseUp={() => { threadSelDragging.current = false }}
         >
         <div className="relative">
-          {true ? (
             <>
               {chunkSlices.map((slice, i) => (
                 <React.Fragment key={i}>
@@ -3482,41 +3445,6 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
                 textareaRef={{ current: chunkRefs.current[activeChunkIndex] ?? null }}
               />
             </>
-          ) : (
-            <>
-              <HighlightedTextarea
-                value={text}
-                composedValueRef={lastComposedRef}
-                onChange={handleTextChange}
-                onCompositionStart={handleCompositionStart}
-                onCompositionEnd={handleCompositionEnd}
-                onCompositionUpdate={handleCompositionUpdate}
-                onClick={handleTextClick}
-                onKeyUp={handleTextKeyUp}
-                onDragOver={handleTextareaDragOver}
-                onDragLeave={handleTextareaDragLeave}
-                onDrop={handleTextareaDrop}
-                rows={desktopRows}
-                placeholder={
-                  replyTo
-                    ? `Reply to @${replyTo.user.username}`
-                    : (
-                      placeholder ?? (quote ? t('post_form.placeholder_quote') : t('post_form.placeholder'))
-                    )
-                }
-                textareaRef={textareaRef}
-                fontSize={replyTo ? 'base' : 'xl'}
-                compact={!!replyTo || hasMedia}
-                autoResize
-              />
-              <MentionAutocomplete
-                text={text}
-                cursorPosition={cursorPosition}
-                onSelect={handleMentionSelect}
-                textareaRef={textareaRef}
-              />
-            </>
-          )}
           {/* Drag overlay */}
           {isDragOverTextarea && (
             <div className="top-[-3px] absolute inset-0 flex items-center justify-center bg-yellow-500/10 border-2 border-dashed border-yellow-500 rounded-lg pointer-events-none">

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -516,7 +516,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
   // stays false → commit normally) from a genuine CJK session (compositionstart
   // fired first → ref is true → defer commit to compositionEnd, preserving #322).
   const isComposingRef = useRef(false)
-  const frozenThreadRef = useRef(false)
+  const frozenChunksRef = useRef<{ chunkCount: number; chunkBoundaries: number[] } | null>(null)
   // Firefox hands us e.currentTarget.value === "" at compositionend even though
   // the composition succeeded — the composed text only appears on the `input`
   // events fired DURING composition, which React then reverts on the controlled
@@ -1991,17 +1991,22 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
   const effectiveTextLength = textBytes + mediaCost + pollBytes
   // Thread mode is active when text overflows one post OR the user typed a
   // manual `---` break marker (which forces a split regardless of length).
-  const rawIsThreadMode = effectiveTextLength > POST_CHAR_LIMIT
-  if (!isComposingRef.current) frozenThreadRef.current = rawIsThreadMode
-  const isThreadMode = isComposingRef.current ? frozenThreadRef.current : rawIsThreadMode
+  const isThreadMode = effectiveTextLength > POST_CHAR_LIMIT
   const firstChunkMediaCost = (!isThreadMode || mediaPosition === 'start') ? mediaCost : 0
   const lastChunkMediaCost = (isThreadMode && mediaPosition === 'end') ? mediaCost : 0
-  const { chunkCount, chunkBoundaries } = getChunkInfo(
+  // While an IME composition is open we do NOT recompute the chunk layout.
+  // Recomputing changes how many textareas are mounted (and the value each
+  // one holds), which ends the composition. Freezing the layout — not just
+  // the single/thread flag — covers every boundary, not only the first.
+  const rawChunkInfo = getChunkInfo(
     text,
     includePageIndicators,
     firstChunkMediaCost + firstChunkPollCost,
     lastChunkMediaCost + lastChunkPollCost,
   )
+  if (!isComposingRef.current) frozenChunksRef.current = rawChunkInfo
+  const { chunkCount, chunkBoundaries } =
+    (isComposingRef.current && frozenChunksRef.current) ? frozenChunksRef.current : rawChunkInfo
 
   // ---------------------------------------------------------------------------
   // Per-chunk slices (marker-stripped) for the N-textarea thread UI.

--- a/client/src/services/FrontEnd/src/components/PostForm.tsx
+++ b/client/src/services/FrontEnd/src/components/PostForm.tsx
@@ -516,6 +516,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
   // stays false → commit normally) from a genuine CJK session (compositionstart
   // fired first → ref is true → defer commit to compositionEnd, preserving #322).
   const isComposingRef = useRef(false)
+  const frozenThreadRef = useRef(false)
   // Firefox hands us e.currentTarget.value === "" at compositionend even though
   // the composition succeeded — the composed text only appears on the `input`
   // events fired DURING composition, which React then reverts on the controlled
@@ -1990,7 +1991,9 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
   const effectiveTextLength = textBytes + mediaCost + pollBytes
   // Thread mode is active when text overflows one post OR the user typed a
   // manual `---` break marker (which forces a split regardless of length).
-  const isThreadMode = effectiveTextLength > POST_CHAR_LIMIT
+  const rawIsThreadMode = effectiveTextLength > POST_CHAR_LIMIT
+  if (!isComposingRef.current) frozenThreadRef.current = rawIsThreadMode
+  const isThreadMode = isComposingRef.current ? frozenThreadRef.current : rawIsThreadMode
   const firstChunkMediaCost = (!isThreadMode || mediaPosition === 'start') ? mediaCost : 0
   const lastChunkMediaCost = (isThreadMode && mediaPosition === 'end') ? mediaCost : 0
   const { chunkCount, chunkBoundaries } = getChunkInfo(
@@ -2214,6 +2217,12 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
     // observed as "second time entering thread mode, focus is lost."
     const skipThisRender = cursorRestoreSkipRef.current
     cursorRestoreSkipRef.current = false
+    // While an IME composition is open the browser owns the composing
+    // range. focus() + a collapsed setSelectionRange() destroys it, so the
+    // next conversion INSERTS instead of replacing the reading (observed as
+    // duplicated text). Leave pendingMasterCursorRef intact — the render
+    // after compositionend restores the caret correctly.
+    if (isComposingRef.current) return
     if (!isThreadMode) {
       // Also drop any pending master cursor on the way out — it was set
       // for a chunk layout that no longer exists.
@@ -2749,7 +2758,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
           <div className="flex items-center space-x-3 w-full">
             {/* Input — single textarea (single-post) or N textareas (thread mode) */}
             <div className="flex-1 min-w-0 relative">
-              {isThreadMode ? (
+              {true ? (
                 <div>
                   {chunkSlices.map((slice, i) => (
                     <React.Fragment key={i}>
@@ -3346,7 +3355,7 @@ const PostForm: React.FC<PostFormProps> = ({ replyTo, quote, onSuccess, placehol
           onMouseUp={() => { threadSelDragging.current = false }}
         >
         <div className="relative">
-          {isThreadMode ? (
+          {true ? (
             <>
               {chunkSlices.map((slice, i) => (
                 <React.Fragment key={i}>


### PR DESCRIPTION
## Background

This started from the "make it narrower" note on #37.

At that point there seemed to be two options: #37's approach (force a single textarea on iOS, no live splitting) or nothing. #37 works — it brings the corruption to zero and has field data behind it — but it changes how editing feels on iOS.

Since the ask was for something narrower, I went looking for a third option: keep live splitting on every engine, and intervene only at the moment a composition crosses a chunk boundary.

## What this does

Widens the "go uncontrolled during composition" gate from Gecko to iOS WebKit as well.

`HighlightedTextarea.tsx` carried a comment saying that going uncontrolled breaks the IME on WebKit and Blink. That claim is what kept this option closed. Measured on device, it does not hold: Blink on 2026-08-04, WebKit on 2026-08-26, both against a live node.

With the textarea uncontrolled, React does not touch the DOM at all during a composition. Chunk mounts, writes into the mirrored copy, and the character push-out at a boundary all move outside the composition window. Splitting stays live; the intervention is confined to the composition itself.

The second commit here fixes a regression the first one introduced: while uncontrolled, the `value` prop stays frozen, so the `autoResize` effect and its hidden measurement mirror both sized the box for the pre-composition text. Composing lines fell outside the visible box. Measuring from the live DOM value fixes it.

## Receipts

- iPhone, MetaMask in-app browser: a 366-character, 3-chunk thread posted successfully, no leftover pre-edit characters.
- iPhone, reply composer: `compositionstart`/`compositionend` pairing 1:1 across both the 1→2 and 2→3 chunk boundaries, no re-fired `compositionstart`.
- Desktop Chrome: typed across four chunks, crossing three boundaries. Clean — #36 is doing its job on Blink and nothing here regresses it.
- Desktop Firefox and Chrome after the autoResize fix: box height tracks correctly through composition.

## Relation to #37

Please read this as a second option alongside #37, not a replacement. #37 is what showed where the breakage actually lives and what needed protecting; this builds on that. @nyaromesama has seen this approach and encouraged me to open it.

#37 also adds an `IS_IOS` constant, for a different purpose (restoring the overlay on `compositionupdate`). The declaration line here is byte-identical to #37's, so whichever lands first, the other side just drops its own declaration.

## Known remaining edge

#36 lists "IME interrupts once when the composition crosses the byte limit" as a known remaining edge.

On iOS that edge is closed here — going uncontrolled removes the mid-composition re-render entirely. **On Blink and Gecko it remains.** Measured 2026-08-28 in desktop Firefox and Chrome: if a composition grows past the byte limit, the push-out runs right after `compositionend` and rolls the chunk back to its previous length, which can interrupt a composition the user has already started. The log shows `CS L139 → CE L144 → CE L138`, followed by a burst of collapsed `setSelectionRange` calls, and a raw romaji character left in the text.

Not addressed here. I'll open a separate issue with the reproduction.

## Out of scope

`IS_IOS` matches iPhone and iPad only. Desktop Safari, and iPad reporting a desktop UA, keep the existing controlled path. Only iPhone was measured.

Firefox has a separate problem at chunk boundaries, distinct from the one above: `setSelectionRange` calls originate inside React's own reconciliation rather than this component's caret restore. Measured 2026-08-27, unrelated to this change.

## Commits

Five commits, each readable on its own:

1. unify the chunk render path, freeze `isThreadMode` during composition,
   guard the caret restore
2. freeze chunk layout during composition
3. go uncontrolled on iOS WebKit
4. drop the now-unreachable single-mode JSX branch — this also restores
   type narrowing on `replyTo`, so `yarn build` passes again
5. fix the autoResize regression the third commit introduced

## Thanks

@nyaromesama — the reply composer regression was entirely down to your review. I had only tested the main composer, where the larger `rows` hides it, and I would have shipped it. You also verified the dead-code removal yourself rather than taking my word for it, and you were right that the behavioral change lives in the earlier commit.

@yuceeman — #36 is what made the Blink side workable to begin with, and its "known remaining edge" note is what pointed at the boundary case.