### PR TITLE
fix(dm): route local first-contact DMs to Requests tab, fix Requests badge count mismatch

### DIFF
--- a/client/src/services/DmService/index.ts
+++ b/client/src/services/DmService/index.ts
@@ -87,6 +87,36 @@ export class DmService {
     // (dm-relay.ts), so any drift here breaks federation.
     const id = deterministicConversationId(userIdA, userIdB)
 
+    // Determine userIdB's (the "recipient" for this creation call)
+    // inbox status, matching dm-relay.ts's first-contact routing rule
+    // exactly: first contact + neither side follows the other -> the
+    // recipient's participant row starts as REQUEST (Requests tab);
+    // otherwise ACCEPTED (Main tab). This is a get-OR-create -- since
+    // `existing` above already returned early for any prior
+    // conversation, reaching here always means first contact, so we
+    // don't need dm-relay.ts's separate isFirstContact check.
+    //
+    // Deliberately mirrors dm-relay.ts's own Follow lookup as-is
+    // (matched on followerId/followingId/action only, not status) so
+    // the two routing paths agree with each other bit-for-bit. Note
+    // for a future pass: neither this nor dm-relay.ts checks
+    // Follow.status, so a not-yet-confirmed (PENDING) follow is
+    // treated the same as a confirmed one here -- a narrow, largely
+    // harmless window (the common case is the follower themselves
+    // messaging right after following, which is expected to land in
+    // Main either way) rather than something this PR changes.
+    const [senderFollowsRecipient, recipientFollowsSender] = await Promise.all([
+      prisma.follow.findFirst({
+        where: { followerId: userIdA, followingId: userIdB, action: 'FOLLOW' }
+      }),
+      prisma.follow.findFirst({
+        where: { followerId: userIdB, followingId: userIdA, action: 'FOLLOW' }
+      }),
+    ])
+    const recipientStatus: 'ACCEPTED' | 'REQUEST' = (!senderFollowsRecipient && !recipientFollowsSender)
+      ? 'REQUEST'
+      : 'ACCEPTED'
+
     return prisma.conversation.create({
       data: {
         id,
@@ -94,8 +124,8 @@ export class DmService {
         creatorId: userIdA,
         participants: {
           create: [
-            { userId: userIdA },
-            { userId: userIdB }
+            { userId: userIdA, status: 'ACCEPTED' },
+            { userId: userIdB, status: recipientStatus }
           ]
         }
       },
@@ -394,6 +424,10 @@ export class DmService {
     return prisma.conversationParticipant.count({
       where: {
         userId,
+        // Match the same leftAt: null filter the requests-tab list
+        // query uses, so the badge count and the list it's counting
+        // never disagree.
+        leftAt: null,
         status: 'REQUEST',
         conversation: { messages: { some: {} } },
       },


### PR DESCRIPTION
## Summary

Two related DM bugs found in `getOrCreateConversation` and `getRequestCount`. Both verified against live cawnest.com data.

## 1. Local (same-instance) first-contact DMs always land in Main, ignoring follow status

`getOrCreateConversation` (the local, same-instance conversation creation path) created both participant rows with no explicit `status`, defaulting to `ConversationParticipantStatus`'s schema default (`ACCEPTED`) regardless of whether the two users follow each other. `dm-relay.ts` (the cross-instance federation path) already implements the intended first-contact routing rule -- neither side follows the other on first contact -> the recipient's participant starts as `REQUEST` (Requests tab), otherwise `ACCEPTED` (Main tab) -- but that logic only ran for messages arriving from another node. Any DM between two users on the **same instance** always landed `ACCEPTED` regardless of follow status, silently defeating the Requests/spam-filtering feature for local conversations, which are presumably the common case on any given node.

**Fix**: mirrored `dm-relay.ts`'s routing rule inside `getOrCreateConversation` itself. Since this function already returns early for any existing conversation, reaching the creation branch always means genuine first contact, so the separate `isFirstContact` check `dm-relay.ts` needs isn't necessary here. Deliberately matched `dm-relay.ts`'s Follow lookup exactly (`followerId`/`followingId`/`action` only, no status filter) so the two paths' routing decisions agree with each other bit-for-bit rather than introducing a second, slightly different definition of "follows."

**Noted for visibility (not fixed here, judged low-impact)**: neither this fix nor the pre-existing `dm-relay.ts` logic checks `Follow.status`, so a not-yet-confirmed (`PENDING`) follow is treated the same as a confirmed one. This only matters for a few minutes at most -- `DataCleaner`'s `cleanupPendingFollows` resolves any stale `PENDING` follow within 5-30 minutes against the on-chain Action log -- and the common real-world case (the follower themselves messaging right after following) is expected to land in Main either way, so this isn't something a user would perceive as broken.

## 2. Requests-tab badge count disagrees with the actual Requests list

`getRequestCount` (the Requests-tab badge) counted `ConversationParticipant` rows by `{ userId, status: 'REQUEST', conversation: { messages: { some: {} } } }` but never filtered `leftAt: null`, while the actual Requests-tab list query does filter it. A user who left/was removed from a still-pending request conversation would be counted in the badge but never appear in the list it's supposedly counting -- an unreachable ghost count with no way to clear it (nothing to accept or decline). Added the same `leftAt: null` filter so the badge and the list it summarizes can never disagree.

## Verification

Verified via a rolled-back-transaction suite against cawnest.com's DB: a first-contact conversation with no follow relation between the two users correctly gets `REQUEST` for the recipient; a first-contact conversation where the sender already follows the recipient correctly gets `ACCEPTED`; `getRequestCount` correctly counts a `REQUEST` conversation with a message; the same conversation's count correctly drops to 0 once the participant's `leftAt` is set. All 4 scenarios PASS.

Also confirmed the bug's real-world impact directly on cawnest.com's existing data before applying the fix: of 3 pre-existing DM conversations, 2 (`dm:3:18`, `dm:9:18`) had both participants `ACCEPTED` despite zero `Follow` rows existing between either pair -- concrete evidence the pre-fix code never actually enforced first-contact routing on this node. Live-verified end-to-end after applying the fix and restarting: a fresh DM between two users with no follow relation correctly landed with the recipient's participant row as `REQUEST` and the sender's as `ACCEPTED`, confirmed via direct DB query and matching the recipient's own account seeing it land in their Requests tab.

`tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

zinsanjp