### PR TITLE
fix(feed): stop polling caws that 404/410 (deleted or hidden)

### DIFF
--- a/client/src/services/FrontEnd/src/components/Feed.tsx
+++ b/client/src/services/FrontEnd/src/components/Feed.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useLayoutEffect, useState, useCallback, forwardRef, useImperativeHandle, useMemo, useRef } from 'react'
 import { useTokenDataStore } from '~/store/tokenDataStore'
 import FeedItem from './FeedItem'
-import { apiFetch } from '../api/client'
+import { apiFetch, IndexingError, RemovedCawError } from '../api/client'
 import { User, CawItem } from '~/types'
 import { useTheme } from '~/hooks/useTheme'
 import { usePendingPostsStore } from '~/store/pendingPostsStore'
@@ -703,8 +703,19 @@ const Feed = forwardRef<FeedRef, Props>(({ filter, username, apiEndpoint, title 
               }
             })
           )
-        } catch {
-          // Ignore errors
+        } catch (err) {
+          // deleted/rolled-back (404) or author-hidden (410 RemovedCawError)
+          // caws never return -> stop polling by dropping from the feed.
+          // IndexingError (202) = not in DB yet -> keep polling; anything
+          // else = transient/network -> keep polling (previous behaviour).
+          const gone =
+            err instanceof RemovedCawError ||
+            (err instanceof Error &&
+              !(err instanceof IndexingError) &&
+              /^API 4(?:04|10)\b/.test(err.message))
+          if (gone) {
+            setItems(current => current.filter(item => item.id !== caw.id))
+          }
         }
       }
     }, 3000)


### PR DESCRIPTION
Problem

The foryou feed was GET-polling /api/caws/130 every 3s indefinitely, all 404. Investigation chain:

Server-side curl /api/caws/130 → 404 (rules out a SW/cache phantom — curl bypasses the service worker)
DB: caw id=130 is null; the feed list JSON never contains 130 → the id is held client-side, not served
nginx logs: 130 returned 200 (897 B) on 8/22, then the row vanished; ever since, 404 every 3s, non-stop
Root cause: the unified poller in Feed.tsx refetches every PENDING/pending item each tick, but catch {} swallowed all errors. A caw that disappeared (404) or was hidden (410) stayed PENDING forever and was re-polled every tick — no stop condition for "the target is gone".

Fix

On terminal errors — 404 (deleted / rolled back) or 410 RemovedCawError (author-hidden) — drop the item from the feed so it leaves the poll set. Keep polling on IndexingError (202 = not indexed yet) and on transient/network failures (previous behaviour).

Verification

Deployed to a live node. The 3s 404 flood stopped the instant the new bundle loaded — last /api/caws/130 at 12:31:49, zero afterward. Feed otherwise unaffected (notifications/users/badges still polling normally).

Note (follow-up, not in this PR)

A second swallowed catch(() => {}) exists in the one-shot refresh-timer path (~line 583). It can't cause the flood (single fire, not a 3s loop) but holds a vanished item similarly. Left out to keep this diff to the single causal change.