### PR TITLE
fix(stake-ledger): prevent in-memory corruption on recordAction rollback via post-commit mutation

### DIFF
--- a/client/src/services/ActionProcessor/index.ts
+++ b/client/src/services/ActionProcessor/index.ts
@@ -375,8 +375,8 @@ async function handleRawAction(raw: { id: number, chainId: number, blockNumber: 
     // checksum in handleRawEvent will halt the writer if state has
     // drifted.
     try {
-      await prisma.$transaction(async (tx) => {
-        await recordAction(tx, {
+      const postCommit = await prisma.$transaction(async (tx) => {
+        return await recordAction(tx, {
           rawAction,
           validatorId,
           blockNumber: raw.blockNumber,
@@ -386,6 +386,11 @@ async function handleRawAction(raw: { id: number, chainId: number, blockNumber: 
           actionIndex,
         })
       }, { timeout: 30_000 })
+      // Apply in-memory mutation strictly AFTER the DB transaction commits
+      // successfully. NEVER move this inside the $transaction callback: memory
+      // must never lead the DB (orphan mutation on rollback / double count on
+      // Prisma deadlock retry).
+      postCommit?.()
     } catch (err: any) {
       console.error('[ActionProcessor] StakeLedger snapshot failed (domain rows committed):', err?.message ?? err)
     }

--- a/client/src/services/StakeLedger/index.ts
+++ b/client/src/services/StakeLedger/index.ts
@@ -142,13 +142,23 @@ interface RecordParams {
  * Run inside the same Prisma $transaction the caller is using for
  * domain effects. The math is pure bigint; the only DB I/O is the
  * row inserts and a final state-update.
+ *
+ * IMPORTANT (Post-Commit Mutation invariant): this function NEVER mutates
+ * the in-memory singleton `s`. All state transitions are staged locally
+ * (localMultiplier / localTotalCaw / stagedOwnership) and written to the DB
+ * from those locals; the singleton is updated only by the callback returned
+ * at the end, which the caller must execute strictly AFTER the transaction
+ * commits. Mutating `s` inside this callback would reintroduce the orphan
+ * mutation / double-count bug (DB rollback or Prisma deadlock-retry leaves
+ * memory diverged from the chain). Returns null when no memory update is
+ * due (halted, or action already processed).
  */
 export async function recordAction(
   tx: PrismaTransactionClient,
   params: RecordParams,
-): Promise<void> {
+): Promise<(() => void) | null> {
   const s = await ensureBooted()
-  if (s.halted) return // Operator must reseed before we resume.
+  if (s.halted) return null // Operator must reseed before we resume.
 
   // Skip already-processed actions on warm restart. ActionProcessor
   // resumes from lastId; we resume from (lastBlock, lastLogIndex).
@@ -156,11 +166,23 @@ export async function recordAction(
     params.blockNumber < s.lastBlock ||
     (params.blockNumber === s.lastBlock && params.logIndex <= s.lastLogIndex)
   ) {
-    return
+    return null
   }
 
   const { rawAction, validatorId, blockNumber, blockTimestamp, txHash, logIndex, actionIndex } = params
   const senderId = Number(rawAction.senderId)
+
+  // Local state staging for Post-Commit Mutation pattern.
+  // DO NOT touch `s` below this line: every read goes through getOwn /
+  // localMultiplier / localTotalCaw so a rolled-back or retried transaction
+  // can never leak a partial state into the singleton.
+  let localMultiplier = s.multiplier
+  let localTotalCaw = s.totalCaw
+  const stagedOwnership = new Map<number, bigint>()
+  const getOwn = (tokenId: number): bigint => stagedOwnership.get(tokenId) ?? ownershipOf(s, tokenId)
+  const setOwn = (tokenId: number, own: bigint) => { stagedOwnership.set(tokenId, own) }
+  const localState = { ...s, multiplier: localMultiplier, totalCaw: localTotalCaw } as typeof s
+
   const receiverId = rawAction.receiverId ? Number(rawAction.receiverId) : 0
   const rawTypeName = ACTION_TYPE_NUM_TO_NAME[Number(rawAction.actionType) as keyof typeof ACTION_TYPE_NUM_TO_NAME]
   // Resolve OTHER:tip into a TIP actionType so the chart can stack tips
@@ -213,11 +235,11 @@ export async function recordAction(
     rawTypeName === 'FOLLOW'
   ) {
     const cost = ACTION_COST[rawTypeName as FixedCostActionType]
-    const senderOwn = ownershipOf(s, senderId)
-    const senderBalBefore = balanceOf(senderOwn, s.multiplier)
+    const senderOwn = getOwn(senderId)
+    const senderBalBefore = balanceOf(senderOwn, localMultiplier)
     let r: ReturnType<typeof spendAndDistribute>
     try {
-      r = spendAndDistribute(senderOwn, s, cost.spend * PRECISION, cost.communal * PRECISION)
+      r = spendAndDistribute(senderOwn, localState, cost.spend * PRECISION, cost.communal * PRECISION)
     } catch (err: any) {
       if (typeof err?.message === 'string' && err.message.includes('Insufficient CAW balance')) {
         console.error(
@@ -225,20 +247,21 @@ export async function recordAction(
           `block=${blockNumber} logIndex=${logIndex}. Run npx tsx scripts/backfill-stake-ledger.ts [--reset] to recover`,
         )
         s.halted = true
-        return
+        return null
       }
       throw err
     }
     if (r.communalDistributed > 0n) {
       multiplierEvents.push({
-        before: s.multiplier,
+        before: localMultiplier,
         after: r.multiplier,
         communal: r.communalDistributed,
         subActionIndex: subActionIndex++,
       })
     }
-    s.multiplier = r.multiplier
-    s.ownership.set(senderId, r.senderOwnership)
+    localMultiplier = r.multiplier
+    localState.multiplier = r.multiplier
+    setOwn(senderId, r.senderOwnership)
     pushTouch(
       senderId,
       r.senderBalance - senderBalBefore, // negative
@@ -249,10 +272,10 @@ export async function recordAction(
     )
 
     if (cost.receive > 0n && receiverId !== 0) {
-      const recvOwn = ownershipOf(s, receiverId)
-      const recvBalBefore = balanceOf(recvOwn, s.multiplier)
-      const recv = addToBalance(recvOwn, s.multiplier, cost.receive * PRECISION)
-      s.ownership.set(receiverId, recv.ownership)
+      const recvOwn = getOwn(receiverId)
+      const recvBalBefore = balanceOf(recvOwn, localMultiplier)
+      const recv = addToBalance(recvOwn, localMultiplier, cost.receive * PRECISION)
+      setOwn(receiverId, recv.ownership)
       pushTouch(
         receiverId,
         recv.balance - recvBalBefore,
@@ -267,17 +290,18 @@ export async function recordAction(
     // Modelled as ACTION_SPEND_BASE so the chart's outgoing stack
     // surfaces it the same way as other type-specific costs.
     const amount = (BigInt(rawAction.amounts?.[0] ?? 0)) * PRECISION
-    const senderOwn = ownershipOf(s, senderId)
-    const senderBal = balanceOf(senderOwn, s.multiplier)
+    const senderOwn = getOwn(senderId)
+    const senderBal = balanceOf(senderOwn, localMultiplier)
     if (senderBal < amount) {
       console.error(`[StakeLedger] WITHDRAW: insufficient balance — ledger drift? sender=${senderId} bal=${senderBal} amt=${amount}`)
       s.halted = true
-      return
+      return null
     }
     const newBal = senderBal - amount
-    const newOwn = ownershipFromBalance(newBal, s.multiplier)
-    s.ownership.set(senderId, newOwn)
-    s.totalCaw -= amount
+    const newOwn = ownershipFromBalance(newBal, localMultiplier)
+    setOwn(senderId, newOwn)
+    localTotalCaw -= amount
+    localState.totalCaw = localTotalCaw
     pushTouch(senderId, -amount, newOwn, newBal, 'ACTION_SPEND_BASE', null)
   }
   // UNLIKE / UNFOLLOW / OTHER (excluding tip side effects via amounts):
@@ -304,10 +328,10 @@ export async function recordAction(
     for (let i = startIndex; i < numRecipients; i++) {
       const recipientTokenId = Number(recipients[i])
       const amountWei = BigInt(amounts[i] ?? 0) * PRECISION
-      const recvOwn = ownershipOf(s, recipientTokenId)
-      const recvBalBefore = balanceOf(recvOwn, s.multiplier)
-      const recv = addToBalance(recvOwn, s.multiplier, amountWei)
-      s.ownership.set(recipientTokenId, recv.ownership)
+      const recvOwn = getOwn(recipientTokenId)
+      const recvBalBefore = balanceOf(recvOwn, localMultiplier)
+      const recv = addToBalance(recvOwn, localMultiplier, amountWei)
+      setOwn(recipientTokenId, recv.ownership)
       pushTouch(
         recipientTokenId,
         recv.balance - recvBalBefore,
@@ -328,11 +352,11 @@ export async function recordAction(
     // portion. This is what makes the outgoing chart legend usable.
     const recipientPortion = amountTotal - validatorTipWei
     if (amountTotal > 0n) {
-      const senderOwn = ownershipOf(s, senderId)
-      const senderBalBefore = balanceOf(senderOwn, s.multiplier)
+      const senderOwn = getOwn(senderId)
+      const senderBalBefore = balanceOf(senderOwn, localMultiplier)
       let r: ReturnType<typeof spendAndDistribute>
       try {
-        r = spendAndDistribute(senderOwn, s, amountTotal, 0n)
+        r = spendAndDistribute(senderOwn, localState, amountTotal, 0n)
       } catch (err: any) {
         if (typeof err?.message === 'string' && err.message.includes('Insufficient CAW balance')) {
           console.error(
@@ -340,12 +364,13 @@ export async function recordAction(
             `block=${blockNumber} logIndex=${logIndex}. Run npx tsx scripts/backfill-stake-ledger.ts [--reset] to recover`,
           )
           s.halted = true
-          return
+          return null
         }
         throw err
       }
-      s.multiplier = r.multiplier // unchanged but assign for clarity
-      s.ownership.set(senderId, r.senderOwnership)
+      localMultiplier = r.multiplier
+      localState.multiplier = r.multiplier // unchanged but assign for clarity
+      setOwn(senderId, r.senderOwnership)
       // recipientPortion: tagged ACTION_SPEND_TIP (the user's outgoing
       // tip spend). For non-tip actions this segment is normally 0;
       // it shows up only when amounts has a payee beyond the validator.
@@ -385,10 +410,10 @@ export async function recordAction(
 
     // Validator receives the tip via addToBalance.
     if (validatorTipWei > 0n) {
-      const valOwn = ownershipOf(s, validatorId)
-      const valBalBefore = balanceOf(valOwn, s.multiplier)
-      const val = addToBalance(valOwn, s.multiplier, validatorTipWei)
-      s.ownership.set(validatorId, val.ownership)
+      const valOwn = getOwn(validatorId)
+      const valBalBefore = balanceOf(valOwn, localMultiplier)
+      const val = addToBalance(valOwn, localMultiplier, validatorTipWei)
+      setOwn(validatorId, val.ownership)
       pushTouch(
         validatorId,
         val.balance - valBalBefore,
@@ -430,7 +455,7 @@ export async function recordAction(
         logIndex,
         actionIndex,
         ownership: t.finalOwnership.toString(),
-        multiplier: s.multiplier.toString(),
+        multiplier: localMultiplier.toString(),
         balance: t.finalBalance.toString(),
         delta: t.delta.toString(),
         reason: t.reason,
@@ -474,25 +499,40 @@ export async function recordAction(
     }
   }
 
-  s.lastBlock = blockNumber
-  s.lastLogIndex = logIndex
   await tx.stakeLedgerState.upsert({
     where: { networkId: CAW_CLIENT_ID },
     create: {
       networkId: CAW_CLIENT_ID,
-      totalCaw: s.totalCaw.toString(),
-      multiplier: s.multiplier.toString(),
+      totalCaw: localTotalCaw.toString(),
+      multiplier: localMultiplier.toString(),
       lastBlock: blockNumber,
       lastLogIndex: logIndex,
     },
     update: {
-      totalCaw: s.totalCaw.toString(),
-      multiplier: s.multiplier.toString(),
+      totalCaw: localTotalCaw.toString(),
+      multiplier: localMultiplier.toString(),
       lastBlock: blockNumber,
       lastLogIndex: logIndex,
       updatedAt: new Date(),
     },
   })
+  // Post-commit mutation callback: apply the staged state to the singleton.
+  // The caller must invoke this exactly once, strictly AFTER
+  // `await prisma.$transaction(...)` resolves. Invoking it earlier
+  // reintroduces the orphan-mutation bug.
+  // Return the in-memory mutation callback to be executed strictly AFTER
+  // the DB transaction commits successfully. If the transaction rolls back
+  // (e.g. timeout on commit), this callback is not invoked and `s` remains
+  // completely untouched, preventing in-memory corruption on retry.
+  return () => {
+    s.multiplier = localMultiplier
+    s.totalCaw = localTotalCaw
+    s.lastBlock = blockNumber
+    s.lastLogIndex = logIndex
+    for (const [tokenId, own] of stagedOwnership) {
+      s.ownership.set(tokenId, own)
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

`StakeLedger.recordAction` (posts, likes, follows, tips, withdrawals) mutated the in-memory singleton (`s.multiplier`, `s.ownership`, `s.totalCaw`, `s.lastBlock`/`s.lastLogIndex`) inside the `prisma.$transaction` callback, before DB writes completed. If a later DB query threw (timeout) or Prisma internally re-executed the interactive transaction on deadlock (40P01 / P2034), the DB rolled back while memory stayed mutated (orphan mutation) or was mutated twice (double count) — leading to `verifyMultiplier` DIVERGENCE and a full node halt (`s.halted = true`). Same root-cause class as the `recordDeposit` post-commit fix (#110).

This PR applies the Post-Commit Mutation pattern with a staging overlay to `recordAction`.

## Root Cause

    // inside the prisma.$transaction callback
    s.multiplier = r.multiplier           // memory mutated before commit
    s.ownership.set(senderId, ...)
    s.totalCaw -= amount                  // WITHDRAW
    s.lastBlock = blockNumber
    await tx.stakeLedgerState.upsert(...) // if this throws: DB rolls back, memory does not

The caller swallowed the rollback error, so the drift persisted until the next verification halted the node.

## Fix

1. **Pure local computation**: `localMultiplier`, `localTotalCaw`, and a `stagedOwnership` overlay map with `getOwn`/`setOwn` helpers; multi-step touches (base spend -> recipient -> validator fee) chain through staging state without touching `s`.
2. **DB snapshot freshness**: `cawOwnershipSnapshot.createMany`, `stakeLedgerState.upsert`, and the `multiplierEvents` `before:` field all use the finalized local values (no fossilized `s` reads).
3. **Post-commit closure**: `recordAction` now returns `(() => void) | null`; `ActionProcessor` executes it strictly after `await prisma.$transaction(...)` resolves (`const postCommit = await prisma.$transaction(...)` then `postCommit?.()`).
4. **Early returns** (halted / already-processed) return `null`.
5. **Design note**: `s.halted = true` on insufficient-balance remains an immediate mutation — intentional: it is a global kill switch, not ledger state.

## Verification

- **TypeScript**: `tsc --noEmit` passes with zero new errors (one pre-existing, unrelated error on `origin/v2`, fixed upstream by #63).
- **Node.js replica suite (8 assertions, all PASS)**: rollback isolation (memory 100% untouched); deadlock internal retry (multiplier exactly matches the single-run golden value; pre-fix doubles it); WITHDRAW rollback (totalCaw preserved); multi-step staging carryover (self-tip with sender==recipient matches reference math).
- **Live log audit**: two DIVERGENCE halts occurred on 2026-09-03; at those timestamps there were zero DB timeout/deadlock errors and the snapshot was written exactly once, and the drift magnitude (~2.6e11 wei, ~0.00000026 CAW) is inconsistent with rollback leakage. Those halts therefore stem from a separate steady-state calculation drift (tracked separately; NOT claimed fixed here). This PR eliminates the structurally guaranteed catastrophic rollback/retry vector under DB contention.

## Known Limitations

The skip-dedup at the top of `recordAction` compares only `(blockNumber, logIndex)` and ignores `actionIndex`; multiple actions inside one RawEvent would skip the 2nd onward. Currently masked in production because `RawEventsGatherer` assigns artificially incremented logIndex per action. Follow-up: compare `(blockNumber, logIndex, actionIndex)` tuples (add `lastActionIndex` to `RuntimeState`).

zinsanjp