### PR TITLE
fix(api): select endsAt and multiSelect in caw poll includes

### DIFF
--- a/client/src/api/routes/hashtags.ts
+++ b/client/src/api/routes/hashtags.ts
@@ -56,14 +56,14 @@ router.get('/:tag/caws', async (req, res) => {
             recaws: currentUserId
               ? { where: { userId: currentUserId, action: 'RECAW' }, select: { id: true } }
               : false,
-            poll: { select: { id: true, options: true, optionImages: true, totalVotes: true } },
+            poll: { select: { id: true, options: true, optionImages: true, totalVotes: true, endsAt: true, multiSelect: true } },
             hashtags: {
               include: { hashtag: { select: { name: true } } }
             },
             parent: {
               include: {
                 user: { select: { tokenId: true, username: true, displayName: true, image: true, avatarUrl: true, defaultAvatarId: true } },
-                poll: { select: { id: true, options: true, optionImages: true, totalVotes: true } },
+                poll: { select: { id: true, options: true, optionImages: true, totalVotes: true, endsAt: true, multiSelect: true } },
                 hashtags: {
                   include: { hashtag: { select: { name: true } } }
                 }

--- a/client/src/api/shared/cawUtils.ts
+++ b/client/src/api/shared/cawUtils.ts
@@ -307,7 +307,7 @@ export function getCawIncludeConfig(options: CawQueryOptions = {}) {
     // viewer's own vote come from a follow-up enrichWithPollVotes() call —
     // groupBy + targeted findMany is cheaper than fanning aggregates out
     // through Prisma's nested includes for every list endpoint.
-    poll: { select: { id: true, options: true, optionImages: true, totalVotes: true } },
+    poll: { select: { id: true, options: true, optionImages: true, totalVotes: true, endsAt: true, multiSelect: true } },
     ...(includeHashtags && {
       hashtags: {
         include: { hashtag: { select: { name: true } } }
@@ -331,7 +331,7 @@ export function getCawIncludeConfig(options: CawQueryOptions = {}) {
         bookmarks: currentUserId
           ? { where: { userId: currentUserId }, select: { userId: true }, take: 1 }
           : false,
-        poll: { select: { id: true, options: true, optionImages: true, totalVotes: true } },
+        poll: { select: { id: true, options: true, optionImages: true, totalVotes: true, endsAt: true, multiSelect: true } },
         ...(includeHashtags && {
           hashtags: {
             include: { hashtag: { select: { name: true } } }


### PR DESCRIPTION
## Summary

Fixes poll expiration ("Ends in Xh" / "Poll ended") never rendering, and multi-select polls always being reported as single-select, because every Prisma `poll.select` clause that shapes API responses omitted `endsAt` and `multiSelect` entirely.

## Root Cause

`Poll.endsAt` and `Poll.multiSelect` are correctly stored and computed at post time, but the `poll.select` clauses in `getCawIncludeConfig` (`cawUtils.ts` -- used by the main feed, single-post, and bookmarks routes) and independently in `hashtags.ts` (the hashtag feed route has its own from-scratch include, not routed through `getCawIncludeConfig`) only selected `id`, `options`, `optionImages`, and `totalVotes`. Since Prisma omits unselected columns from the returned object entirely (not `null`, `undefined`), `shapeCaw`'s `raw.poll.endsAt ? raw.poll.endsAt.toISOString() : null` always fell through to `null`, and `multiSelect: !!raw.poll.multiSelect` always evaluated `!!undefined` to `false` -- silently downgrading any multi-select poll to single-select in every API response, on top of the `endsAt` gap.

No poll on cawnest.com happened to be created with `multiSelect:true` yet, so that half wasn't visibly exercised in production data here, but the `endsAt` gap was live and visible: every poll rendered with no countdown and never showed "Poll ended" regardless of its actual expiration.

Confirmed this doesn't affect vote-processing correctness: the indexer's own `handleVoteAction` resolves the poll via its own independent select (already includes `endsAt`/`multiSelect`), so this fix only corrects what API responses expose for display -- it does not change how votes are counted or validated. Also confirmed no double-management risk: `enrichWithPollVotes` (the other function that decorates poll data post-fetch) only touches `optionVoteCounts`/`userVote`/`userVotes`, never `endsAt`/`multiSelect` -- `shapeCaw` remains the single place these two fields are set. Checked the frontend too: `PollDisplay.tsx` already correctly reads `poll.endsAt`/`poll.multiSelect` (`isMulti`, `hasEnded`, the countdown footer) -- no frontend change needed, it was only ever missing the data.

## Fix

Added `endsAt: true` and `multiSelect: true` to every `poll.select` clause that was missing them:
- `cawUtils.ts`'s `getCawIncludeConfig` (root caw's poll + parent caw's poll, covering the main feed, single-post view, and bookmarks -- all three route through this shared config).
- `hashtags.ts`'s two from-scratch `poll.select` clauses (root + parent), which don't go through `getCawIncludeConfig` and were missed by an initial pass that only fixed `cawUtils.ts`.

## Verification

Verified live on cawnest.com: applied the `cawUtils.ts` fix, restarted, then fetched an existing poll's caw via the API -- response now includes `"endsAt": "2026-08-30T04:11:09.984Z"` and `"multiSelect": false` where both were previously absent. Confirmed on the frontend too: polls that had already passed their `endsAt` now correctly render "投票は終了しました" ("Poll ended") and remaining-time footers ("1h 36mで終了"), neither of which had ever appeared before this fix across the entire session. Then audited for other `poll.select` sites and found `hashtags.ts`'s independent includes were still missing the same two fields -- fixed and applied those too; `bookmarks.ts` and `caws.ts` both route through `getCawIncludeConfig` so needed no separate change.

`tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

zinsanjp