### PR TITLE
fix(RawEventsGatherer): resume from last after floor-fill completes

### DIFF
--- a/client/src/services/RawEventsGatherer/index.ts
+++ b/client/src/services/RawEventsGatherer/index.ts
@@ -206,6 +206,8 @@ export const rawEventsGathererService: Service = {
           getLastProcessedEvent: getLast,
           storeEvent:            storeAndPublish,
           storeBatch:            storeBatchAndPublish,
+          isFloorFilled:   async () => (await redis.get(`raw-events-gatherer:${chainId}:${networkId}:floor-filled`)) === '1',
+          markFloorFilled: async () => { await redis.set(`raw-events-gatherer:${chainId}:${networkId}:floor-filled`, '1') },
         },
         onTick: () => ctx.heartbeat('poll'),
       })

--- a/client/src/services/RawEventsGatherer/index.ts
+++ b/client/src/services/RawEventsGatherer/index.ts
@@ -206,8 +206,22 @@ export const rawEventsGathererService: Service = {
           getLastProcessedEvent: getLast,
           storeEvent:            storeAndPublish,
           storeBatch:            storeBatchAndPublish,
-          isFloorFilled:   async () => (await redis.get(`raw-events-gatherer:${chainId}:${networkId}:floor-filled`)) === '1',
-          markFloorFilled: async () => { await redis.set(`raw-events-gatherer:${chainId}:${networkId}:floor-filled`, '1') },
+          // Floor-fill completion is persisted in ChainData (DB) rather than
+          // Redis: the flag is a write-once, never-touched-again key, so under
+          // an LRU/LFU maxmemory-policy it is the prime eviction candidate among
+          // the hot per-poll cursors — and losing it forces a full historical
+          // re-floor. ChainData is as durable as the events themselves and is
+          // never evicted. Written only after processEvents() returns
+          // successfully (see markFloorFilled call site), so a crash mid-scan
+          // still fails safe toward re-floor, never toward a false "filled".
+          isFloorFilled:   async () => {
+            const row = await prisma.chainData.findUnique({ where: { key: `raw-events-gatherer:${chainId}:${networkId}:floor-filled` } })
+            return (row?.value as any)?.filled === true
+          },
+          markFloorFilled: async () => {
+            const key = `raw-events-gatherer:${chainId}:${networkId}:floor-filled`
+            await prisma.chainData.upsert({ where: { key }, update: { value: { filled: true } }, create: { key, value: { filled: true } } })
+          },
         },
         onTick: () => ctx.heartbeat('poll'),
       })

--- a/client/src/services/RawEventsGatherer/listenForRawEvents.ts
+++ b/client/src/services/RawEventsGatherer/listenForRawEvents.ts
@@ -220,6 +220,16 @@ export default async function listenForRawEvents(
        * one INSERT instead of N. Falls back to storeEvent when absent.
        */
       storeBatch?(events: RawEventInput[]): Promise<void>
+      /**
+       * Floor-fill guard (idempotent, Redis-backed). isFloorFilled() reports
+       * whether the historical scan down to the configured startBlock has
+       * completed on a prior run; markFloorFilled() records completion. Once
+       * filled, restarts resume from the last processed block instead of
+       * re-flooring to startBlock and re-scanning the whole
+       * config.startBlock..last range on every restart.
+       */
+      isFloorFilled(): Promise<boolean>
+      markFloorFilled(): Promise<void>
     }
     /** Optional callback to signal liveness — called at the end of each successful poll */
     onTick?: () => void
@@ -254,6 +264,7 @@ export default async function listenForRawEvents(
     : null
 
   const last = await config.rawEventsProvider.getLastProcessedEvent()
+  const floorAlreadyFilled = await config.rawEventsProvider.isFloorFilled()
   // Resolve the historical-scan start block.
   //
   // A configured startBlock (config.json override or Network.creationBlock) is a
@@ -270,7 +281,15 @@ export default async function listenForRawEvents(
   // double-processing, just gap-filling. So we never MISS history, and never
   // re-process what's already there.
   let startBlock: number
-  if (config.startBlock !== undefined) {
+  let resumingFromLast = false
+  if (config.startBlock !== undefined && last && floorAlreadyFilled) {
+    // Floor already filled on a prior run — the config.startBlock..last range
+    // is fully in the DB, so resume from `last` instead of re-flooring to the
+    // configured startBlock and re-scanning that whole range on every restart.
+    startBlock = last.blockNumber
+    resumingFromLast = true
+    console.log(`[RawEventsGatherer] Floor already filled — resuming from last processed block ${startBlock}`)
+  } else if (config.startBlock !== undefined) {
     startBlock = last ? Math.min(last.blockNumber, config.startBlock) : config.startBlock
     if (last && config.startBlock < last.blockNumber) {
       console.log(`[RawEventsGatherer] Flooring scan at configured startBlock ${config.startBlock} (last event at ${last.blockNumber} — filling history below it)`)
@@ -279,6 +298,7 @@ export default async function listenForRawEvents(
     }
   } else if (last) {
     startBlock = last.blockNumber
+    resumingFromLast = true
   } else {
     startBlock = await httpProvider.getBlockNumber()
     console.log(`[RawEventsGatherer] Fresh DB, no startBlock configured — starting from current block ${startBlock}`)
@@ -286,7 +306,7 @@ export default async function listenForRawEvents(
   // parentHash chain seed: only trust `last`'s hash when we're actually
   // resuming from it (no configured floor pulling us earlier); otherwise the
   // historical walk re-derives the chain from the floor.
-  let lastHash = (config.startBlock === undefined && last) ? last.parentHash : 'genesis'
+  let lastHash = (resumingFromLast && last) ? last.parentHash : 'genesis'
 
   function hashNext(prev: string, action: any): string {
     // JSON stringify with bigint→string replacer
@@ -503,6 +523,17 @@ export default async function listenForRawEvents(
   }
 
   await processEvents(past, httpContract)
+
+  // Historical fill down to the configured floor is now complete and durably
+  // in the DB. Record it so subsequent restarts resume from `last` (see the
+  // floor-already-filled branch above) rather than re-scanning the whole
+  // config.startBlock..latest range each time. Setting this without a real
+  // fill is harmless: the resume branch also requires `last`, so the flag
+  // only changes behaviour once there is a last-processed block to resume from.
+  if (config.startBlock !== undefined && !floorAlreadyFilled) {
+    await config.rawEventsProvider.markFloorFilled()
+    console.log(`[RawEventsGatherer] Marked floor-fill complete — future restarts resume from last processed block`)
+  }
 
   // Setup WebSocket for real-time events
   async function setupWebSocket() {


### PR DESCRIPTION
The configured startBlock acts as a hard floor on every startup: when a prior event sits above it, listenForRawEvents floors the historical scan back down to startBlock and re-derives the entire startBlock..latest range on each restart. On a live node that means re-scanning hundreds of thousands of blocks every time the process restarts, delaying live-event processing behind a redundant historical walk.

Add a Redis-backed floor-fill guard through the rawEventsProvider abstraction (isFloorFilled / markFloorFilled). Once the historical fill down to the configured floor has completed once and is durably in the DB, subsequent restarts resume from the last processed block instead of re-flooring. The floor path is preserved unchanged for the cold-start race it was written for (a stray live/WS/peer event pinning last above startBlock before the historical scan runs); the guard only skips the RE-flooring on later restarts. lastHash seeding now keys off an explicit resumingFromLast flag so the resume path correctly trusts last.parentHash.

Keyed per (chainId, networkId). Marking without a real fill is harmless: the resume branch also requires last, so the flag only changes behaviour once there is a last-processed block to resume from.