### PR TITLE
Auto-unpin hidden caws to release the pin-cap slot (#77)

### DIFF
--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -1573,7 +1573,7 @@ async function handleHideAction(
     // grace, see orphanedMedia.ts) so revertable hides don't lose data.
     const target = await tx.caw.findFirst({
       where:  { userId: senderId, cawonce, status: 'SUCCESS' },
-      select: { imageData: true },
+      select: { id: true, imageData: true },
     })
 
     const result = await tx.caw.updateMany({
@@ -1587,6 +1587,22 @@ async function handleHideAction(
       markOrphansInImageData(target?.imageData).catch(e =>
         console.warn('[handleHideAction] markOrphansInImageData failed:', e)
       )
+      // #77: hiding a pinned caw must release its pin slot. The pin row is
+      // self-only (only the author can pin their own post), so at most the
+      // sender's own row references this caw. Left in place it keeps counting
+      // toward pinnedCawCount and occupies a top-3 read slot while the caw is
+      // invisible on the profile — a 3/3 cap deadlock with no reachable Unpin.
+      // HIDDEN is terminal for status (no on-chain un-hide), so the row is dead
+      // weight: delete it and recompute the derived counter.
+      if (target) {
+        const removed = await tx.pinnedCaw.deleteMany({
+          where: { userId: senderId, cawId: target.id },
+        })
+        if (removed.count > 0) {
+          await recomputePinnedCount(tx, senderId)
+          console.log(`[handleHideAction] Auto-unpinned hidden caw=${target.id} for user=${senderId}`)
+        }
+      }
     } else {
       console.warn(`[handleHideAction] No matching caw found: user=${senderId} cawonce=${cawonce}`)
     }


### PR DESCRIPTION
## Problem: hiding a pinned caw creates a 3/3 pin-cap deadlock

Hiding your own pinned post (`hide:caw:{cawonce}`) flips the caw
`SUCCESS -> HIDDEN` but leaves its `PinnedCaw` row untouched. That
stale row poisons the pin cap from two directions at once:

1. **Counter never drops.** `recomputePinnedCount` counts
   `pending:false, pendingUnpin:false` rows with **no status filter**
   (`utils/pinnedCount.ts`), so the hidden caw's row keeps counting
   toward `pinnedCawCount`. `handleHideAction` also never calls
   recompute, so nothing re-derives the counter on hide.

2. **Read slot is stolen.** The profile read
   (`api/routes/caws.ts`) does `findMany(... take: 3)` ordered by
   `createdAt desc` and *then* filters `status === 'SUCCESS'`. A hidden
   pin among the newest 3 occupies a slot before the filter runs, so an
   older valid pin never surfaces.

The FE then reads `pinnedCawCount` for the cap UX
(`FeedItem.tsx`: `atCap = myPinCount >= 3` disables the pin button).
Net effect: the profile shows fewer than 3 pins, the button says
**3/3 and is disabled**, and the hidden pin isn't rendered anywhere so
there's **no reachable Unpin** — a dead-end deadlock.

## Fix

Release the pin slot at hide time, inside the same transaction:

- `hide:caw` now selects the caw `id` (in addition to `imageData`) so
  we can address its pin row.
- After the status flip, `deleteMany` the sender's `PinnedCaw` row for
  that caw and `recomputePinnedCount`.

Pins are **self-only** (`handlePinAction` rejects `target.userId !==
senderId`), so at most the author's own row references the caw —
`deleteMany` keyed by `(userId, cawId)` touches nothing else and is a
no-op when there was no pin. `HIDDEN` is terminal for status (there is
no on-chain un-hide action that flips it back to `SUCCESS`), so the pin
row is dead weight rather than a recoverable tombstone; deleting it is
safe.

`+17/-1`, one file (`ActionProcessor/actionHandlers.ts`),
`handleHideAction` only.

## Scope / relation to other PRs

- **Independent of #84.** #84 hardens the pin *entry* (portable
  cross-mirror cawonce + a `status === 'SUCCESS'` guard on the pin
  target). This PR handles the *exit* — releasing the slot when a
  pinned caw is hidden. Different function, non-overlapping hunks; the
  two are the entry/exit halves of the same pin-cap story and don't
  conflict.
- No change to `handleUnpinAction`, the off-chain pin routes, or the
  read/count paths.

## Verification

- Mechanism read end-to-end across `pinnedCount.ts` (no status
  filter), `caws.ts` (take-3-then-filter), and `FeedItem.tsx` (cap
  gate).
- `tsc --noEmit`: **no new errors** — baseline and patched both report
  the same pre-existing env/generated noise
  (`@ethersproject/abstract-provider`, marketplace `WhereUniqueInput`),
  confirmed by stashing the change and re-running (count unchanged).
- **Not yet done (honest):** production `pm2` reload (deferred to after
  merge, since the running tree is a different worktree) and a live
  hide -> confirm-slot-frees -> re-pin round trip. Happy to run the
  live round trip once merged, or before if preferred.

Base: `v2`.