### PR TITLE
fix(scheduled-posts): include cawonce on TxQueue insert to enforce duplicate-submission guard

### DIFF
--- a/client/src/services/ScheduledPostProcessor/index.ts
+++ b/client/src/services/ScheduledPostProcessor/index.ts
@@ -242,6 +242,17 @@ async function processScheduledPost(scheduledPost: any): Promise<boolean> {
       const txQueueEntry = await prisma.txQueue.create({
         data: {
           senderId: data.senderId,
+          // Without this, the row lands with cawonce: NULL, which the
+          // partial unique index TxQueue_senderId_cawonce_active_unique
+          // (see migration 20260429100000) explicitly excludes via its
+          // own `AND "cawonce" IS NOT NULL` clause -- so a NULL-cawonce
+          // row is silently invisible to the duplicate-submission guard
+          // that every other action path (e.g. api/routes/actions.ts's
+          // insert) relies on. A processor restart or polling race
+          // while a scheduled post is in flight could then insert a
+          // second TxQueue row for the same underlying signed action,
+          // with no DB-level protection to catch it.
+          cawonce: data.cawonce,
           payload: { data, domain, types },
           signedTx: signature
         }


### PR DESCRIPTION
## Summary

Fixes `ScheduledPostProcessor` omitting `cawonce` when creating the `TxQueue` row for a due scheduled post, silently bypassing the `TxQueue_senderId_cawonce_active_unique` partial unique index and leaving no DB-level protection against duplicate in-flight submissions on a processor restart or polling race.

## Root Cause

`prisma.txQueue.create()` in `ScheduledPostProcessor/index.ts` passed `senderId`, `payload`, and `signedTx`, but not `cawonce: data.cawonce` -- unlike `api/routes/actions.ts`'s own `txQueue.create` (L856), which always stamps it. `data.cawonce` is already established as the correct field elsewhere in this same file (used for the Caw's own `cawonce`, and for the Reply upsert's `userId_cawonce` key), so this was purely an omission at this one insert site, not a naming/availability issue.

Migration `20260429100000_add_txqueue_cawonce_unique`'s own SQL makes the exposure explicit: the partial index is defined `WHERE status IN (...) AND "cawonce" IS NOT NULL` -- a row inserted with `cawonce` left unset lands as `NULL` and is excluded from the index entirely, so the duplicate-submission guard every other action path relies on silently never applied to scheduled posts.

## Fix

Added `cawonce: data.cawonce` to the `txQueue.create()` call.

## Verification

Verified via a rolled-back-transaction scenario against cawnest.com's DB, exercising the actual partial unique index: two `TxQueue` rows created without `cawonce` (reproducing the pre-fix insert) landed as `NULL` and were NOT blocked by the index -- confirms the bug's mechanism directly. Two rows created WITH the same `(senderId, cawonce)` (reproducing the post-fix insert on a hypothetical retry) correctly triggered a `UniqueConstraintViolation` on the second insert. Both PASS.

Checked cawnest.com's live `TxQueue` table: zero existing rows with `cawonce IS NULL`, meaning this specific gap hasn't yet produced a real duplicate submission on this node -- the scheduled-post feature hasn't been exercised heavily enough to hit the restart/race window that would trigger it, not that the bug is inert. Also confirmed this doesn't overlap with the separate concurrency-lock fix from an earlier PR (`557851ae6`, "add atomic concurrency lock to prevent double-processing") -- that commit guards `ScheduledPostProcessor` itself from picking up the same due post twice via `scheduledCaw.updateMany`'s own claim mechanism; this fix protects the downstream `TxQueue` insert via the DB's partial unique index. The two are complementary layers, not overlapping or conflicting.

Applied and restarted on cawnest.com. `tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

zinsanjp