### PR TITLE
fix(marketplace): cancel active listings and stale offers on token ownership transfer

### DIFF
--- a/client/src/services/MarketplaceIndexerService/index.ts
+++ b/client/src/services/MarketplaceIndexerService/index.ts
@@ -636,6 +636,14 @@ export const marketplaceIndexerService: Service = {
               data: { status: 'ACCEPTED' },
             })
 
+            // Ownership just transferred to the buyer. Any prior active listing
+            // for this token is now stale (the seller no longer owns it, and
+            // acceptOffer cancelled it on-chain). Cancel it so it stops appearing as live.
+            await prisma.marketplaceListing.updateMany({
+              where: { tokenId, status: 'ACTIVE' },
+              data: { status: 'CANCELLED' },
+            })
+
             // Notify seller and buyer. Mirrors the Sale-event SALE_SOLD/
             // SALE_BOUGHT pair above (L289-347) — an accepted offer is a
             // completed sale too, it just has no MarketplaceListing/Sale


### PR DESCRIPTION
## Summary

Fixes ghost listings and stale offers persisting in the marketplace database after NFT ownership transfers. When a token is sold via direct sale, auction settlement, accepted offer, or transferred externally, any existing active listings (`MarketplaceListing`) and outstanding offers (`MarketplaceOffer`) on that `tokenId` are now automatically marked as `CANCELLED`.

## Root Cause

1. **`OfferAccepted` event**: Updates the accepted `MarketplaceOffer` to `ACCEPTED`, but leaves any prior active `MarketplaceListing` on that `tokenId` in `ACTIVE` state (ghost listing). Leaves all other active offers from other buyers on that same `tokenId` in `ACTIVE` state, even though the token now belongs to a new owner and the previous seller can no longer accept them.
2. **`Sale` (direct buy) & `AuctionSettled` events**: Mark the listing as `SOLD`, but omit cancelling outstanding active offers from other buyers for that `tokenId`.
3. **`Transfer` (external transfer) event**: Cancels the active listing, but omits cancelling outstanding active offers for that `tokenId`.

Confirmed the frontend has no ownership-aware filtering on top of this — `GET /marketplace/tokens/:tokenId/offers` and the address-offers route (`marketplace.ts`) both query strictly on `status: 'ACTIVE'`, so a stale offer left in that state is served to the client as live.

## Fix

Comprehensive ownership-transfer cleanup across all 4 indexer event paths in `client/src/services/MarketplaceIndexerService/index.ts`, using batch `updateMany` keyed by `tokenId` + `status: 'ACTIVE'`:

1. **`OfferAccepted`**: cancel prior active listing + cancel other active offers (excluding the accepted one) on that `tokenId`.
2. **`Sale`**: cancel other active offers on that `tokenId`.
3. **`AuctionSettled`**: cancel other active offers on that `tokenId`.
4. **`Transfer`**: cancel active offers on that `tokenId`, regardless of whether a listing existed.

## Verification

- Verified via 4 rolled-back-transaction scenarios against cawnest.com's DB, exercising the exact `updateMany` logic added to each path:
  - `OfferAccepted`: listing `ACTIVE→CANCELLED`, accepted offer `→ACCEPTED`, other offer `→CANCELLED`. PASS.
  - `Sale`: other pending offer `→CANCELLED`. PASS.
  - `AuctionSettled`: other pending offer `→CANCELLED`. PASS.
  - `External Transfer`: listing `→CANCELLED`, pending offer `→CANCELLED`. PASS.
- Checked cawnest.com's live data for a real-world repro (1 active listing, 0 active offers) — the one active listing's seller still matches the token's current on-chain-synced owner (`User.address`), so no ownership transfer has occurred on this node yet to exercise the bug end-to-end; verification relies on the rolled-back-transaction scenarios above instead.
- `tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).
- Idempotent by design — `updateMany` keyed on `status: 'ACTIVE'` is a no-op on re-indexing or retry.

zinsanjp