### PR TITLE
fix(hashtags): align pagination cursor with CawHashtag relation id

### DIFF
--- a/client/src/api/routes/hashtags.ts
+++ b/client/src/api/routes/hashtags.ts
@@ -75,12 +75,12 @@ router.get('/:tag/caws', async (req, res) => {
     })
 
     // Handle pagination and shape the caws
-    const { items: rawCaws, nextCursor } = handlePagination(
-      cawHashtags.map(ch => ch.caw),
+    const { items: rawCawHashtags, nextCursor } = handlePagination(
+      cawHashtags,
       limit,
-      (caw) => caw.id
+      (ch) => ch.id
     )
-    const items = rawCaws.map(caw => shapeCaw(caw))
+    const items = rawCawHashtags.map(ch => shapeCaw(ch.caw))
     await enrichWithPollVotes(items, currentUserId)
     await enrichWithXBadges(items)
 


### PR DESCRIPTION
## Summary

Fixes cursor pagination in `GET /api/hashtags/:tag/caws` where scrolling past the first page (20 posts) prematurely terminates and returns empty results (`items: []`, `nextCursor: null`), even when thousands of tagged posts remain.

## Root Cause

`GET /api/hashtags/:tag/caws` queries the `CawHashtag` join table with cursor filtering on `CawHashtag.id`:

```typescript
const cawHashtags = await prisma.cawHashtag.findMany({
  where: { hashtagId: hashtag.id, caw: { status: 'SUCCESS' } },
  cursor: cursor ? { id: cursor.id } : undefined, // expects CawHashtag.id
  ...
})
```

But the pagination helper was fed the mapped array of `Caw` objects and emitted `caw.id` (the post ID) as the cursor instead of `CawHashtag.id` (the join-table row ID):

```typescript
// Buggy:
const { items: rawCaws, nextCursor } = handlePagination(
  cawHashtags.map(ch => ch.caw),
  limit,
  (caw) => caw.id // wrong id space
)
```

`CawHashtag.id` and `Caw.id` are independent autoincrement sequences, so requesting page 2 with `cursor=<caw.id>` looks for a `CawHashtag` row that doesn't exist at that id, and Prisma returns zero rows — stopping infinite scroll after the first page.

## Fix

Paginate on `cawHashtags` directly (keyed by `ch.id`), then shape the caws afterward:

```typescript
const { items: rawCawHashtags, nextCursor } = handlePagination(
  cawHashtags,
  limit,
  (ch) => ch.id
)
const items = rawCawHashtags.map(ch => shapeCaw(ch.caw))
```

## Verification

- **Live reproduction on V1 (`caw-testnode.com`)**: `#CAW` has 6,000+ tagged posts. Page 1 returns 20 items and `nextCursor: <caw.id>`; requesting page 2 with that cursor returns `items: []` — confirms the bug on real production data with the pre-fix code shape (V1 hasn't received this fix).
- **Synthetic before/after test** (rolled-back transaction, 5 posts, limit 2, deliberately offset `CawHashtag.id` from `Caw.id` via an extra dummy tag on the first post to make the two id spaces diverge): pre-fix logic reproduces the bug (page 2 empty); post-fix logic correctly returns all 5 posts across 3 pages with no gaps or duplicates.
- **Smoke-tested on cawnest.com**: applied the fix, restarted, confirmed `GET /api/hashtags/caw/caws` still returns a well-formed response (no regressions to the existing single-page case).
- `tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

## Note for reviewers

Ordering: `orderBy` sorts by `caw.createdAt`/`caw.id` (post time) while the cursor is `CawHashtag.id` (tag-assignment time). These are different axes and can diverge (~24% of positions differ on V1's `#CAW` tag, likely from batched multi-tag inserts or async hashtag extraction). This doesn't cause duplicates or gaps — cursor-based pagination is correct regardless of sort-order drift — but it means page boundaries aren't guaranteed to align exactly with strict post-time order. Pre-existing property of this pagination pattern, not introduced by this fix; flagging for visibility only.

zinsanjp