### PR TITLE
fix(tips): compute totalAmount over all matching tips, not just the c…

### DIFF
--- a/client/src/api/routes/tips.ts
+++ b/client/src/api/routes/tips.ts
@@ -18,7 +18,7 @@ router.get('/post/:cawId', async (req, res) => {
     const limit = Math.min(Number(req.query.limit) || 20, 100)
     const offset = Number(req.query.offset) || 0
 
-    const [tips, totalCount] = await Promise.all([
+    const [tips, totalCount, amountAgg] = await Promise.all([
       prisma.tip.findMany({
         where: { cawId },
         take: limit,
@@ -35,10 +35,19 @@ router.get('/post/:cawId', async (req, res) => {
           }
         }
       }),
-      prisma.tip.count({ where: { cawId } })
+      prisma.tip.count({ where: { cawId } }),
+      // Sum over ALL tips on this post, not just the current page --
+      // reducing over `tips` (the paginated page) silently understated
+      // the total once a post had more tips than one page's `limit`.
+      // Also excludes still-pending tips, matching what the rest of the
+      // app treats as "real" (confirmed) tip totals.
+      prisma.tip.aggregate({
+        where: { cawId, pending: false },
+        _sum: { amount: true }
+      })
     ])
 
-    const totalAmount = tips.reduce((sum, tip) => sum + tip.amount, 0)
+    const totalAmount = amountAgg._sum.amount ?? 0
 
     return res.json({ tips, totalAmount, count: totalCount, hasMore: offset + tips.length < totalCount })
   } catch (error) {
@@ -103,24 +112,32 @@ router.get('/received', requireAuth({ lookup: async (req) => Number(req.query.us
 
     const userTokenId = parseInt(userId as string)
 
-    const tips = await prisma.tip.findMany({
-      where: { recipientId: userTokenId },
-      take: Math.min(Number(limit), 100),
-      skip: Number(offset),
-      orderBy: { createdAt: 'desc' },
-      include: {
-        sender: {
-          select: {
-            tokenId: true,
-            username: true,
-            displayName: true,
-            avatarUrl: true, defaultAvatarId: true
+    const [tips, amountAgg] = await Promise.all([
+      prisma.tip.findMany({
+        where: { recipientId: userTokenId },
+        take: Math.min(Number(limit), 100),
+        skip: Number(offset),
+        orderBy: { createdAt: 'desc' },
+        include: {
+          sender: {
+            select: {
+              tokenId: true,
+              username: true,
+              displayName: true,
+              avatarUrl: true, defaultAvatarId: true
+            }
           }
         }
-      }
-    })
+      }),
+      // Sum over ALL tips this user has received, not just the current
+      // page -- see the matching fix in GET /post/:cawId above for why.
+      prisma.tip.aggregate({
+        where: { recipientId: userTokenId, pending: false },
+        _sum: { amount: true }
+      })
+    ])
 
-    const totalAmount = tips.reduce((sum, tip) => sum + tip.amount, 0)
+    const totalAmount = amountAgg._sum.amount ?? 0
 
     return res.json({ tips, totalAmount })
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes `GET /api/tips/post/:cawId` and `GET /api/tips/received` returning a `totalAmount` that silently understates the real total once a post (or user) has more tips than fit in a single page, and that also included still-pending (unconfirmed) tips.

## Root Cause

Both endpoints computed `totalAmount` by `tips.reduce((sum, tip) => sum + tip.amount, 0)` over the just-fetched page (`take: limit`), not over every matching row. A post/user with more tips than `limit` (default 20/50) silently reported a lower total than reality, with no error or indication anything was truncated. Neither endpoint filtered `pending: false` either, so a tip that hadn't yet confirmed on-chain was counted the same as a confirmed one.

## Fix

Added a parallel `prisma.tip.aggregate({ _sum: { amount: true } })` scoped the same way as the existing `count`/`findMany` (by `cawId` or `recipientId`), filtered to `pending: false`, and used its result as `totalAmount` instead of reducing over the page. The page's `findMany` is otherwise unchanged -- this only fixes what `totalAmount` reports, not which tips get listed.

Note:aggregate is scoped to pending: false while listing/count preserve existing behavior

## Verification

Verified via a rolled-back-transaction scenario against cawnest.com's DB: created 25 tips on one post (limit 20 per page), 3 of them pending. Fetching page 1 (20 rows) confirmed `totalAmount` correctly reflects the sum of all 22 confirmed tips (22000), not the 20-row page's sum (20000, which is what the old reduce-over-page logic would have returned and is demonstrably wrong either way it's sliced -- it both misses 2 confirmed tips past the page boundary and would have also wrongly included any pending ones inside the page).

Also live-verified end-to-end on cawnest.com: applied the fix, restarted, then queried `GET /api/tips/post/467?limit=5` (a real post with 13 tips, more than the 5-row limit requested) -- `totalAmount` correctly returned `472545913` (the full 13-tip sum, matching a direct DB aggregate query run beforehand) despite only 5 rows being present in the response's `tips` array.

`tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

zinsanjp