### PR TITLE
fix(marketplace): sort prices, bids, and offers numerically using BigInt instead of string order

### DIFF
--- a/client/src/api/routes/marketplace.ts
+++ b/client/src/api/routes/marketplace.ts
@@ -11,6 +11,34 @@ const redis = process.env.REDIS_URL
 const router = Router()
 
 /**
+ * Numerically compares two Wei-denominated amounts stored as strings.
+ * startPrice/amount columns are String in schema.prisma specifically
+ * to hold 18+ digit Wei values without integer overflow -- but that
+ * means a plain Prisma `orderBy` on these columns sorts them as
+ * PostgreSQL text (lexicographic/ASCII order), not numerically.
+ * "1000000000000000000" (1.0 ETH) sorts BEFORE "90000000000000000"
+ * (0.09 ETH) as a string (leading '1' < '9'), so price_asc/price_desc
+ * and "highest bid/offer" selection were both silently wrong whenever
+ * two values had a different number of digits -- live-confirmed on
+ * cawnest.com: a 355,660,137.41 CAW listing sorted as "cheapest"
+ * ahead of a 5.29 CAW listing under price_asc.
+ * Falls back to string comparison only if a value fails to parse as
+ * a BigInt (defensive; shouldn't happen for well-formed Wei strings).
+ */
+function compareWei(a: string | null | undefined, b: string | null | undefined): number {
+  if (!a && !b) return 0
+  if (!a) return -1
+  if (!b) return 1
+  try {
+    const bigA = BigInt(a)
+    const bigB = BigInt(b)
+    return bigA > bigB ? 1 : bigA < bigB ? -1 : 0
+  } catch {
+    return (a || '').localeCompare(b || '')
+  }
+}
+
+/**
  * GET /api/marketplace/listings
  * Filtered, sorted, paginated active listings.
  * Query params: type, minLength, maxLength, paymentToken, sort, limit, offset, status
@@ -52,28 +80,65 @@ router.get('/listings', async (req, res) => {
       ]
     }
 
+    // startPrice is a String column (see compareWei's doc comment) --
+    // price_asc/price_desc can't be expressed as a Prisma `orderBy`
+    // without sorting lexicographically. Fetch all matching rows
+    // (still respecting `where`), sort numerically in-process, then
+    // apply the same take/skip window the DB-sorted paths use, so
+    // pagination behaves identically regardless of sort mode.
+    const isPriceSort = sort === 'price_asc' || sort === 'price_desc'
+
     let orderBy: any = { createdAt: 'desc' }
     switch (sort) {
-      case 'price_asc':  orderBy = { startPrice: 'asc' }; break
-      case 'price_desc': orderBy = { startPrice: 'desc' }; break
       case 'newest':     orderBy = { createdAt: 'desc' }; break
       case 'length_asc': orderBy = { usernameLength: 'asc' }; break
       case 'length_desc': orderBy = { usernameLength: 'desc' }; break
     }
 
-    const [listings, total] = await Promise.all([
-      prisma.marketplaceListing.findMany({
-        where,
-        orderBy,
-        take: limit,
-        skip: offset,
-        include: {
-          bids: { where: { status: 'ACTIVE' }, orderBy: { amount: 'desc' }, take: 1 },
-          _count: { select: { bids: true } },
-        },
-      }),
-      prisma.marketplaceListing.count({ where }),
-    ])
+    let listings: any[]
+    let total: number
+
+    if (isPriceSort) {
+      const [allMatching, count] = await Promise.all([
+        prisma.marketplaceListing.findMany({
+          where,
+          include: {
+            bids: { where: { status: 'ACTIVE' }, orderBy: { amount: 'desc' } },
+            _count: { select: { bids: true } },
+          },
+        }),
+        prisma.marketplaceListing.count({ where }),
+      ])
+      allMatching.sort((a, b) =>
+        sort === 'price_asc' ? compareWei(a.startPrice, b.startPrice) : compareWei(b.startPrice, a.startPrice)
+      )
+      for (const listing of allMatching) {
+        listing.bids.sort((x: any, y: any) => compareWei(y.amount, x.amount))
+        listing.bids = listing.bids.slice(0, 1)
+      }
+      listings = allMatching.slice(offset, offset + limit)
+      total = count
+    } else {
+      const [dbListings, count] = await Promise.all([
+        prisma.marketplaceListing.findMany({
+          where,
+          orderBy,
+          take: limit,
+          skip: offset,
+          include: {
+            bids: { where: { status: 'ACTIVE' }, orderBy: { amount: 'desc' } },
+            _count: { select: { bids: true } },
+          },
+        }),
+        prisma.marketplaceListing.count({ where }),
+      ])
+      for (const listing of dbListings) {
+        listing.bids.sort((x: any, y: any) => compareWei(y.amount, x.amount))
+        listing.bids = listing.bids.slice(0, 1)
+      }
+      listings = dbListings
+      total = count
+    }
 
     res.json({ listings, total })
   } catch (err: any) {
@@ -114,8 +179,14 @@ router.get('/listings/token/:tokenId', async (req, res) => {
     const tokenId = parseInt(req.params.tokenId)
     const listing = await prisma.marketplaceListing.findFirst({
       where: { tokenId, status: 'ACTIVE' },
-      include: { bids: { where: { status: 'ACTIVE' }, orderBy: { amount: 'desc' } } },
+      include: { bids: { where: { status: 'ACTIVE' } } },
     })
+
+    // amount is a String column -- sort numerically, not lexicographically
+    // (see compareWei's doc comment).
+    if (listing) {
+      listing.bids.sort((a, b) => compareWei(b.amount, a.amount))
+    }
 
     res.json(listing || null)
   } catch (err: any) {
@@ -348,15 +419,17 @@ router.get('/offers/token/:tokenId', async (req, res) => {
     const limit = Math.min(parseInt(req.query.limit as string) || 20, 100)
     const offset = parseInt(req.query.offset as string) || 0
 
-    const [offers, total] = await Promise.all([
+    // amount is a String column -- sort numerically, not lexicographically
+    // (see compareWei's doc comment). Fetch all active offers, sort
+    // in-process, then apply the same take/skip pagination window.
+    const [allOffers, total] = await Promise.all([
       prisma.marketplaceOffer.findMany({
         where: { tokenId, status: 'ACTIVE' },
-        orderBy: { amount: 'desc' },
-        take: limit,
-        skip: offset,
       }),
       prisma.marketplaceOffer.count({ where: { tokenId, status: 'ACTIVE' } }),
     ])
+    allOffers.sort((a, b) => compareWei(b.amount, a.amount))
+    const offers = allOffers.slice(offset, offset + limit)
 
     res.json({ offers, total })
   } catch (err: any) {


### PR DESCRIPTION
## Summary

Fixes corrupted price, bid, and offer ordering in the marketplace API routes (`api/routes/marketplace.ts`). Because `startPrice` and `amount` are stored as `String` columns in Prisma/PostgreSQL to safely hold 18+ digit Wei values, using direct `orderBy` performed lexicographical (ASCII string) sorting instead of numerical sorting.

## Root Cause

On string columns, PostgreSQL compares character-by-character from left to right:

- `"1000000000000000000"` (1.0 ETH) starts with `'1'`, so on `price_asc` it was treated as cheaper than `"50000000000000000"` (0.05 ETH) and `"90000000000000000"` (0.09 ETH).
- In token offers (`GET /api/marketplace/offers/token/:tokenId`), `"90000000000000000"` (0.09 ETH) sorted to the top above `"1000000000000000000"` (1.0 ETH) because `'9' > '1'`. This created an economic risk where a seller viewing the top offer could mistakenly accept a 0.09 ETH offer over a 1.0 ETH offer.

## Live impact on cawnest.com (verified against the production DB)

The two listings with different digit counts coexisted as ACTIVE for ~13 minutes (2026-08-20 00:20:13 – 00:33:30 UTC):

| listing id | tokenId | status | startPrice (Wei) | actual value |
|---|---|---|---|---|
| 3 | 17 | CANCELLED | 355660137410000000000000000 | 355,660,137.41 CAW |
| 1 | 5 | ACTIVE | 5290000000000000000 | 5.29 CAW |

During that window, `price_asc` ranked listing 3 (~67 million times more expensive than listing 1) as the cheapest item, because lexicographic comparison sees `'3' < '5'`. Any user browsing "Price: Low to High" in that window saw the inverted ordering.

No economic damage occurred: the marketplace has zero bids and zero sales to date, and the single offer that ever existed (10 CAW on tokenId 17, now EXPIRED, never accepted) was alone on its token, so no offer misranking was possible. As of this PR only one listing is ACTIVE, so there is no ongoing display impact — but the bug is latent and will resurface whenever two ACTIVE rows with different digit counts coexist.

## Fix

1. **`api/routes/marketplace.ts`**: Added `compareWei(a, b)` helper using `BigInt` comparison.
2. **`GET /api/marketplace/listings`**: Handled `price_asc` and `price_desc` with numerical `BigInt` sorting; ensured active `bids` within listings are accurately sorted to pick the true highest bid.
3. **`GET /api/marketplace/listings/token/:tokenId`**: Sorted active bids numerically descending.
4. **`GET /api/marketplace/offers/token/:tokenId`**: Sorted active offers numerically descending (highest offer first).

## Verification

- Verified `compareWei` directly from source via unit test: ASC/DESC ordering across diverse Wei scales (0.05 ETH → 2.50 ETH) confirmed correct; null/undefined handling verified.
- `tsc --noEmit`: zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).

zinsanjp