### PR TITLE
fix(stake-ledger): move memory mutation to post-commit to prevent double-counting

### DIFF
--- a/client/src/services/DepositWatcher/index.ts
+++ b/client/src/services/DepositWatcher/index.ts
@@ -27,7 +27,7 @@ import { getL1HttpRpcUrl, getL1HttpRpcUrls, makeResilientHttpProvider, makeVerif
 import { Service } from '../../Service'
 import { prisma } from '../../prismaClient'
 import { CAW_NAMES_ADDRESS } from '../../abi/addresses'
-import { recordDeposit } from '../StakeLedger'
+import { recordDeposit, applyDepositToMemory } from '../StakeLedger'
 import { getNetworkId } from '../../utils/networkId'
 
 const Config = z.object({
@@ -191,8 +191,8 @@ export const depositWatcherService: Service = {
               const blockTimestamp = blockTsByNumber.get(ev.blockNumber) ?? new Date()
 
               try {
-                await prisma.$transaction(async (tx) => {
-                  await recordDeposit(tx, {
+                const result = await prisma.$transaction(async (tx) => {
+                  return await recordDeposit(tx, {
                     tokenId,
                     amountWei: amount,
                     blockNumber,
@@ -201,6 +201,13 @@ export const depositWatcherService: Service = {
                     logIndex,
                   })
                 }, { timeout: 15_000 })
+                // Post-Commit Mutation: Apply to in-memory ledger ONLY after
+                // the DB transaction has successfully committed. This guarantees
+                // atomicity between DB and memory, preventing double-counting
+                // on checkpoint retries.
+                if (result) {
+                  await applyDepositToMemory(result.tokenId, result.amountWei, result.afterOwnership)
+                }
               } catch (err: any) {
                 // Swallow-and-advance was the bug: a failed deposit used to be
                 // warned and then lastBlock advanced past it, so the block was

--- a/client/src/services/StakeLedger/index.ts
+++ b/client/src/services/StakeLedger/index.ts
@@ -540,6 +540,7 @@ export async function recordDeposit(
   const own = ownershipOf(s, tokenId)
   const startingBalance = balanceOf(own, s.multiplier)
   const after = addToBalance(own, s.multiplier, amountWei)
+  const nextTotalCaw = s.totalCaw + amountWei
 
   await tx.cawOwnershipSnapshot.create({
     data: {
@@ -589,13 +590,13 @@ export async function recordDeposit(
     where: { networkId: CAW_CLIENT_ID },
     create: {
       networkId: CAW_CLIENT_ID,
-      totalCaw: s.totalCaw.toString(),
+      totalCaw: nextTotalCaw.toString(),
       multiplier: s.multiplier.toString(),
       lastBlock: blockNumber,
       lastLogIndex: logIndex,
     },
     update: {
-      totalCaw: s.totalCaw.toString(),
+      totalCaw: nextTotalCaw.toString(),
       multiplier: s.multiplier.toString(),
       lastBlock: blockNumber,
       lastLogIndex: logIndex,

--- a/client/src/services/StakeLedger/index.ts
+++ b/client/src/services/StakeLedger/index.ts
@@ -511,9 +511,9 @@ export async function recordDeposit(
     txHash: string
     logIndex: number
   },
-): Promise<void> {
+): Promise<{ tokenId: number; amountWei: bigint; afterOwnership: bigint } | null> {
   const s = await ensureBooted()
-  if (s.halted) return
+  if (s.halted) return null
   const { tokenId, amountWei, blockNumber, blockTimestamp, txHash, logIndex } = params
 
   // Dedup: a watcher restart catching up may replay the same Deposited
@@ -522,7 +522,7 @@ export async function recordDeposit(
     where: { txHash, logIndex, reason: 'DEPOSIT' },
     select: { id: true },
   })
-  if (existing) return
+  if (existing) return null
 
   // Compute the post-deposit state WITHOUT mutating the in-memory
   // singleton `s` yet. addToBalance/balanceOf are pure — they read `s`
@@ -578,21 +578,13 @@ export async function recordDeposit(
       onChainStakeUpdatedAt: new Date(),
     },
   })
-  // Apply the in-memory mutation ONLY NOW, after every DB write above has
-  // been issued without throwing. If any of the tx.* calls above throw,
-  // we return via the catch in the caller (DepositWatcher) with `s` left
-  // untouched — the checkpoint is held, the block range is retried, the
-  // dedup check at the top of this function (which reads confirmed DB
-  // state) is the sole source of truth for "was this deposit already
-  // applied", and it will correctly see nothing and let us try again
-  // exactly once. Do not move this earlier: this function runs inside the
-  // caller's `prisma.$transaction(...)` callback, and `s` is a
-  // module-level singleton shared across polls — an early mutation here
-  // combined with a mid-transaction failure elsewhere in the batch is
-  // exactly the drift bug this ordering fixes.
-  s.totalCaw += amountWei
-  s.ownership.set(tokenId, after.ownership)
-
+  // ⚠️ Do NOT mutate `s` here. This function runs inside the caller's
+  // `prisma.$transaction(...)` callback. If the subsequent upsert throws
+  // (or Prisma internally retries the callback), mutating `s` here would
+  // leave the in-memory ledger drifted from the rolled-back DB state,
+  // causing double-counting on the checkpoint retry.
+  // The caller (DepositWatcher) must apply these mutations to `s` ONLY
+  // after the transaction resolves successfully (Post-Commit Mutation).
   await tx.stakeLedgerState.upsert({
     where: { networkId: CAW_CLIENT_ID },
     create: {
@@ -610,6 +602,17 @@ export async function recordDeposit(
       updatedAt: new Date(),
     },
   })
+  return { tokenId, amountWei, afterOwnership: after.ownership }
+}
+
+/**
+ * Apply the deposit mutation to the in-memory singleton `s`.
+ * MUST ONLY be called AFTER the DB transaction has successfully committed.
+ */
+export async function applyDepositToMemory(tokenId: number, amountWei: bigint, afterOwnership: bigint) {
+  const s = await ensureBooted()
+  s.totalCaw += amountWei
+  s.ownership.set(tokenId, afterOwnership)
 }
 
 // Error message substrings that indicate the RPC endpoint does not retain


### PR DESCRIPTION
## Summary

Fixes a structural risk of in-memory ledger double-counting in `StakeLedger.recordDeposit`. Previously, the in-memory singleton `s` (`totalCaw` / `ownership`) was mutated inside the `prisma.$transaction` callback, immediately before the final `stakeLedgerState.upsert`. If that final upsert threw (or if Prisma internally retried the callback), the DB would roll back but the memory would retain the increment. Combined with the checkpoint-hold retry logic from PR #50, the next poll would re-apply the deposit to memory, resulting in double-counting and a subsequent `DIVERGENCE` halt.

This PR refactors `recordDeposit` to return a mutation descriptor instead of mutating `s` directly. The caller (`DepositWatcher`) now applies the mutation to the in-memory ledger **only after** the transaction resolves successfully (Post-Commit Mutation pattern), ensuring strict atomicity between DB state and memory state.

## Root Cause

In `client/src/services/StakeLedger/index.ts`, `recordDeposit` was mutating the module-level singleton `s` inside the transaction callback:

    await tx.user.updateMany(...)
    // "Apply the in-memory mutation ONLY NOW..."
    s.totalCaw += amountWei          // ⚠️ Memory mutation before commit
    s.ownership.set(tokenId, ...)
    await tx.stakeLedgerState.upsert(...) // If this throws, DB rolls back but memory doesn't

Because PR #50 holds the checkpoint on failure, the next poll retries the same block. The dedup check (reading DB state) sees the deposit is missing and allows re-application. However, the memory was already incremented in the failed attempt, so the retry increments it again → **double-counting**.

## Fix

1. **`StakeLedger.recordDeposit`**: Removed `s.totalCaw +=` and `s.ownership.set()` from inside the function. The function now returns a descriptor `{ tokenId, amountWei, afterOwnership }` upon successful DB writes. Added a new exported helper `applyDepositToMemory` to safely apply the mutation from outside the transaction.
2. **`DepositWatcher`**: The caller now awaits `prisma.$transaction(...)` and calls `applyDepositToMemory` **outside** the transaction block. If the transaction throws, the `s` mutation is skipped entirely.

## Verification

- **Unit simulation test** (executed a JS replica of the Prisma transaction and retry loop):
  - PRE-FIX: Poll 1 fails (DB timeout) -> DB rolls back, but memory `totalCaw` is incremented (1000n → 1500n). Poll 2 retries and succeeds -> memory incremented again (1500n → 2000n). Result: `❌ DIVERGENCE` (Double-count bug reproduced).
  - POST-FIX: Poll 1 fails -> DB rolls back, memory remains untouched (1000n). Poll 2 succeeds -> memory incremented exactly once (1000n → 1500n). Result: `✅ MATCH_HEALTHY` (Perfect consistency with chain).
- **TypeScript check**: `tsc --noEmit` passes with zero new errors (one pre-existing, unrelated error on `origin/v2`, already fixed by #63 upstream).
- **Structural audit**: Confirmed that `recordDeposit` no longer references the `s` singleton for writes. Memory mutations now occur in `DepositWatcher` strictly after the `$transaction` promise resolves.
- **Live log context**: Recent logs show `DIVERGENCE` events halting the node, though their magnitude (~0.00000026 CAW) suggests other minor timing drifts may also be involved. Regardless of the exact trigger, this structural fix eliminates the double-counting attack vector entirely, preventing silent ledger corruption on checkpoint retries.

## Known Limitations

The same "mutation inside transaction" pattern appears to exist in `recordAction` (used for tips, withdrawals, etc.), where `s.multiplier`, `s.ownership`, and `s.totalCaw` are mutated before the transaction commits. This is a significantly more complex refactor (multiple state variables, conditional logic) and carries higher regression risk.


zinsanjp