### PR TITLE
fix(fe): auto-reconcile poll pending state via a self-contained widget poller

### DIFF
--- a/client/src/services/FrontEnd/src/components/PollDisplay.tsx
+++ b/client/src/services/FrontEnd/src/components/PollDisplay.tsx
@@ -210,11 +210,21 @@ const PollDisplay: React.FC<Props> = ({ caw, optionLabelsOverride }) => {
   // pending state matches.
   useEffect(() => {
     if (!poll) return
-    // "Server confirmed at least one of our votes": any row that
-    // came back with pending=false. If the user has a still-pending
-    // optimistic pick we keep that until the indexer round-trips.
-    const serverConfirmed = (poll.userVotes ?? (poll.userVote ? [poll.userVote] : []))
-      .some(r => !r.pending)
+    // "Server confirmed the option(s) we currently have selected" --
+    // NOT just "any row came back with pending=false". During a vote
+    // CHANGE, the server can transiently report both the OLD confirmed
+    // row (e.g. option A, pending:false) and the NEW pending row (e.g.
+    // option B, pending:true) at once -- the old row isn't deleted
+    // until the new one confirms (see the totalVotes-double-count fix,
+    // which stopped the API layer from deleting the old row up front).
+    // Checking "any row confirmed" saw A's leftover confirmed row and
+    // treated the poll as settled BEFORE B actually confirmed,
+    // snapping the UI back to the stale A pick and orphaning the wait
+    // for B. Scope the check to rows whose option we currently have
+    // picked, so a stale unrelated confirmed row can't trigger a
+    // premature resync.
+    const rows = poll.userVotes ?? (poll.userVote ? [poll.userVote] : [])
+    const serverConfirmed = rows.some(r => !r.pending && local.picks.has(r.optionIndex))
     const ourLocalHasPending = Array.from(local.pending.values()).some(v => v)
     if (!userTouchedRef.current || (serverConfirmed && ourLocalHasPending)) {
       setLocal(buildInitialLocal())
@@ -230,11 +240,71 @@ const PollDisplay: React.FC<Props> = ({ caw, optionLabelsOverride }) => {
     // row is now confirmed (pending=false). After confirm we can't
     // cancel it anyway, and a stale entry would make a future "cancel
     // before resubmit" try to cancel an already-finalized action.
-    for (const r of poll.userVotes ?? (poll.userVote ? [poll.userVote] : [])) {
+    for (const r of rows) {
       if (!r.pending) pendingTxIdsRef.current.delete(r.optionIndex)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(poll?.userVotes ?? poll?.userVote), poll?.totalVotes, JSON.stringify(poll?.optionVoteCounts)])
+
+  // Self-contained reconciliation poller for in-flight votes. The
+  // effect above (re-sync from the `poll` prop) only fires when the
+  // PARENT re-fetches and passes fresh props down -- outside Feed.tsx
+  // (e.g. a single-post page, bookmarks, or a modal) nothing was
+  // re-fetching, so a vote could sit in "pending" indefinitely until
+  // a manual reload. This effect makes the widget independently poll
+  // /api/caws/:id every 3s WHILE any of our own votes are still
+  // pending, and stops the moment the server confirms -- works the
+  // same regardless of which screen renders this component.
+  // Read as a plain boolean, not the Map object itself: local.pending
+  // is a fresh Map on every setLocal call (submitVote copies via
+  // `new Map(curr.pending)`), so depending on the Map reference itself
+  // would be fine too -- but deriving a boolean here is clearer about
+  // what actually gates this effect and avoids relying on that
+  // implementation detail continuing to hold.
+  const hasLocalPending = Array.from(local.pending.values()).some(v => v)
+  useEffect(() => {
+    if (!hasLocalPending) return
+
+    const interval = setInterval(async () => {
+      try {
+        const data = await apiFetch<{ caw: CawItem }>(`/api/caws/${caw.id}`)
+        const freshPoll = data.caw?.poll
+        if (!freshPoll) return
+
+        const rows = freshPoll.userVotes ?? (freshPoll.userVote ? [freshPoll.userVote] : [])
+        // Same scoping fix as the sibling effect above: only treat this
+        // as settled once the option(s) we're CURRENTLY waiting on are
+        // confirmed, not just any row -- a stale pre-change confirmed
+        // row can coexist with our still-pending new pick during a
+        // vote change.
+        const serverConfirmed = rows.some(r => !r.pending && local.picks.has(r.optionIndex))
+        if (!serverConfirmed) return
+
+        const picks = new Set<number>()
+        const pending = new Map<number, boolean>()
+        for (const r of rows) {
+          picks.add(r.optionIndex)
+          pending.set(r.optionIndex, r.pending)
+        }
+        setLocal({
+          picks,
+          pending,
+          counts: freshPoll.optionVoteCounts ? freshPoll.optionVoteCounts.slice() : (freshPoll.options || []).map(() => 0),
+          total: freshPoll.totalVotes || 0,
+        })
+        userTouchedRef.current = false
+        for (const r of rows) {
+          if (!r.pending) pendingTxIdsRef.current.delete(r.optionIndex)
+        }
+      } catch {
+        // Transient network error -- retry on the next tick rather than
+        // surfacing anything to the user.
+      }
+    }, 3000)
+
+    return () => clearInterval(interval)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [caw.id, hasLocalPending])
 
   // Mount-once flag so bars get a "fill from 0" entry animation the first
   // time results render. Without this the bars would snap to width on


### PR DESCRIPTION
## Summary

Enables automatic, reload-free reconciliation of poll votes and pending badges on screens outside the main feed (single-post view, bookmarks, modals), and fixes the pending badge getting stuck on a stale pick during a vote CHANGE anywhere it's shown.

## Dependencies

This PR assumes #89 and #90 are merged first:
- #89 changed the API layer to stop deleting the prior confirmed Vote row up front on a single-select vote change, so the server can transiently report BOTH the old confirmed row and the new pending row at once during a vote change. This PR's core fix (scoping the "server confirmed" check to the option currently selected) only matters, and was only found, because of that behavior change.
- #90 fixes a separate DataCleaner orphan-replay bug that, left unfixed, corrupts totalVotes and flips the poll's displayed option on every vote change -- without it, this PR's auto-reconcile behavior can't be verified against a stable server state (every live test kept getting drowned out by that bug's noise).

## Problem

After voting on a poll, the widget optimistically enters the "pending" state. `PollDisplay.tsx` already had a `useEffect` that clears this state once fresh confirmed props arrive from the parent, but that effect only fires when the PARENT re-fetches and passes updated props down:
- `Feed.tsx`'s unified 3s polling loop (`toRefetch` filter) checks `item.status`, `likePending`, `recawPending`, `replyPending`, and `tipPending` -- but not any poll-pending signal, so polls rendered inside Feed never got re-fetched on the poll's account.
- Outside `Feed.tsx` (`CawPage.tsx` single-post view, Bookmarks, modals), there is no polling of poll state at all -- those screens' own polling loops only watch `caw.status === 'PENDING'` or `replyPending`.

As a result, a poll vote stayed frozen on "pending" indefinitely on every screen until the user manually reloaded the page.

## Fix (part 1): self-contained widget poller

Rather than wiring `pollPending` through `Feed.tsx`'s `toRefetch` filter (which would still miss every screen other than Feed), give `PollDisplay.tsx` its own self-contained polling effect. It activates only while `local.pending` has at least one `true` entry, hits `/api/caws/:id` every 3s, and as soon as the server reports the CURRENTLY SELECTED option(s) confirmed, syncs local state to the fresh server snapshot and stops.

## Fix (part 2): scope "server confirmed" to the current pick, not any row

Found during live verification (with #89 and #90 already applied): after the FIRST vote this worked perfectly, but every subsequent vote CHANGE left the pending badge stuck until a reload. Root cause: both this new poller and the pre-existing prop-driven `useEffect` judged "server confirmed" by checking whether ANY row in `poll.userVotes` had `pending:false` -- not whether the option the user currently has selected was the one that confirmed. Because #89 stopped the API layer from deleting the prior confirmed row up front, a vote CHANGE transiently reports BOTH the OLD confirmed row (e.g. option A) and the NEW pending row (e.g. option B) at once. The old "any row confirmed" check saw A's leftover confirmed row and treated the poll as already settled -- before B's real confirmation ever landed -- snapping local state back to the stale A pick and abandoning the wait for B (`userTouchedRef` reset to false, the poller's `hasLocalPending` flipped to false, poller stopped). A reload picked up the eventually-correct B from a fresh fetch, masking the bug.

Fixed both effects to check `rows.some(r => !r.pending && local.picks.has(r.optionIndex))` instead of `rows.some(r => !r.pending)` -- only a confirmed row for an option the user actually has selected counts as "this vote change is done."

Also fixed, from an earlier round of live testing: the poller's `useEffect` depended on the `local.pending` Map object directly, which (it turned out, after checking) IS freshly re-created via `new Map(curr.pending)` on every `submitVote` call, so that specific concern didn't apply -- but deriving a plain `hasLocalPending` boolean outside the effect and depending on that instead is clearer about what actually gates the effect, so kept that as a defensive/readability improvement regardless.

## Known limitation (not fixed here)

Unvoting (removing your pick entirely) clears both `local.picks` and `local.pending`, so `hasLocalPending` goes false and this poller never activates for that action -- there's nothing left it thinks it needs to wait for. On `Feed.tsx`, the unvote's eventual confirmation still gets picked up incidentally by Feed's own unrelated 3s poll (which re-fetches the whole caw for other pending flags). On every other screen (`CawPage`, Bookmarks, modals), an unvote's on-chain confirmation status isn't actively reconciled by this widget -- if the unvote submission itself silently fails, the optimistic "no longer voted" UI state won't self-correct without a reload. Scoped out of this PR to keep it focused; worth a follow-up if it turns out to matter in practice.

## Verification

Live end-to-end on cawnest.com (with #89 and #90 both applied), fully reload-free after one initial reload to load the new bundle:
- Fresh poll, first vote: pending badge cleared into confirmed 100%/1-vote display automatically. PASS.
- Vote change (A -> B): pending badge on B cleared into confirmed display automatically, no reload -- DB confirmed exactly 1 Vote row (optionIndex=1, pending=false) throughout. PASS.
- Vote change back (B -> A), repeated to confirm this isn't a one-off: same result, no reload needed. PASS.

`tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

zinsanjp