### PR TITLE
fix(viewtracker): filter getTrendingByViews by status SUCCESS to prevent leaking deleted posts

### DIFF
--- a/client/src/services/ViewTracker.ts
+++ b/client/src/services/ViewTracker.ts
@@ -98,6 +98,15 @@ export async function trackBulkViews(cawIds: number[], userId?: number, ipHash?:
 export async function getTrendingByViews(limit: number = 10): Promise<number[]> {
   const trending = await prisma.caw.findMany({
     where: {
+      // Without this, a deleted (HIDDEN) or on-chain-confirmation-failed
+      // (FAILED) post that accrued enough views before that happened
+      // still qualifies -- its id then leaks into the trending list,
+      // and GET /api/views/trending's callers hit a 404 fetching its
+      // details. Matches the status filter tools/hashtags.ts already
+      // uses for hashtag trending, and lets the Caw model's existing
+      // @@index([status, createdAt]) composite index actually be used
+      // (leading column now constrained) instead of scanning past it.
+      status: 'SUCCESS',
       createdAt: {
         gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) // Last 7 days
       },


### PR DESCRIPTION
## Summary

Fixes `getTrendingByViews()` including deleted (`HIDDEN`) or confirmation-failed (`FAILED`) posts in the trending list whenever they accrued 5+ views before that status change. `GET /api/views/trending` returns a bare id array to callers, who then fetch each post's details -- a leaked HIDDEN/FAILED id produces a 404, a zombie fetch, or a ghost-post render on the client, depending on the caller.

## Root Cause

The `where` clause filtered on `createdAt` (7-day window) and `viewCount` (>= 5) but never checked `status` at all.

## Fix

Added `status: 'SUCCESS'` to the `where` clause. Matches the status filter `tools/hashtags.ts`'s `getHashtagsInWindow` already uses for hashtag trending (`WHERE c.status = 'SUCCESS' AND c."createdAt" >= since`), unifying the two trending queries' semantics. Also lets Postgres actually use the `Caw` model's existing `@@index([status, createdAt])` composite index (leading column now constrained) instead of scanning past it.

## Verification

Verified via a rolled-back-transaction scenario against cawnest.com's DB: created 4 posts (`SUCCESS`, `HIDDEN`, `FAILED`, `PENDING`) all with `viewCount >= 5` and `createdAt` within the trending window, ran the post-fix query -- only the `SUCCESS` post was included; `HIDDEN`, `FAILED`, and `PENDING` were all correctly excluded. PASS.

Also confirmed the bug's real-world shape on cawnest.com's live data: `caw_default` (V1) has 599 `HIDDEN` rows (max viewCount 11) and 335 `FAILED` rows (max viewCount 7); `caw_cawnest_com` (V2) has 32 `HIDDEN` rows (max viewCount 12) -- any of these that happened to fall within the trending window's 7-day/5-view threshold would have leaked. None currently do (no `HIDDEN`/`FAILED` row is both within the last 7 days and at `viewCount >= 5` right now), so the fix couldn't be observed correcting a currently-live leak, but the underlying condition is real and will recur any time a post is deleted or fails confirmation shortly after picking up enough views.

## Note

`trackView()` itself doesn't check `status` when incrementing `viewCount`, so a `HIDDEN` post's `viewCount` can still climb if someone has a direct link and keeps viewing it -- that's a separate, unrelated gap (whether view-tracking itself should stop once a post is deleted) and doesn't affect this fix: regardless of how high a deleted post's `viewCount` climbs, this PR's status filter keeps it out of the trending list either way.

Applied and restarted on cawnest.com. `tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

zinsanjp