### PR TITLE
fix(action-processor): scope vote orphan-replay check by cawonce ordering, not exact match

### DIFF
--- a/client/src/services/ActionProcessor/domainObjectChecks.ts
+++ b/client/src/services/ActionProcessor/domainObjectChecks.ts
@@ -1,6 +1,7 @@
 // src/services/ActionProcessor/domainObjectChecks.ts
 import { findOrCreateUser } from '../UserService'
 import { CawNotFoundError, findCawId } from './actionHandlers'
+import { parseVoteText } from '../../tools/pollMarker'
 import type { PrismaTransactionClient, RawAction, ProcessedAction } from './types'
 
 /**
@@ -286,24 +287,83 @@ async function checkOtherExists(
   }
 
   if (rawAction.text?.startsWith('vote:')) {
-    // M-2: gate vote replay to prevent multi-select toggle-drift.
-    // Double-replay of a "vote:N" action on a multi-select poll:
-    //   pass 1 — row absent → create + increment totalVotes
-    //   pass 2 — row present → delete + decrement totalVotes  (drift: -1)
-    // Skipping on confirmed-row-present collapses the toggle to a no-op.
-    // Key: (pollId, voterId, optionIndex) = pollId_voterId_optionIndex unique.
-    // We derive the lookup from cawonce (identifies the action) rather than
-    // re-parsing receiverId/optionIndex from text to keep this check cheap
-    // and decoupled from the vote-text parser.
+    // M-2 (original): gate vote replay to prevent multi-select toggle-
+    // drift. That fix keyed the lookup on `cawonce: action.cawonce`
+    // alone, which works for multi-select (each option's toggle is a
+    // distinct on-chain action with its own cawonce that never gets
+    // reassigned) but breaks for single-select: changing a vote
+    // legitimately deletes the prior option's row, and the surviving
+    // row's cawonce becomes whatever this change's action.cawonce was
+    // -- there is only ever ONE row per (pollId, voterId) in
+    // single-select, and it always carries the MOST RECENT confirming
+    // action's cawonce (handleVoteAction sets cawonce: action.cawonce
+    // on both the sameIndex-update and the fresh-create paths). So once
+    // a voter changes their pick, the row's cawonce moves to the new
+    // action -- and the OLD action's cawonce no longer matches ANY row,
+    // even though its effect (superseded by the newer change) is fully
+    // accounted for. The old cawonce-keyed check then returned false
+    // ("not found" == "not yet processed") for an action that was
+    // already correctly applied and later legitimately superseded --
+    // DataCleaner's orphan sweep replayed it repeatedly for up to an
+    // hour, each replay swapping the poll's Vote row back to the STALE
+    // option and drifting totalVotes. Reported by Zin (poll_id showed
+    // 1 real Vote row but totalVotes=2, and the option flip-flopped
+    // roughly every minute in server logs).
+    const parsed = parseVoteText(rawAction.text)
+    if (!parsed) return false
+    if (!rawAction.receiverId || !Number.isFinite(Number(rawAction.receiverCawonce))) return false
+
     const voterId = await findOrCreateUser(action.senderId)
-    const existingVote = await tx.vote.findFirst({
-      where: {
-        voterId,
-        cawonce: action.cawonce,
-        pending: false
-      }
+    let cawId: number
+    try {
+      cawId = await findCawId(Number(rawAction.receiverCawonce), rawAction.receiverId)
+    } catch (err) {
+      if (err instanceof CawNotFoundError) return false
+      throw err
+    }
+    const targetCaw = await tx.caw.findUnique({
+      where: { id: cawId },
+      select: { poll: { select: { id: true, multiSelect: true } } },
     })
-    return existingVote !== null
+    if (!targetCaw?.poll) return false
+    const pollId = targetCaw.poll.id
+
+    if (targetCaw.poll.multiSelect) {
+      // Multi-select: each option toggles independently via its own
+      // on-chain action/cawonce, so the original cawonce-scoped check
+      // is correct here -- no cross-option supersession to worry about.
+      if (parsed.optionIndex === null) return false // unvote text isn't used in multi-select
+      const existing = await tx.vote.findUnique({
+        where: { pollId_voterId_optionIndex: { pollId, voterId, optionIndex: parsed.optionIndex } },
+      })
+      return existing !== null && existing.cawonce === action.cawonce && !existing.pending
+    }
+
+    // Single-select (and unvote): there is at most one row for
+    // (pollId, voterId), and it always carries the cawonce of the
+    // most recently confirmed action for this voter on this poll.
+    // Compare cawonce, not row identity: if the current row's cawonce
+    // is >= this action's cawonce, a confirmation at least as new as
+    // this action has already landed -- this action's effect (whatever
+    // it was) is fully accounted for, whether it was the one that
+    // produced the current row or a since-superseded earlier one.
+    // If the row's cawonce is OLDER than this action's, this action
+    // genuinely hasn't been applied yet (e.g. crash between Tx1 and
+    // Tx2) and must run.
+    const existing = await tx.vote.findFirst({
+      where: { pollId, voterId },
+      select: { cawonce: true },
+    })
+    if (parsed.optionIndex === null) {
+      // Unvote: fully applied once no row remains -- but if a row DOES
+      // remain, only treat this unvote as done if that row is NEWER
+      // (a re-vote after this unvote superseded it); an older row means
+      // this unvote genuinely hasn't run yet.
+      if (!existing) return true
+      return existing.cawonce > action.cawonce
+    }
+    if (!existing) return false
+    return existing.cawonce >= action.cawonce
   }
 
   // For all other OTHER subtypes (profile updates, pin, unpin, hide, xpi, pi)


### PR DESCRIPTION
## Summary

Fixes `DataCleaner`'s orphan-action reconciliation (`cleanupOrphanActions`) repeatedly replaying already-superseded `vote:` actions for up to an hour, each replay corrupting `Poll.totalVotes` and flipping the poll's displayed result between options.

## Root Cause

`checkOtherExists`'s `vote:` branch (added for M-2, to prevent multi-select toggle-drift on replay) keyed its "already processed" check on an exact match: a confirmed `Vote` row with `cawonce === action.cawonce`. This is correct for multi-select, where each option toggles independently via its own on-chain action whose `cawonce` never gets reassigned. It's wrong for single-select: changing a vote legitimately deletes the prior option's row (single-select promises exactly one row per `(pollId, voterId)`), and the surviving row's `cawonce` is overwritten to whatever action confirmed it last. So once a voter changes their pick, the EARLIER action's `cawonce` no longer matches any row — even though that action's effect was already correctly applied and has since been legitimately superseded by the newer change.

The old check returned `false` ("not found" == "not yet processed") for that earlier action, so `DataCleaner`'s 1h-lookback orphan sweep treated it as unapplied and replayed `handleVoteAction` for it — reverting the poll's displayed result and corrupting `totalVotes` on every replay. Observed in production: 1 real Vote row but `totalVotes=2`, with the displayed option flipping roughly every minute in server logs for up to an hour after a vote change.

## Fix

For single-select (and unvote), compare `cawonce` ordering instead of requiring an exact match. There is at most one `Vote` row per `(pollId, voterId)`, and it always carries the `cawonce` of the most recently confirmed action for that voter on that poll (a strictly increasing per-sender nonce, per `CawActions.sol`'s contiguous-cawonce invariant):

- if a row exists with `cawonce >= this action's cawonce`, a confirmation at least as new as this action has already landed — already processed, skip.
- if the row's `cawonce` is older (or no row exists, for a genuinely new pending vote), this action hasn't been applied yet and must run.
- unvote (`optionIndex` null): already applied if no row remains, or if the remaining row is newer.

Multi-select is unchanged in spirit — still keyed on the specific `(pollId, voterId, optionIndex)` row with an exact `cawonce` match, since no cross-option supersession exists there.

## Verification

- Verified via 2 rolled-back-transaction suites against cawnest.com's DB, exercising the exact post-fix predicate: single-select change-vote correctly distinguishes superseded/current/not-yet-applied actions; multi-select same-action vs. different-option correctly distinguished; unvote correctly recognizes a genuinely new action. All PASS.
- Live end-to-end on cawnest.com: applied the fix, restarted, then exercised repeated single-select vote changes (A→B→A→B) on a fresh poll over a 5+ minute window. `totalVotes` stayed exactly 1 throughout (matching the single real Vote row) with zero drift, and server logs showed only expected "Confirmed vote" lines — no replay bursts and no `DataCleaner` "Recovered orphan" entries for this poll, in contrast to the pre-fix behavior observed minutes earlier on the same node (`totalVotes` drifting to 2 against 1 real row, option flip-flopping roughly every minute).
- `tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

## Note

Found while verifying an unrelated, still-in-progress fix for poll pending-state auto-reconciliation on the frontend (a separate PR to follow) -- this bug was corrupting `totalVotes` badly enough that the other fix couldn't be cleanly verified against a stable server count while it was active.

zinsanjp