### PR TITLE
fix(notifications): clean up notification and group on recaw undo

### DIFF
--- a/client/src/api/routes/caws.ts
+++ b/client/src/api/routes/caws.ts
@@ -769,14 +769,67 @@ router.delete('/:originalCawId/recaw', requireAuth({
         })
         await tx.caw.delete({ where: { id: recaw.id } })
         await safeDecrement(tx, 'Caw', 'recawCount', 'id', originalCawId)
-        await tx.notification.deleteMany({
+
+        // Find the notification(s) to delete FIRST so we can also clean up
+        // their NotificationGroup -- deleteMany alone leaves the group's
+        // count/latestNotificationId pointing at rows that no longer exist.
+        const staleNotifications = await tx.notification.findMany({
           where: {
             actorId: userId,
             userId: originalCaw.userId,
             type: 'REPOST',
             cawId: originalCawId,
           },
+          select: { id: true, groupId: true },
         })
+        if (staleNotifications.length > 0) {
+          await tx.notification.deleteMany({
+            where: { id: { in: staleNotifications.map(n => n.id) } },
+          })
+          // Roll back each affected group's count by however many of its
+          // rows we just deleted (normally 1, but be exact in case of a
+          // rare double-write), and drop the group entirely once its count
+          // hits zero so no empty rollup lingers in the feed.
+          const groupIds = [...new Set(staleNotifications.map(n => n.groupId).filter((id): id is number => id != null))]
+          for (const groupId of groupIds) {
+            const deletedInGroup = staleNotifications.filter(n => n.groupId === groupId).length
+            const group = await tx.notificationGroup.findUnique({
+              where: { id: groupId },
+              select: { count: true, latestNotificationId: true },
+            })
+            if (!group) continue
+            const newCount = Math.max(0, group.count - deletedInGroup)
+            if (newCount === 0) {
+              await tx.notificationGroup.delete({ where: { id: groupId } })
+            } else {
+              const deletedWasLatest = staleNotifications.some(
+                n => n.groupId === groupId && n.id === group.latestNotificationId,
+              )
+              if (deletedWasLatest) {
+                // The group's "lead" pointer was one of the rows we just
+                // removed -- repoint it at whatever member is now newest
+                // so the feed doesn't render a dangling reference.
+                const next = await tx.notification.findFirst({
+                  where: { groupId },
+                  orderBy: { createdAt: 'desc' },
+                  select: { id: true },
+                })
+                await tx.notificationGroup.update({
+                  where: { id: groupId },
+                  data: {
+                    count: newCount,
+                    ...(next ? { latestNotificationId: next.id } : {}),
+                  },
+                })
+              } else {
+                await tx.notificationGroup.update({
+                  where: { id: groupId },
+                  data: { count: newCount },
+                })
+              }
+            }
+          }
+        }
       })
     } else {
       // No confirmed recaw row yet — might be a pending txqueue that hasn't been processed.

--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -1619,6 +1619,62 @@ async function handleHideAction(
       // Decrement the parent's recawCount via CountManager (floors at zero + audit log)
       await countManager.onRecawRemoved(tx, { originalCawId: originalCaw.id, senderId, amount: deleted.count })
       console.log(`[handleHideAction] Deleted recaw: user=${senderId} of caw=${originalCaw.id}`)
+
+      // Clean up the REPOST notification the recaw generated -- without
+      // this, the receiver's notification feed keeps a "ghost" repost
+      // notice for a repost that no longer exists on-chain. Mirrors the
+      // same cleanup /api/caws/:originalCawId/recaw does for the
+      // client-initiated undo path (this is the on-chain-confirmed path).
+      const staleNotifications = await tx.notification.findMany({
+        where: {
+          actorId: senderId,
+          userId: receiverId, // receiverId is the original post's author (see the where clause above)
+          type: 'REPOST',
+          cawId: originalCaw.id,
+        },
+        select: { id: true, groupId: true },
+      })
+      if (staleNotifications.length > 0) {
+        await tx.notification.deleteMany({
+          where: { id: { in: staleNotifications.map(n => n.id) } },
+        })
+        const groupIds = [...new Set(staleNotifications.map(n => n.groupId).filter((id): id is number => id != null))]
+        for (const groupId of groupIds) {
+          const deletedInGroup = staleNotifications.filter(n => n.groupId === groupId).length
+          const group = await tx.notificationGroup.findUnique({
+            where: { id: groupId },
+            select: { count: true, latestNotificationId: true },
+          })
+          if (!group) continue
+          const newCount = Math.max(0, group.count - deletedInGroup)
+          if (newCount === 0) {
+            await tx.notificationGroup.delete({ where: { id: groupId } })
+          } else {
+            const deletedWasLatest = staleNotifications.some(
+              n => n.groupId === groupId && n.id === group.latestNotificationId,
+            )
+            if (deletedWasLatest) {
+              const next = await tx.notification.findFirst({
+                where: { groupId },
+                orderBy: { createdAt: 'desc' },
+                select: { id: true },
+              })
+              await tx.notificationGroup.update({
+                where: { id: groupId },
+                data: {
+                  count: newCount,
+                  ...(next ? { latestNotificationId: next.id } : {}),
+                },
+              })
+            } else {
+              await tx.notificationGroup.update({
+                where: { id: groupId },
+                data: { count: newCount },
+              })
+            }
+          }
+        }
+      }
     } else {
       console.warn(`[handleHideAction] No recaw found to delete: user=${senderId} originalCaw=${originalCaw.id}`)
     }


### PR DESCRIPTION
## Summary

When a user undoes a recaw (repost), the associated REPOST notification and its NotificationGroup were left behind, so the receiver's notification feed kept showing a "ghost" repost that no longer exists.

## Root Cause

1. `actionHandlers.ts`'s `handleHideAction` (the on-chain-confirmed `hide:recaw:` path) deleted the recaw `Caw` row and decremented `recawCount`, but never touched the `Notification` table at all.
2. `api/routes/caws.ts`'s `DELETE /:originalCawId/recaw` (the client-initiated path) DID delete the `Notification` row, but never rolled back the parent `NotificationGroup`'s `count` or deleted the group once empty -- leaving an orphaned, permanently-open group whose `latestNotificationId` could point at a row that no longer exists.

## Fix

Both paths now look up the stale REPOST notification(s) BEFORE deleting, so the affected `NotificationGroup`(s) can be reconciled in the same transaction:

- Delete the notification row(s).
- Decrement each affected group's `count` by however many of its rows were just removed (normally 1).
- If a group's `count` reaches zero, delete the group entirely rather than leaving an empty rollup in the feed.
- If the group still has other members but the deleted row was its `latestNotificationId` (the "lead" pointer used for rendering), repoint it at the next-most-recent surviving member so the feed doesn't render a dangling reference.

Both `handleHideAction` and the API route run this inside the same transaction as the recaw deletion + `recawCount` decrement, so a failure here rolls back the whole undo rather than leaving `recawCount` decremented with the notification still present.

## Verification

- Verified via 2 rolled-back-transaction scenarios against cawnest.com's DB:
  - Solo notification (group count 1 -> 0): both notification and group deleted. PASS.
  - Grouped notifications: undoing a non-latest member correctly decrements count and leaves `latestNotificationId` untouched; undoing the last remaining (and latest) member correctly deletes the group. PASS.
- Also live-verified end-to-end on cawnest.com: found 2 pre-existing ghost REPOST notifications in production data (orphaned by this bug before the fix), confirming the bug is real and has already caused drift. Applied the fix, restarted, then recawed and undid a fresh recaw through the on-chain `hide:recaw:` path -- the `Caw` row, the `Notification`, and the now-empty `NotificationGroup` were all correctly removed within seconds of the on-chain confirmation, with no manual cleanup needed. Pre-existing ghost notifications from before the fix are out of scope for this PR (this fixes new occurrences going forward, not a backfill of historical drift).
- `tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

zinsanjp