### PR TITLE
fix(action-processor): break on backlog event failure to prevent permanent skip

### DIFF
--- a/client/src/services/ActionProcessor/index.ts
+++ b/client/src/services/ActionProcessor/index.ts
@@ -93,6 +93,7 @@ export const actionProcessorService: Service = {
             } else {
               console.error(`[ActionProcessor] Failed to process backlog event ${raw.id}:`, err)
               // Don't advance lastId — the next restart will retry this event.
+              break
             }
           }
           ctx.heartbeat('listen')


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug in `ActionProcessor`'s startup backlog drain loop. When processing a chunk of `RawEvent` rows, if an event throws a transient error (e.g. DB timeout / deadlock), the catch block logs it and intentionally skips the `lastId = raw.id` advance — but was missing a `break` to stop the loop. As a result, the loop continued to the next event; when that one succeeded, `lastId` jumped past the failed event, which was then permanently skipped by all future `WHERE id > lastId` queries.

## Root Cause

In `client/src/services/ActionProcessor/index.ts` (backlog drain loop):

    try {
      await handleRawEvent(raw, /* skipVerify */ !atBlockBoundary)
      lastId = raw.id
    } catch (err) {
      if (err instanceof StaleTokenError) {
        // Intentional permanent skip for burned/old tokens
        console.warn(`[ActionProcessor] Skipping stale event ${raw.id}: ${err.message}`)
        lastId = raw.id
      } else {
        console.error(`[ActionProcessor] Failed to process backlog event ${raw.id}:`, err)
        // Don't advance lastId — the next restart will retry this event.
        // ⚠️ MISSING `break` HERE: loop continues, next success advances lastId past us
      }
    }

Because the `for` loop kept running after a failure, event `i` was left behind while event `i+1` (and onwards) succeeded and advanced `lastId`. The next startup's `WHERE id > lastId` query never returned event `i` again. This pattern had a "hot loop" safeguard (`if (lastId === startOfChunk) break`) at the end of the chunk, but that safeguard only triggers when NO events in the chunk advanced `lastId` — i.e., it protects against a whole-chunk failure but NOT against mid-chunk partial failures.

## Fix

Add a single `break;` in the catch block's generic-error branch. This stops the chunk at the failed event, leaving `lastId` at `i-1`.

1. The chunk bailout `if (lastId === startOfChunk) break` at the end of the `while` loop continues to function correctly for whole-chunk failures (preventing hot loops).
2. For mid-chunk failures, `lastId` now stops at the last successfully processed event, and the next startup re-queries from that point and retries the failed event.
3. `StaleTokenError` branch is untouched — that one is intentionally a permanent skip for burned/deprecated tokens.

### Replay Safety (Idempotency)
Retrying a failed event on the next startup is completely safe because downstream processing is strictly idempotent:
- `Action` has a unique constraint on `(chainId, senderId, cawonce)` and uses `createOrFindAction` with a recovery path.
- `checkDomainObjectExists` ensures domain side-effects (likes, recaws, replies) are only processed if they didn't already commit.
- Therefore, a partially applied multi-action batch safely resumes without double-applying prior actions.



## Verification

- **Unit simulation test** (executed a JS replica of the loop):
  - PRE-FIX (no break): events 101-105 with transient failure at 102 → `lastId` advances to 105. Event 102 is permanently lost (DATA_LOSS confirmed).
  - POST-FIX (with break): same scenario → `lastId` stops at 101, loop exits. Event 102 will be re-queried and retried from `id > 101` on next restart (RETRY_SAFE).
- **Live log audit**: 20,000 lines of `caw-server-cawnest.com` logs show zero "Failed to process backlog event" events — no observed data loss on this node; the bug is latent but structurally certain to trigger on any transient DB hiccup during startup.
- **TypeScript check**: `tsc --noEmit` passes with zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).
- **Operational escape hatch**: If a malformed event causes permanent failure and the processor halts on the same event across restarts, the operator can manually advance the checkpoint by updating the `rawEventId` column in the `Action` table (or by deleting the stuck `RawEvent` row if it is confirmed to be malformed and non-essential).

zinsanjp