### PR TITLE
fix(pin): broadcast portable cawonce for pin/unpin instead of node-lo…

### DIFF
--- a/client/src/api/routes/actions.ts
+++ b/client/src/api/routes/actions.ts
@@ -918,13 +918,19 @@ router.post('/', async (req, res) => {
       try {
         const isUnpin = plaintext.startsWith('xpi:')
         const prefix = isUnpin ? 'xpi:' : 'pi:'
-        const cawId = parseInt(plaintext.replace(prefix, '').trim())
-        if (!isNaN(cawId) && cawId > 0) {
+        const cawonce = parseInt(plaintext.replace(prefix, '').trim())
+        if (!isNaN(cawonce) && cawonce >= 0) {
+          // Resolve the sender's own caw by the portable (userId, cawonce)
+          // key. The on-chain action text now carries cawonce (not a node-
+          // local DB id), matching like/recaw/tip. Ownership is implicit:
+          // we only ever look up a caw under data.senderId, so this can't
+          // pin someone else's post.
           const target = await prisma.caw.findUnique({
-            where: { id: cawId },
-            select: { userId: true },
+            where: { userId_cawonce: { userId: data.senderId, cawonce } },
+            select: { id: true },
           })
-          if (target && target.userId === data.senderId) {
+          if (target) {
+            const cawId = target.id
             if (isUnpin) {
               // Mark the existing row pendingUnpin so the read path
               // suppresses it; indexer deletes on confirm.
@@ -948,7 +954,7 @@ router.post('/', async (req, res) => {
               console.log(`[Actions] Optimistic pin: user=${data.senderId} caw=${cawId}`)
             }
           } else {
-            console.log(`[Actions] Pin/unpin skipped: target ${cawId} not owned by sender ${data.senderId}`)
+            console.log(`[Actions] Pin/unpin skipped: no caw for sender ${data.senderId} cawonce ${cawonce}`)
           }
         }
       } catch (pinErr) {

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -1568,7 +1568,12 @@ async function handlePinAction(
   //     top-level handler treats as a quiet, retryable orphan that self-
   //     heals once the caw lands — replacing the old warn+return that left
   //     a permanent orphan for cleanupOrphanActions to re-dispatch forever.
-  const cawId = await findCawId(cawonce, senderId)
+  const target = await tx.caw.findUnique({
+    where: { userId_cawonce: { userId: senderId, cawonce } },
+    select: { id: true },
+  })
+  if (!target) throw new CawNotFoundError(senderId, cawonce)
+  const cawId = target.id
 
   // Two cases the indexer needs to handle:
   //   (a) /api/actions already wrote a pending row → flip pending=false.
@@ -1641,16 +1646,15 @@ async function handleUnpinAction(
   // this node hasn't indexed is a genuine no-op: there can be no pin row to
   // delete, and nothing to converge to. So a missing caw resolves quietly
   // rather than throwing a retryable orphan.
-  let cawId: number
-  try {
-    cawId = await findCawId(cawonce, senderId)
-  } catch (err) {
-    if (err instanceof CawNotFoundError) {
-      console.log(`[handleUnpinAction] No local caw for user=${senderId} cawonce=${cawonce}; nothing to unpin`)
-      return
-    }
-    throw err
+  const target = await tx.caw.findUnique({
+    where: { userId_cawonce: { userId: senderId, cawonce } },
+    select: { id: true },
+  })
+  if (!target) {
+    console.log(`[handleUnpinAction] No local caw for user=${senderId} cawonce=${cawonce}; nothing to unpin`)
+    return
   }
+  const cawId = target.id
 
   const existing = await tx.pinnedCaw.findUnique({
     where: { userId_cawId: { userId: senderId, cawId } },

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -1570,9 +1570,9 @@ async function handlePinAction(
   //     a permanent orphan for cleanupOrphanActions to re-dispatch forever.
   const target = await tx.caw.findUnique({
     where: { userId_cawonce: { userId: senderId, cawonce } },
-    select: { id: true },
+    select: { id: true, status: true },
   })
-  if (!target) throw new CawNotFoundError(senderId, cawonce)
+  if (!target || target.status !== 'SUCCESS') throw new CawNotFoundError(senderId, cawonce)
   const cawId = target.id
 
   // Two cases the indexer needs to handle:

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -1549,24 +1549,26 @@ async function handlePinAction(
   senderId: number
 ): Promise<void> {
   const text: string = rawAction.text || ''
-  const cawId = parseInt(text.replace('pi:', '').trim())
-  if (isNaN(cawId) || cawId <= 0) {
-    console.warn('[handlePinAction] Invalid cawId:', text)
+  const cawonce = parseInt(text.replace('pi:', '').trim())
+  if (isNaN(cawonce) || cawonce < 0) {
+    console.warn('[handlePinAction] Invalid cawonce:', text)
     return
   }
 
-  const target = await tx.caw.findUnique({
-    where: { id: cawId },
-    select: { userId: true },
-  })
-  if (!target) {
-    console.warn(`[handlePinAction] Caw not found: id=${cawId}`)
-    return
-  }
-  if (target.userId !== senderId) {
-    console.warn(`[handlePinAction] User ${senderId} cannot pin caw ${cawId} owned by ${target.userId}`)
-    return
-  }
+  // Resolve the sender's own caw by the portable (userId, cawonce) key
+  // instead of a raw local DB id. pin/unpin used to broadcast the origin
+  // node's primary key (pi:{cawId}), which is meaningless on any mirror —
+  // like/recaw/tip already key by (receiverId, receiverCawonce). Using
+  // findCawId here:
+  //   - makes ownership implicit — it only ever resolves the sender's own
+  //     caw, so User A can't pin User B's post via a crafted action;
+  //   - makes cross-mirror case (b) work — the mirror resolves the same
+  //     on-chain caw to ITS OWN local id;
+  //   - routes a not-yet-indexed target through CawNotFoundError, which the
+  //     top-level handler treats as a quiet, retryable orphan that self-
+  //     heals once the caw lands — replacing the old warn+return that left
+  //     a permanent orphan for cleanupOrphanActions to re-dispatch forever.
+  const cawId = await findCawId(cawonce, senderId)
 
   // Two cases the indexer needs to handle:
   //   (a) /api/actions already wrote a pending row → flip pending=false.
@@ -1629,10 +1631,25 @@ async function handleUnpinAction(
   senderId: number
 ): Promise<void> {
   const text: string = rawAction.text || ''
-  const cawId = parseInt(text.replace('xpi:', '').trim())
-  if (isNaN(cawId) || cawId <= 0) {
-    console.warn('[handleUnpinAction] Invalid cawId:', text)
+  const cawonce = parseInt(text.replace('xpi:', '').trim())
+  if (isNaN(cawonce) || cawonce < 0) {
+    console.warn('[handleUnpinAction] Invalid cawonce:', text)
     return
+  }
+
+  // Portable resolution, mirroring handlePinAction. Unlike pin, a target
+  // this node hasn't indexed is a genuine no-op: there can be no pin row to
+  // delete, and nothing to converge to. So a missing caw resolves quietly
+  // rather than throwing a retryable orphan.
+  let cawId: number
+  try {
+    cawId = await findCawId(cawonce, senderId)
+  } catch (err) {
+    if (err instanceof CawNotFoundError) {
+      console.log(`[handleUnpinAction] No local caw for user=${senderId} cawonce=${cawonce}; nothing to unpin`)
+      return
+    }
+    throw err
   }
 
   const existing = await tx.pinnedCaw.findUnique({

--- a/client/src/services/ActionProcessor/domainObjectChecks.ts
+++ b/client/src/services/ActionProcessor/domainObjectChecks.ts
@@ -247,11 +247,21 @@ async function checkOtherExists(
   // Caw arrives. Treating it as "already processed" here would silently
   // discard a legitimate action. Same safe-retry pattern as checkLikeExists.
   if (rawAction.text?.startsWith('pi:')) {
-    const cawId = parseInt(rawAction.text.replace('pi:', '').trim(), 10)
-    if (Number.isNaN(cawId) || cawId <= 0) return false
+    const cawonce = parseInt(rawAction.text.replace('pi:', '').trim(), 10)
+    if (Number.isNaN(cawonce) || cawonce < 0) return false
     const senderId = await findOrCreateUser(action.senderId)
+    // Portable (userId, cawonce) resolution — the action text carries the
+    // per-user cawonce, not a node-local DB id. If the target Caw isn't
+    // indexed locally yet there's no local id (and no pin row), so return
+    // false: the action retries next poll once the Caw arrives. Preserves
+    // the safe-retry contract described above.
+    const targetCaw = await tx.caw.findUnique({
+      where: { userId_cawonce: { userId: senderId, cawonce } },
+      select: { id: true },
+    })
+    if (!targetCaw) return false
     const existing = await tx.pinnedCaw.findUnique({
-      where: { userId_cawId: { userId: senderId, cawId } },
+      where: { userId_cawId: { userId: senderId, cawId: targetCaw.id } },
       select: { pending: true },
     })
     return existing?.pending === false
@@ -263,11 +273,18 @@ async function checkOtherExists(
   // to delete it. "No row" also covers the legitimate "user never pinned
   // this caw to begin with" case — handleUnpinAction is idempotent there.
   if (rawAction.text?.startsWith('xpi:')) {
-    const cawId = parseInt(rawAction.text.replace('xpi:', '').trim(), 10)
-    if (Number.isNaN(cawId) || cawId <= 0) return false
+    const cawonce = parseInt(rawAction.text.replace('xpi:', '').trim(), 10)
+    if (Number.isNaN(cawonce) || cawonce < 0) return false
     const senderId = await findOrCreateUser(action.senderId)
+    // Portable resolution, mirroring the pi: branch. No local Caw → no pin
+    // row could exist → the unpin is already a no-op, so it's "done" (true).
+    const targetCaw = await tx.caw.findUnique({
+      where: { userId_cawonce: { userId: senderId, cawonce } },
+      select: { id: true },
+    })
+    if (!targetCaw) return true
     const existing = await tx.pinnedCaw.findUnique({
-      where: { userId_cawId: { userId: senderId, cawId } },
+      where: { userId_cawId: { userId: senderId, cawId: targetCaw.id } },
       select: { id: true },
     })
     return existing === null

--- a/client/src/services/FrontEnd/src/components/FeedItem.tsx
+++ b/client/src/services/FrontEnd/src/components/FeedItem.tsx
@@ -817,13 +817,23 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
 
     try {
       if (onChain) {
+        // On-chain pin/unpin must carry the portable cawonce (per-user
+        // action nonce), NOT the node-local DB id — a mirror node can't
+        // resolve another node's primary key. cawonce === 0 is a valid
+        // first post, so guard on null, not falsiness (#81 falsy-trap).
+        const pinCawonce = useItem.cawonce
+        if (pinCawonce == null) {
+          console.warn('[Pin] missing cawonce; skipping on-chain pin for', useItem.id)
+          onPinUpdate?.(useItem.id, !willBePinned)
+          return
+        }
         try {
           await signAndSubmit({
             actionType: 'other',
             senderId: effectiveTokenId,
             receiverId: 0,
             receiverCawonce: 0,
-            text: willBePinned ? `pi:${cawId}` : `xpi:${cawId}`,
+            text: willBePinned ? `pi:${pinCawonce}` : `xpi:${pinCawonce}`,
           })
         } catch (err) {
           console.error('[Pin] on-chain submit failed:', err)

--- a/client/src/utils/txQueueFailure.ts
+++ b/client/src/utils/txQueueFailure.ts
@@ -247,20 +247,37 @@ async function cleanupOptimisticRows(
       //   xpi: optimistic write only set pendingUnpin=true on an EXISTING
       //        confirmed row → flip it back to false. The original pin
       //        survives the failed unpin attempt.
+      // The pin/unpin action text carries the portable per-user cawonce
+      // (not a node-local id), so resolve it to this node's local caw id
+      // before touching PinnedCaw. On the origin node the target caw is
+      // always local, so this resolves; if it somehow doesn't, there's no
+      // optimistic row to roll back anyway.
       if (text.startsWith('pi:')) {
-        const cawId = parseInt(text.replace('pi:', '').trim())
-        if (!isNaN(cawId) && cawId > 0) {
-          await prisma.pinnedCaw.deleteMany({
-            where: { userId: senderId, cawId, pending: true }
+        const targetCawonce = parseInt(text.replace('pi:', '').trim())
+        if (!isNaN(targetCawonce) && targetCawonce >= 0) {
+          const targetCaw = await prisma.caw.findUnique({
+            where: { userId_cawonce: { userId: senderId, cawonce: targetCawonce } },
+            select: { id: true },
           })
+          if (targetCaw) {
+            await prisma.pinnedCaw.deleteMany({
+              where: { userId: senderId, cawId: targetCaw.id, pending: true }
+            })
+          }
         }
       } else if (text.startsWith('xpi:')) {
-        const cawId = parseInt(text.replace('xpi:', '').trim())
-        if (!isNaN(cawId) && cawId > 0) {
-          await prisma.pinnedCaw.updateMany({
-            where: { userId: senderId, cawId, pendingUnpin: true },
-            data: { pendingUnpin: false }
+        const targetCawonce = parseInt(text.replace('xpi:', '').trim())
+        if (!isNaN(targetCawonce) && targetCawonce >= 0) {
+          const targetCaw = await prisma.caw.findUnique({
+            where: { userId_cawonce: { userId: senderId, cawonce: targetCawonce } },
+            select: { id: true },
           })
+          if (targetCaw) {
+            await prisma.pinnedCaw.updateMany({
+              where: { userId: senderId, cawId: targetCaw.id, pendingUnpin: true },
+              data: { pendingUnpin: false }
+            })
+          }
         }
       }
     }


### PR DESCRIPTION
# fix(pin): broadcast portable cawonce for pin/unpin instead of node-local id

**Base:** `v2`  ·  **Branch:** `fix/portable-pin-cawonce`

## Summary

`pin`/`unpin` were the **only** on-chain actions that broadcast a **node-local
DB primary key** (`pi:{cawId}`) rather than a portable on-chain coordinate.
Every other action that targets an existing caw carries `(userId, cawonce)`:

| action        | broadcast text                | resolves via                         |
|---------------|-------------------------------|--------------------------------------|
| like / recaw / tip | `receiverId` + `receiverCawonce` | `findCawId(cawonce, userOnChain)` |
| hide          | `hide:caw:{cawonce}`          | `where { userId: senderId, cawonce }` |
| **pin / unpin (before)** | **`pi:{cawId}` (local PK)** | **`findUnique({ id: cawId })`** ← breaks off-origin |

`(userId, cawonce)` is globally unique (`@@unique([userId, cawonce])` on `Caw`)
and portable; a local autoincrement `id` is not. Because pin broadcast the
origin node's local id, a mirror node running `findUnique({ id })` looked in a
different id space and could not resolve the target.

## The two symptoms are one bug

1. **Cross-mirror pins never resolve.** A mirror indexes the same on-chain pin
   event but the `id` in the text belongs to the origin's DB, so
   `handlePinAction` hits its `Caw not found` branch.
2. **Orphan log storm.** That branch was a bare `console.warn` + `return`, so
   the Action row was never satisfied → `cleanupOrphanActions` re-dispatched it
   every minute (~59 warns/hour per stuck action until it aged out at 1h).
   The `CawNotFoundError` that would have marked it a *recognized* retryable
   orphan was never thrown.

Both fall out of the single `local-id` keying choice. `handlePinAction`'s own
case-(b) comment already states the intent — *"Mirror node sees the on-chain
event … upsert the row directly"* — so cross-mirror propagation is **designed**;
local-id keying is what broke it.

## Fix

Adopt the portable `(userId, cawonce)` pattern that like/recaw/hide already use,
across **all five sites** that produce or consume the pin/unpin text:

| # | file | change |
|---|------|--------|
| 1 | `FrontEnd/.../FeedItem.tsx` | broadcast `pi:{cawonce}` / `xpi:{cawonce}`; guard on `cawonce == null` (**not** falsy — `cawonce === 0` is a valid first post) |
| 2 | `api/routes/actions.ts` | optimistic write resolves `cawonce → local caw id` before touching `PinnedCaw` |
| 3 | `ActionProcessor/actionHandlers.ts` | `handlePinAction` / `handleUnpinAction` resolve via `findCawId` (pin **throws** `CawNotFoundError` on a not-yet-indexed target → recognized retryable orphan that self-heals once the caw lands; unpin treats "no local caw" as a quiet no-op) |
| 4 | `ActionProcessor/domainObjectChecks.ts` | the retry gate (`checkDomainObjectExists`) resolves `cawonce → local id` so its "already done?" verdict matches the new payload |
| 5 | `utils/txQueueFailure.ts` | optimistic-row rollback resolves `cawonce → local id` before delete/revert |

**Ownership is now implicit.** Resolution only ever looks up a caw under
`senderId`, so a crafted `pi:{arbitrary}` action can only ever resolve to the
sender's *own* caw (or nothing) — it is structurally impossible to pin another
user's post. This replaces the previous explicit `target.userId === senderId`
guard with a stronger invariant.

**Off-chain `/api/pins/:cawId` is unchanged** — it is origin-local by
definition (no chain event, no mirror propagation), so a local id is correct
there.

## Why the not-found handling differs between pin and unpin

- **pin**: the row *must* eventually exist, so a missing target throws
  `CawNotFoundError` → the top-level handler records the Action, logs a quiet
  warn, and retries next pass. Since the caw's own tx precedes the pin tx, the
  window is effectively zero on a caught-up mirror; the orphan self-heals.
- **unpin**: deleting a row that can't exist is a genuine no-op, so a missing
  target resolves *quietly* (`true`/return) — there is nothing to converge to,
  and throwing would create a retry that never resolves.

## Scope / disjointness

Touches only pin/unpin producers and consumers. `findCawId`, `CawNotFoundError`,
`findOrCreateUser` are reused as-is (no signature changes). Function-disjoint
from the follow/orphan work (#73/#74) and the InstanceRegistry fix (#75).

## Confidence & test gate

- **Code-level: confirmed.** All five text-producing/consuming sites are
  portable; ownership preserved (strengthened); self-heal path verified against
  the existing `CawNotFoundError` orphan-retry contract in
  `ActionProcessor/index.ts`; brace/scope checked; repo-wide grep confirms no
  remaining pin/unpin text is treated as a local id.
- **Not yet run here** (sandbox has no DB): the final gate is a real-node
  build + a cross-mirror pin round-trip. Suggested check:
  1. `cd client && npm run build` (or `tsc --noEmit`) — type gate.
  2. On node A: pin an own caw on-chain; confirm `PinnedCaw` row lands and
     `pinnedCawCount` bumps.
  3. On mirror node B: confirm the same pin resolves (case-b) and the
     `~59 warns/hour` orphan storm is gone.
  4. Unpin; confirm the row is deleted on both nodes.

## Credit

Independently code-reviewed and confirmed by **Zin** (cawnest.com), who
identified that pin is self-only (`senderId == author`) and therefore the
`hide:caw:{cawonce}` sibling — not `receiverId + receiverCawonce` — is the
natural parent pattern.
