### PR TITLE
fix(cli): add missing DepositWatcher and StakeLedgerReconciler to config template and generator

### DIFF
--- a/cli/src/steps/generate.js
+++ b/cli/src/steps/generate.js
@@ -431,6 +431,17 @@ export function buildServiceList(nodeType, config) {
         chainId: net.l1ChainId,
       }
     })
+    services.push({
+      service: 'DepositWatcher',
+      config: {
+        l1RpcUrl: '${L1_RPC_URL}',
+        chainId: net.l1ChainId,
+      }
+    })
+    services.push({
+      service: 'StakeLedgerReconciler',
+      config: {}
+    })
   }
 
   return services

--- a/client/config.template.json
+++ b/client/config.template.json
@@ -58,5 +58,16 @@
       "l1RpcUrl": "${L1_RPC_URL}",
       "chainId":  11155111
     }
+  },
+  {
+    "service": "DepositWatcher",
+    "config": {
+      "l1RpcUrl": "${L1_RPC_URL}",
+      "chainId":  11155111
+    }
+  },
+  {
+    "service": "StakeLedgerReconciler",
+    "config": {}
   }
 ]


### PR DESCRIPTION
## Summary

**This PR has two goals**: (1) fix `DepositWatcher` and `StakeLedgerReconciler` so they actually start, and (2) **clearly flag to the dev team that these are not the only background services that have never run on any node** -- at least 4 are implemented and registered but silently absent from config generation.

Both `client/config.template.json` and the CLI's `generate.js` (`cli/src/steps/generate.js`'s `buildServiceList()` -- what `install.sh` -> `cli/bin/caw.js install` actually uses to write a node's `config.json`; confirmed no code path reads `config.template.json` outside `node_modules`, so fixing the template alone would not have been enough) were missing `DepositWatcher` and `StakeLedgerReconciler`, so neither service has ever started on any node. Both are implemented and registered in `runServices.ts`'s `availableServiceList`, but absent from both the template and `buildServiceList()`, so `programs/start.ts` (which only launches services explicitly enumerated in `config.json`) never reaches `start()` for either.

## Important note for the dev team: other services are also not running

This PR only fixes `DepositWatcher` and `StakeLedgerReconciler`, but **`LzRelayService` and `SponsorRepayIndexer` are, for the exact same reason (missing from config), also currently not running on any node.** @tentencaw independently investigated this on their own node (node2) and confirmed via log audit: `DepositWatcher`, `LzRelayService`, and `SponsorRepayIndexer` all log unconditionally on start/skip, and none of those lines appear anywhere across 2 days of node2's logs. `StakeLedgerReconciler` has no logging at all so its silence isn't diagnostic on its own, but its absence from config is independently confirmed.

**These two (`LzRelayService`, `SponsorRepayIndexer`) are intentionally left out of this PR** because a same-shape "just add it to config" fix isn't sufficient for either:
- `LzRelayService` needs `LZ_SELF_RELAY_ENABLED=true` to do anything -- otherwise it starts but stays `idle`.
- `SponsorRepayIndexer` reads `cfg.minterAddress`/`cfg.ledgerAddress` directly from config with no env-var fallback (unlike `DepositWatcher`'s `cfg.cawProfileAddress || CAW_NAMES_ADDRESS` pattern) -- real per-node address values would need to be decided and set.

Both need a real design decision -- whether to enable them (and how, operationally) or leave them deliberately disabled -- and we wanted that flagged explicitly here rather than silently left as-is.

Separately, @tentencaw's investigation also surfaced that **`InstanceRegistry` is missing from `config.template.json`** (though correctly present in `generate.js`). No live impact (the installer path is correct), but it's further evidence that the template and the actual generator (`generate.js`) have drifted out of sync across multiple services, independent of the 4 flagged above.

## Root cause context

`DepositWatcher` not running is the root cause of a bug found and fixed earlier in this same series (see the StakeLedger unseen-token-halt PR): L1 deposits never reached `StakeLedger.recordDeposit`, undercounting local `totalCaw` relative to the on-chain total and skewing the reward-multiplier's distribution denominator on every action -- producing a small, compounding DIVERGENCE that eventually halted the ledger. `StakeLedgerReconciler` is the service that would otherwise have caught and self-corrected exactly this kind of drift via its 24h reconciliation sweep, so its absence compounded the problem. The two are complementary: `DepositWatcher` only picks up deposits from its own checkpoint forward (a first-time start has no history, by design), so `StakeLedgerReconciler`'s 24h sweep is what backfills anything `DepositWatcher` missed.

## Fix

Added both services to:
- `client/config.template.json`
- `cli/src/steps/generate.js`'s `buildServiceList()`, under the same `RUNS_INDEXER` guard as the other L1/L2-dependent indexer services (`RawEventsGatherer`, `ChainSyncService`, `NftTransferWatcher`) -- this is the entry that actually matters, since the installer's generated `config.json` comes from here, not the template.

Also verified (via @tentencaw's investigation, confirmed by reading `rpcProvider.ts`): the config template's `"${L1_RPC_URL}"`-style placeholder values are never actually substituted anywhere in the codebase. Every RPC-consuming service instead resolves its real URL from environment variables first (`getL1HttpRpcUrl`), so the placeholder is effectively inert as long as the operator's `.env` has the real URL set. This is a pre-existing pattern shared by every other service entry in both files, not something introduced or left unfixed by this PR -- flagged here for visibility, template-wide placeholder-expansion redesign is out of scope.

Verified each service's Config schema accepts the values added:
- `DepositWatcher`: `l1RpcUrl` and `chainId` both optional/defaulted in the zod schema, but the service throws at startup without a resolvable `l1RpcUrl` -- matches the template's explicit values.
- `StakeLedgerReconciler`: all fields optional/defaulted, so an empty `{}` config is valid. `stats()` reporting `"idle"` between 24h runs is expected, not an error state.

`client/config.template.json`: valid JSON. `cli/src/steps/generate.js`: valid syntax (`node --check`). Client `tsc --noEmit`: zero new errors.

## Verification

Live-verified end-to-end on cawnest.com: added the same two service entries to the node's actual `config.json` (a separate, manual operational change outside this PR's scope, done purely to verify the fix works end to end) and restarted. Both services started successfully for the first time in this node's history: `[DepositWatcher] No checkpoint — starting from current head 11609676`, `Instance DepositWatcher started`, `Instance StakeLedgerReconciler started`, `stats for StakeLedgerReconciler: idle [loops: reconcile=30s]`.

zinsanjp