### PR TITLE
fix(og): add TTL expiration and LRU eviction to the OG image disk cache

### DIFF
--- a/client/src/api/routes/og.ts
+++ b/client/src/api/routes/og.ts
@@ -2531,6 +2531,72 @@ async function serveCachedOrRender(
   }
 }
 
+/**
+ * Clean up stale OG card PNGs from the disk cache. Nothing in this file
+ * (or anywhere else -- grepped the repo) ever deletes from CACHE_DIR,
+ * so it grows without bound: crawlers/social-bots hit every locale
+ * variant of every profile/caw/hashtag card, and any profile stat
+ * change (follower count, avatar, etc.) mints a new cacheKey, leaving
+ * the old one to sit forever. Live-confirmed on cawnest.com: 3,147
+ * files / 1.2GB accumulated with no cleanup mechanism at all.
+ *
+ * Safe to prune freely -- serveCachedOrRender's fs.existsSync check
+ * means a missing file just falls through to build() and regenerates
+ * on the next request (~20-50ms), never a 404 or broken image.
+ *
+ * Removes files older than maxAgeMs (default: 7 days), and if the
+ * surviving count still exceeds maxFiles (default: 2000, ~800MB at
+ * ~400KB/file), evicts the oldest-by-mtime until back under the cap --
+ * an LRU-style safety ceiling independent of the TTL, so a sudden
+ * traffic spike within the 7-day window can't blow past a bounded
+ * disk footprint.
+ */
+export async function cleanStaleOgCache(
+  maxAgeMs: number = 7 * 24 * 60 * 60 * 1000,
+  maxFiles: number = 2000
+): Promise<{ scanned: number; deleted: number; freedBytes: number }> {
+  if (!fs.existsSync(CACHE_DIR)) return { scanned: 0, deleted: 0, freedBytes: 0 }
+  try {
+    const files = await fs.promises.readdir(CACHE_DIR)
+    const pngFiles = files.filter(f => f.endsWith('.png'))
+    const now = Date.now()
+    let deleted = 0
+    let freedBytes = 0
+    const surviving: { file: string; mtimeMs: number; size: number }[] = []
+
+    for (const file of pngFiles) {
+      const fullPath = path.join(CACHE_DIR, file)
+      try {
+        const stat = await fs.promises.stat(fullPath)
+        if (now - stat.mtimeMs > maxAgeMs) {
+          await fs.promises.unlink(fullPath)
+          deleted++
+          freedBytes += stat.size
+        } else {
+          surviving.push({ file: fullPath, mtimeMs: stat.mtimeMs, size: stat.size })
+        }
+      } catch { /* best-effort — ignore race with concurrent delete */ }
+    }
+
+    if (surviving.length > maxFiles) {
+      surviving.sort((a, b) => a.mtimeMs - b.mtimeMs)
+      const excess = surviving.slice(0, surviving.length - maxFiles)
+      for (const item of excess) {
+        try {
+          await fs.promises.unlink(item.file)
+          deleted++
+          freedBytes += item.size
+        } catch { /* best-effort */ }
+      }
+    }
+
+    return { scanned: pngFiles.length, deleted, freedBytes }
+  } catch (err: any) {
+    console.error('[og] cleanStaleOgCache failed:', err?.message || err)
+    return { scanned: 0, deleted: 0, freedBytes: 0 }
+  }
+}
+
 router.get('/image/profile/:username', async (req, res) => {
   const username = String(req.params.username).toLowerCase()
   // ?locale=<code> selects the chrome language; validated against the

--- a/client/src/services/DataCleaner/index.ts
+++ b/client/src/services/DataCleaner/index.ts
@@ -4,6 +4,7 @@ import { makeJsonRpcProvider, makeWebSocketProvider, getL2HttpRpcUrl } from '../
 import { dataCleanerLogger as logger } from '../../utils/dataCleanerLogger'
 import { markTxQueueFailed } from '../../utils/txQueueFailure'
 import { sweep as sweepOrphanedMedia, pendingCount as orphanedMediaPendingCount } from '../../api/util/orphanedMedia'
+import { cleanStaleOgCache } from '../../api/routes/og'
 import { cawProfileLedgerAbi } from '../../abi/generated'
 import { CAW_NAMES_L2_ADDRESS } from '../../abi/addresses'
 import { checkDomainObjectExists } from '../ActionProcessor/domainObjectChecks'
@@ -1324,7 +1325,38 @@ async function runDataCleanup() {
   // there's nothing to do (single ZRANGEBYSCORE).
   await sweepOrphanedMediaTask()
 
+  // Clean stale OG card image cache from disk (>7 days old or >2000
+  // files). Nothing else in the codebase ever prunes this directory --
+  // see cleanStaleOgCache's doc comment in og.ts. Throttled to run at
+  // most once per hour (below) so DataCleaner's normal per-minute tick
+  // doesn't churn a readdir+stat over every cached PNG that often.
+  await sweepOgCacheTask()
+
   logger.log('All cleanup tasks completed')
+}
+
+// Throttle: DataCleaner's main loop ticks every minute, but scanning
+// the OG cache directory (readdir + stat per file) doesn't need to
+// run nearly that often -- once an hour keeps disk I/O negligible
+// while still reclaiming space well within the 7-day TTL window.
+let lastOgCacheSweep = 0
+const OG_CACHE_SWEEP_INTERVAL = 60 * 60 * 1000 // 1 hour
+
+async function sweepOgCacheTask() {
+  const now = Date.now()
+  if (now - lastOgCacheSweep < OG_CACHE_SWEEP_INTERVAL) return
+  lastOgCacheSweep = now
+  try {
+    const res = await cleanStaleOgCache()
+    if (res.deleted > 0) {
+      const freedMb = (res.freedBytes / (1024 * 1024)).toFixed(2)
+      logger.log(
+        `OG cache sweep: deleted ${res.deleted} stale images, freed ${freedMb} MB (scanned ${res.scanned})`
+      )
+    }
+  } catch (err: any) {
+    logger.error(`OG cache sweep error: ${err?.message || err}`)
+  }
 }
 
 async function sweepOrphanedMediaTask() {


### PR DESCRIPTION
## Summary

Fixes unbounded disk growth in the OG card image cache (`public/uploads/og-cache/`). Rendered PNG preview cards were written to disk on cache miss with no TTL, expiration, or size cap anywhere in the codebase -- grepped the whole repo and confirmed the only writes to `CACHE_DIR` were `fs.writeFileSync` calls in `og.ts`, with zero unlink or pruning code for it (`DataCleaner`'s existing `orphanedMedia.ts` sweep handles Filebase assets, not this local disk cache).

Live-confirmed on cawnest.com: `og-cache/` had accumulated **3,147 PNG files totaling 1.2GB** with no cleanup mechanism at all. Crawlers and social-media bots request every locale variant of every profile/caw/hashtag card (`?locale=ja`, `?locale=ko`, `?locale=ar`, etc.), and any profile stat change (follower count, avatar) mints a fresh cacheKey, leaving the old one to sit forever -- disk usage grows without bound as user count and crawl traffic scale.

## Fix

1. **`api/routes/og.ts`**: added `cleanStaleOgCache(maxAgeMs, maxFiles)`.
   - Deletes files older than `maxAgeMs` (default 7 days).
   - If the surviving count still exceeds `maxFiles` (default 2000, ~800MB at ~400KB/file), evicts the oldest-by-mtime until back under the cap -- an LRU-style ceiling independent of the TTL, so a traffic spike within the 7-day window can't blow past a bounded disk footprint.
   - Safe to prune freely: `serveCachedOrRender`'s `fs.existsSync` check means a missing file just falls through to `build()` and regenerates on the next request (~20-50ms) -- never a 404 or broken image. Best-effort per-file error handling (a single failed unlink from a concurrent-delete race doesn't abort the sweep).

2. **`services/DataCleaner/index.ts`**: integrated `sweepOgCacheTask()` into `runDataCleanup()`, throttled to run at most once per hour (`OG_CACHE_SWEEP_INTERVAL`) -- `DataCleaner`'s normal per-minute tick doesn't need to `readdir`+`stat` the whole cache directory that often. Runs automatically on node startup, no manual config or cron needed. Logs deleted count and freed MB when it actually removes something.

`maxFiles=2000` (~800MB) is left as the reported default for this PR; noted as a follow-up that neither `maxAgeMs` nor `maxFiles` is configurable via env var, so an operator running a much smaller VPS than this testnet node has no way to tighten the cap without editing code -- out of scope here, tracked separately.

## Verification

Verified in an isolated tmp directory (not the live cache, to avoid touching real files during the test) with synthetic PNGs and backdated mtimes via `fs.utimesSync`: TTL pruning correctly deleted exactly the 5 files older than the 7-day boundary out of 10 total, leaving the 5 fresh ones; LRU eviction (`maxFiles=2`) on the 5 survivors correctly evicted the 3 oldest by mtime, leaving exactly 2. Both scenarios PASS.

Live-verified end-to-end on cawnest.com: applied the fix, restarted. `og-cache/` dropped from 3,147 files / 1.2GB to 26 files / 9.7MB after `DataCleaner`'s first sweep -- over 120x reduction, confirmed via direct `find`/`du` on the live directory before and after. Confirmed no real impact after deletion: requesting a previously-cached post's OG card (`/api/og/caw/467`) after the sweep correctly returned `HTTP 200`, auto-regenerated on demand with no broken behavior.

`tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

zinsanjp