### PR TITLE
fix(stake-ledger): support dynamic cap oracle to prevent divergence HALT

### DIFF
--- a/client/src/services/StakeLedger/cawActionsContract.ts
+++ b/client/src/services/StakeLedger/cawActionsContract.ts
@@ -1,0 +1,19 @@
+import { JsonRpcProvider, WebSocketProvider, Contract } from 'ethers'
+import { makeJsonRpcProvider, makeWebSocketProvider, getL2HttpRpcUrl } from '../../utils/rpcProvider'
+import { cawActionsAbi } from '../../abi/generated'
+
+let _provider: JsonRpcProvider | WebSocketProvider | null = null
+let _contract: Contract | null = null
+
+export function getCawActions(): Contract {
+  if (_contract) return _contract
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { CAW_ACTIONS_ADDRESS } = require('../../abi/addresses') as { CAW_ACTIONS_ADDRESS: string }
+  const rpcUrl = getL2HttpRpcUrl()
+  if (!rpcUrl) throw new Error('[StakeLedger] L2 RPC not configured')
+  _provider = rpcUrl.startsWith('wss://') || rpcUrl.startsWith('ws://')
+    ? makeWebSocketProvider(rpcUrl, 84532)
+    : makeJsonRpcProvider(rpcUrl, 84532)
+  _contract = new Contract(CAW_ACTIONS_ADDRESS, cawActionsAbi as any, _provider)
+  return _contract
+}

