### PR TITLE
fix(sponsor-repay): fall back to canonical addresses.ts like DepositWatcher

### DIFF
--- a/client/src/services/SponsorRepayIndexer/index.ts
+++ b/client/src/services/SponsorRepayIndexer/index.ts
@@ -28,6 +28,7 @@ import { z } from 'zod'
 import { ethers } from 'ethers'
 import Redis from 'ioredis'
 import { makeJsonRpcProvider, getL1HttpRpcUrl, getL2HttpRpcUrl, redactRpcUrl } from '../../utils/rpcProvider'
+import { CAW_NAMES_MINTER_ADDRESS, CAW_NAMES_L2_ADDRESS } from '../../abi/addresses'
 import { Service } from '../../Service'
 import { prisma } from '../../prismaClient'
 
@@ -301,15 +302,16 @@ export const sponsorRepayIndexerService: Service = {
 
       // ── L1: CawProfileMinter — SponsorRepaySet ──────────────────────────
       const l1RpcUrl = getL1HttpRpcUrl(cfg.l1RpcUrl)
-      if (l1RpcUrl && cfg.minterAddress) {
+      const minterAddress = cfg.minterAddress || CAW_NAMES_MINTER_ADDRESS
+      if (l1RpcUrl && minterAddress) {
         const l1Provider = makeJsonRpcProvider(l1RpcUrl, cfg.l1ChainId)
-        const minterContract = new ethers.Contract(cfg.minterAddress, MINTER_ABI as any, l1Provider)
+        const minterContract = new ethers.Contract(minterAddress, MINTER_ABI as any, l1Provider)
 
-        const l1CpKey = cpKey(String(cfg.l1ChainId), cfg.minterAddress)
+        const l1CpKey = cpKey(String(cfg.l1ChainId), minterAddress)
         const currentL1 = await l1Provider.getBlockNumber().catch(() => 0)
         const l1Start = await loadCheckpoint(redis, l1CpKey, cfg.l1StartBlock ?? currentL1)
 
-        console.log(`[SponsorRepayIndexer:L1] Starting — minter=${cfg.minterAddress} chainId=${cfg.l1ChainId} fromBlock=${l1Start}`)
+        console.log(`[SponsorRepayIndexer:L1] Starting — minter=${minterAddress} chainId=${cfg.l1ChainId} fromBlock=${l1Start}`)
 
         l1Loop = makePollLoop({
           label:    'SponsorRepayIndexer:L1',
@@ -338,15 +340,16 @@ export const sponsorRepayIndexerService: Service = {
 
       // ── L2: CawProfileLedger — Registered / Swept / Forgiven ───────────
       const l2RpcUrl = getL2HttpRpcUrl(cfg.l2RpcUrl)
-      if (l2RpcUrl && cfg.ledgerAddress) {
+      const ledgerAddress = cfg.ledgerAddress || CAW_NAMES_L2_ADDRESS
+      if (l2RpcUrl && ledgerAddress) {
         const l2Provider = makeJsonRpcProvider(l2RpcUrl, cfg.l2ChainId)
-        const ledgerContract = new ethers.Contract(cfg.ledgerAddress, LEDGER_ABI as any, l2Provider)
+        const ledgerContract = new ethers.Contract(ledgerAddress, LEDGER_ABI as any, l2Provider)
 
-        const l2CpKey = cpKey(String(cfg.l2ChainId), cfg.ledgerAddress)
+        const l2CpKey = cpKey(String(cfg.l2ChainId), ledgerAddress)
         const currentL2 = await l2Provider.getBlockNumber().catch(() => 0)
         const l2Start = await loadCheckpoint(redis, l2CpKey, cfg.l2StartBlock ?? currentL2)
 
-        console.log(`[SponsorRepayIndexer:L2] Starting — ledger=${cfg.ledgerAddress} chainId=${cfg.l2ChainId} fromBlock=${l2Start}`)
+        console.log(`[SponsorRepayIndexer:L2] Starting — ledger=${ledgerAddress} chainId=${cfg.l2ChainId} fromBlock=${l2Start}`)
 
         l2Loop = makePollLoop({
           label:    'SponsorRepayIndexer:L2',


### PR DESCRIPTION
## Give SponsorRepayIndexer the same address fallback DepositWatcher has

Follow-up to #99. That PR intentionally left `SponsorRepayIndexer` out of the generator because, unlike `DepositWatcher`, it reads its contract addresses straight from config with no fallback:

if (l1RpcUrl && cfg.minterAddress) { ... } // L1
if (l2RpcUrl && cfg.ledgerAddress) { ... } // L2


So without explicit `minterAddress` / `ledgerAddress` in `config.json` it just logs `Skipping` and never runs — which means "add it to `buildServiceList`" alone wouldn't have started it. `DepositWatcher` avoids this with `cfg.cawProfileAddress || CAW_NAMES_ADDRESS`.

### Change
This mirrors that pattern exactly:
- L1: `cfg.minterAddress || CAW_NAMES_MINTER_ADDRESS`
- L2: `cfg.ledgerAddress || CAW_NAMES_L2_ADDRESS`

Both constants already exist in `client/src/abi/addresses.ts`, and `CAW_NAMES_L2_ADDRESS` is the same address `getCawProfileLedger()` resolves the ledger from — so this reads from the canonical generated source rather than requiring operators to hand-write addresses into config. Config-level `minterAddress` / `ledgerAddress` still override when present.

### Effect
With RPC resolved env-first (`getL1/L2HttpRpcUrl`) and the address now falling back to the canonical constant, `SponsorRepayIndexer` runs whenever RPC is available — same activation shape as `DepositWatcher`. This unblocks adding it to `buildServiceList()` / `config.template.json` with a minimal config entry, which I've left as a follow-up to avoid conflicting with #99's `RUNS_INDEXER` edits.

### Scope
Code-only; no generator/template change here (see above). tsc `--noEmit` clean, no new errors.