--- a/client/src/services/StakeLedger/index.ts
+++ b/client/src/services/StakeLedger/index.ts
@@ -22,9 +22,9 @@
 import { prisma } from '../../prismaClient'
 import type { PrismaTransactionClient, RawAction } from '../ActionProcessor/types'
 import {
-  ACTION_COST,
   ACTION_TYPE_NUM_TO_NAME,
   type FixedCostActionType,
+  getActionCost,
 } from '../../utils/cawActionCosts'
 import {
   PRECISION,
@@ -34,6 +34,7 @@ import {
   addToBalance,
 } from './contractMath'
 import { getCawProfileLedger as _getCawProfileLedgerReal } from './cawProfileLedger'
+import { getCawActions as _getCawActionsReal } from './cawActionsContract'
 import { getNetworkId } from '../../utils/networkId'
 
 // Tests can override this to avoid real RPC calls.
@@ -42,6 +43,13 @@ let _cawProfileLedgerOverride: { rewardMultiplier: (...args: any[]) => Promise<a
 
 function getCawProfileLedger(): { rewardMultiplier: (...args: any[]) => Promise<any> } {
   return (_cawProfileLedgerOverride ?? _getCawProfileLedgerReal()) as any
+}
+
+// Tests can override this to avoid real RPC calls.
+let _cawActionsOverride: { capState: (...args: any[]) => Promise<any> } | null = null
+
+function getCawActions(): { capState: (...args: any[]) => Promise<any> } {
+  return (_cawActionsOverride ?? _getCawActionsReal()) as any
 }
 
 // One client per process — the snapshotter reads CLIENT_ID from env at
@@ -58,6 +66,11 @@ const CAW_CLIENT_ID = (() => {
 export interface RuntimeState {
   multiplier: bigint
   totalCaw: bigint
+  // Dynamic action-cost cap (CawActions.capState), refreshed in
+  // verifyMultiplier(). 0n ratio means the oracle is dormant — costs fall
+  // back to the manifesto baseline. See cawActionCosts.getActionCost().
+  capRatio: bigint
+  capLastUpdatedAt: bigint
   // Cached cawOwnership[tokenId]. Loaded lazily — on first touch we read
   // from CawOwnershipCurrent (or assume 0n for never-seen tokens).
   ownership: Map<number, bigint>
@@ -89,10 +102,25 @@ export async function ensureBooted(): Promise<RuntimeState> {
     const ownership = new Map<number, bigint>()
     const currentRows = await prisma.cawOwnershipCurrent.findMany()
     for (const row of currentRows) ownership.set(row.tokenId, BigInt(row.ownership))
+
+    let initialCapRatio = 0n
+    let initialCapLastUpdatedAt = 0n
+    try {
+      const cs = await getCawActions().capState()
+      if (cs && cs[0] !== undefined && cs[1] !== undefined) {
+        initialCapLastUpdatedAt = BigInt(cs[0])
+        initialCapRatio = BigInt(cs[1])
+      }
+    } catch (err: any) {
+      console.warn('[StakeLedger] Failed to fetch initial capState from CawActions; defaulting to 0n (baseline costs):', err?.message ?? err)
+    }
+
     const next: RuntimeState = persisted
       ? {
           multiplier: BigInt(persisted.multiplier),
           totalCaw: BigInt(persisted.totalCaw),
+          capRatio: initialCapRatio,
+          capLastUpdatedAt: initialCapLastUpdatedAt,
           ownership,
           lastBlock: BigInt(persisted.lastBlock),
           lastLogIndex: persisted.lastLogIndex,
@@ -101,6 +129,8 @@ export async function ensureBooted(): Promise<RuntimeState> {
       : {
           multiplier: PRECISION,
           totalCaw: 0n,
+          capRatio: initialCapRatio,
+          capLastUpdatedAt: initialCapLastUpdatedAt,
           ownership,
           lastBlock: 0n,
           lastLogIndex: -1,
@@ -212,7 +242,8 @@ export async function recordAction(
     rawTypeName === 'RECAW' ||
     rawTypeName === 'FOLLOW'
   ) {
-    const cost = ACTION_COST[rawTypeName as FixedCostActionType]
+    const blockSec = BigInt(Math.floor(blockTimestamp.getTime() / 1000))
+    const cost = getActionCost(rawTypeName as FixedCostActionType, s.capRatio, s.capLastUpdatedAt, blockSec)
     const senderOwn = ownershipOf(s, senderId)
     const senderBalBefore = balanceOf(senderOwn, s.multiplier)
     let r: ReturnType<typeof spendAndDistribute>
@@ -690,6 +721,17 @@ export async function verifyMultiplier(): Promise<void> {
     }
   }
 
+  // Keep capRatio and capLastUpdatedAt fresh in case the oracle pushed a new ratio
+  try {
+    const cs = await getCawActions().capState()
+    if (cs && cs[0] !== undefined && cs[1] !== undefined) {
+      s.capLastUpdatedAt = BigInt(cs[0])
+      s.capRatio = BigInt(cs[1])
+    }
+  } catch {
+    // non-critical: transient RPC failure should not break verification
+  }
+
   if (onChain !== s.multiplier) {
     console.error(
       `[StakeLedger] DIVERGENCE: chain rewardMultiplier=${onChain}, ledger=${s.multiplier} ` +
@@ -716,6 +758,11 @@ export function _resetForTests(): void {
 /** For tests: inject a mock contract so verifyMultiplier never hits a real RPC. */
 export function _setContractForTests(mock: { rewardMultiplier: (...args: any[]) => Promise<any> } | null): void {
   _cawProfileLedgerOverride = mock
+}
+
+/** For tests: inject a mock CawActions contract to control capState. */
+export function _setActionsContractForTests(mock: { capState: (...args: any[]) => Promise<any> } | null): void {
+  _cawActionsOverride = mock
 }
 
 /** For tests: directly inject RuntimeState, bypassing Prisma boot. */

--- a/client/src/utils/cawActionCosts.ts
+++ b/client/src/utils/cawActionCosts.ts
@@ -21,11 +21,63 @@ export interface ActionCost {
   receive: bigint
 }
 
+export const ACTION_BASELINE_AND_CAP = {
+  CAW:    { baseline: 5000n,  ethCap: 500_000_000_000n },   // 5e11
+  LIKE:   { baseline: 2000n,  ethCap: 200_000_000_000n },   // 2e11
+  RECAW:  { baseline: 4000n,  ethCap: 400_000_000_000n },   // 4e11
+  FOLLOW: { baseline: 30000n, ethCap: 3_000_000_000_000n }, // 30e11
+} as const
+
+export const CAP_STALE_THRESHOLD_SECONDS = 86400n // 24 hours (solidity/contracts/CawActions.sol:229)
+
+/**
+ * Compute the effective action cost taking into account CawActions._getCost dynamic capping.
+ * If capRatio == 0 or if the oracle sample is older than CAP_STALE_THRESHOLD (24h),
+ * baseline manifesto costs apply.
+ * Mirrors CawActions._getCost and CawActions._applyAction split logic.
+ */
+export function getActionCost(
+  typeName: FixedCostActionType,
+  capRatio: bigint = 0n,
+  lastUpdatedAt: bigint = 0n,
+  currentTimestampSeconds: bigint = 0n,
+): ActionCost {
+  const spec = ACTION_BASELINE_AND_CAP[typeName]
+  let cost: bigint = spec.baseline
+
+  const isFresh =
+    capRatio > 0n &&
+    (lastUpdatedAt === 0n ||
+      currentTimestampSeconds === 0n ||
+      (currentTimestampSeconds >= lastUpdatedAt &&
+        currentTimestampSeconds - lastUpdatedAt <= CAP_STALE_THRESHOLD_SECONDS))
+
+  if (isFresh) {
+    let capped = ((spec.ethCap << 112n) / capRatio) / 10n**18n
+    if (capped === 0n) capped = 1n
+    if (capped < spec.baseline) cost = capped
+  }
+
+  if (typeName === 'CAW') {
+    return { spend: cost, communal: cost, receive: 0n }
+  } else if (typeName === 'LIKE') {
+    const communal = cost / 5n
+    return { spend: cost, communal, receive: cost - communal }
+  } else if (typeName === 'RECAW') {
+    const communal = cost / 2n
+    return { spend: cost, communal, receive: cost - communal }
+  } else if (typeName === 'FOLLOW') {
+    const communal = cost / 5n
+    return { spend: cost, communal, receive: cost - communal }
+  }
+  return { spend: cost, communal: cost, receive: 0n }
+}
+
 export const ACTION_COST: Record<FixedCostActionType, ActionCost> = {
-  CAW:    { spend: 5000n,  communal: 5000n, receive: 0n },
-  LIKE:   { spend: 2000n,  communal: 400n,  receive: 1600n },
-  RECAW:  { spend: 4000n,  communal: 2000n, receive: 2000n },
-  FOLLOW: { spend: 30000n, communal: 6000n, receive: 24000n },
+  CAW:    getActionCost('CAW', 0n),
+  LIKE:   getActionCost('LIKE', 0n),
+  RECAW:  getActionCost('RECAW', 0n),
+  FOLLOW: getActionCost('FOLLOW', 0n),
 }
 
 // Numeric tag mapping. The contract uses a uint8 enum; the database uses

--- a/client/tests/services/StakeLedger/dynamicActionCost.test.ts
+++ b/client/tests/services/StakeLedger/dynamicActionCost.test.ts
@@ -1,0 +1,75 @@
+// Tests for dynamic action-cost capping (getActionCost + recordAction's use
+// of it via spendAndDistribute). Verifies NEW-32 against real incident data
+// recorded in production (RewardMultiplierSnapshot for blocks 46314816 /
+// 46321989 on cawnest.com, captured 2026-09-04). See NEW-32 investigation
+// reports for full incident detail.
+//
+// The reproduction tests use a synthetic sender balance/ownership large
+// enough to cover the spend, with totalCaw chosen so that
+// (totalCaw - balance) exactly equals the denominator reverse-derived from
+// the real (buggy) production multiplier transition — isolating the
+// cost-calculation fix from unrelated totalCaw drift between the incident
+// time and now (no historical totalCaw snapshot exists to read directly).
+
+import { expect } from 'chai'
+process.env.CLIENT_ID = '1'
+
+import { getActionCost, CAP_STALE_THRESHOLD_SECONDS } from '../../../src/utils/cawActionCosts'
+import { spendAndDistribute, PRECISION } from '../../../src/services/StakeLedger/contractMath'
+
+const REAL_RATIO = 6790207473144214254423584n
+const REAL_LAST_UPDATED = 1788325938n
+
+describe('cawActionCosts / getActionCost — dynamic cap (NEW-32)', () => {
+  it('returns baseline costs when capRatio is 0 (oracle dormant)', () => {
+    const caw = getActionCost('CAW', 0n, 0n, 0n)
+    const follow = getActionCost('FOLLOW', 0n, 0n, 0n)
+    expect(caw).to.deep.equal({ spend: 5000n, communal: 5000n, receive: 0n })
+    expect(follow).to.deep.equal({ spend: 30000n, communal: 6000n, receive: 24000n })
+  })
+
+  it('applies the dynamic cap when ratio is fresh (real on-chain ratio, block 46314816 timestamp)', () => {
+    const blockSec = 1788397920n
+    const caw = getActionCost('CAW', REAL_RATIO, REAL_LAST_UPDATED, blockSec)
+    const follow = getActionCost('FOLLOW', REAL_RATIO, REAL_LAST_UPDATED, blockSec)
+    expect(caw).to.deep.equal({ spend: 382n, communal: 382n, receive: 0n })
+    expect(follow.communal).to.equal(458n)
+  })
+
+  it('falls back to baseline when the sample is stale (>24h)', () => {
+    const staleSec = REAL_LAST_UPDATED + CAP_STALE_THRESHOLD_SECONDS + 1n
+    const caw = getActionCost('CAW', REAL_RATIO, REAL_LAST_UPDATED, staleSec)
+    expect(caw).to.deep.equal({ spend: 5000n, communal: 5000n, receive: 0n })
+  })
+
+  it('still applies the cap 1 second before the 24h stale boundary (block 46321989 near-miss)', () => {
+    // Real incident #2: block timestamp 1788412266 vs oracle lastUpdatedAt
+    // 1788325938 — an 86328s gap, only 72s inside the 86400s threshold.
+    const nearStaleSec = 1788412266n
+    const follow = getActionCost('FOLLOW', REAL_RATIO, REAL_LAST_UPDATED, nearStaleSec)
+    expect(follow.communal).to.equal(458n)
+  })
+
+  it('reproduces incident #1 (block 46314816: CAW then FOLLOW, senderId=4) to within 1300 wei', () => {
+    // denominator reverse-derived from the actual buggy production
+    // multiplier transition recorded in RewardMultiplierSnapshot.
+    const before1 = 1000047447554470150n
+    const senderOwnership = 999952554696693462989702698648n
+    const totalCaw1 = 1039102546981633772741084599107n // = denom1 + balanceOf(senderOwnership, before1)
+
+    const caw = getActionCost('CAW', REAL_RATIO, REAL_LAST_UPDATED, 1788397920n)
+    const r1 = spendAndDistribute(senderOwnership, { multiplier: before1, totalCaw: totalCaw1 }, caw.spend * PRECISION, caw.communal * PRECISION)
+
+    const denom2 = 39102551981531843618974864124n
+    const totalCaw2 = denom2 + r1.senderBalance
+
+    const follow = getActionCost('FOLLOW', REAL_RATIO, REAL_LAST_UPDATED, 1788397920n)
+    const r2 = spendAndDistribute(r1.senderOwnership, { multiplier: r1.multiplier, totalCaw: totalCaw2 }, follow.spend * PRECISION, follow.communal * PRECISION)
+
+    const onchainTarget = 1000047469037465921n
+    const diff = r2.multiplier > onchainTarget ? r2.multiplier - onchainTarget : onchainTarget - r2.multiplier
+    // Old hardcoded-baseline bug produced a ~281B wei (13x) divergence here;
+    // the fix lands within rounding distance of the real on-chain value.
+    expect(diff).to.be.lessThan(1300n)
+  })
+})

--- a/client/tests/services/StakeLedger/verifyMultiplier.test.ts
+++ b/client/tests/services/StakeLedger/verifyMultiplier.test.ts
@@ -24,6 +24,8 @@ function makeState(overrides: Partial<RuntimeState> = {}): RuntimeState {
   return {
     multiplier: PRECISION,
     totalCaw: 0n,
+    capRatio: 0n,
+    capLastUpdatedAt: 0n,
     ownership: new Map(),
     lastBlock: 100n,
     lastLogIndex: 0,


### PR DESCRIPTION
### Problem
`cawnest.com` halted twice on 2026-09-03 (`[StakeLedger] DIVERGENCE`, blocks 46314816 and 46321989). Root cause: `CawActions._getCost` dynamically caps CAW/LIKE/RECAW/FOLLOW costs against a price-oracle ratio (`CawCapOracle`), but `StakeLedger` (`cawActionCosts.ts`) always used the hardcoded baseline (e.g. FOLLOW communal = 6,000 CAW), causing StakeLedger to overcount the `rewardMultiplier` increment by ~13x the moment the cap was active.

### Root Cause
The oracle pushed an active ratio on 2026-09-02 05:12 UTC (`ratio=6790207473144214254423584`, confirmed via direct RPC read of `CawActions.capState()` at the incident blocks). From that point, every CAW/LIKE/RECAW/FOLLOW action processed on-chain used the capped cost, but `StakeLedger` had no knowledge of `capState` and kept computing against the full baseline.

### Solution
1. `cawActionCosts.ts`: `getActionCost(typeName, capRatio, lastUpdatedAt, currentTimestampSeconds)` mirrors `_getCost`'s UQ112.112 math and the 24h staleness fallback.
2. `cawActionsContract.ts` (new): read-only provider for `CawActions.capState()`.
3. `StakeLedger`: caches `capRatio`/`capLastUpdatedAt` on `RuntimeState`, seeded at boot (`ensureBooted`) and refreshed each `verifyMultiplier()` call. An RPC failure during refresh leaves the previous cached value in place rather than resetting to `0n`.
4. `recordAction()` uses `getActionCost()` instead of the static `ACTION_COST` table.

### Verification
Rather than a standalone simulation, both incidents were replayed through the actual `spendAndDistribute()` used in production:
- The `(totalCaw - balance)` denominator for each incident was reverse-derived from the real (buggy) `multiplierBefore`/`multiplierAfter` pair recorded in `RewardMultiplierSnapshot`, isolating the cost-calculation fix from unrelated `totalCaw` drift (no historical `totalCaw` snapshot exists to read directly).
- Replaying with the corrected (capped) cost lands within **~1,300 wei** of the actual on-chain `rewardMultiplier` for both incidents — versus the ~281B wei (13x) divergence the bug produced. Remaining wei-level difference is integer-truncation rounding, not a modeling error.
- The second incident (block 46321989) occurred only 72 seconds inside the 24h staleness threshold — a near-miss regression case now covered explicitly in the test suite.

New test file: `tests/services/StakeLedger/dynamicActionCost.test.ts` (5 cases: dormant-oracle baseline, active-cap values against the real on-chain ratio, staleness fallback, the 72s near-stale case, and full replay of the first incident). `tsc --noEmit` clean.

### Known Limitations
- `capRatio` refresh happens in `verifyMultiplier()`, which runs after `recordAction()` for a block, not before — so the first block following an oracle push is still computed against the pre-push ratio. Low practical risk (oracle push cadence >> block time) but not eliminated.

### Out of Scope (tracked separately)
`CawActions._getCost(1000, 1e11)` — the implicit per-action validator tip charged to session-key actions with no explicit recipient/tip (e.g. `hide:*`) — is applied on-chain outside the `amounts[]`/`recipients[]` path `StakeLedger` reads, so it may currently go uncounted entirely. Zero production occurrences confirmed to date (no `OTHER` rows in `RewardMultiplierSnapshot`), so not urgent, but structurally the same DIVERGENCE-HALT risk as this bug, in the opposite (undercounting) direction.

---
zinsanjp