### PR TITLE
fix(api): allow default avatar 101-131 (female range) end-to-end

### DIFF
--- a/client/src/api/routes/og.ts
+++ b/client/src/api/routes/og.ts
@@ -189,7 +189,7 @@ function defaultAvatarIdFor(user: {
   defaultAvatarId?: number | null
   tokenId?: number
 }): number {
-  return Math.max(1, Math.min(100, user.defaultAvatarId || ((user.tokenId || 0) % 100) + 1))
+  return Math.max(1, Math.min(131, user.defaultAvatarId || ((user.tokenId || 0) % 100) + 1))
 }
 
 // Universal "always works" fallback. Resolved once at module init by

--- a/client/src/api/routes/og.ts
+++ b/client/src/api/routes/og.ts
@@ -172,7 +172,7 @@ const DEFAULT_AVATARS_DIR = path.join(
 )
 const defaultAvatarCache = new Map<number, string | null>()
 function loadDefaultAvatarDataUri(id: number): string | null {
-  const clamped = Math.max(1, Math.min(100, id))
+  const clamped = Math.max(1, Math.min(131, id))
   if (defaultAvatarCache.has(clamped)) return defaultAvatarCache.get(clamped)!
   try {
     const bytes = fs.readFileSync(path.join(DEFAULT_AVATARS_DIR, `${clamped}.png`))

--- a/client/src/api/routes/users.ts
+++ b/client/src/api/routes/users.ts
@@ -957,7 +957,7 @@ router.patch(
       // Handle defaultAvatarId separately (integer, not string)
       if (defaultAvatarId !== undefined) {
         const id = parseInt(String(defaultAvatarId))
-        if (id >= 1 && id <= 100) updateData.defaultAvatarId = id
+        if (id >= 1 && id <= 131) updateData.defaultAvatarId = id
       }
 
       for (const [field, rawValue] of Object.entries(incoming)) {


### PR DESCRIPTION
The AvatarPicker already offers `FEMALE_RANGE {101..131}` and all 131 avatar PNGs ship in v2, but two backend bounds were still capped at 100 — so choosing a female avatar (101–131) was silently dropped on save and mis-rendered on OG cards:

- **`users.ts`** `PATCH /:tokenId/profile` — the `id <= 100` guard dropped 101–131 writes, so the selection never persisted.
- **`og.ts`** `defaultAvatarIdFor` — `Math.min(100, …)` clamped a chosen 101–131 down to 100 on the OG image. (The `(tokenId % 100) + 1` fallback is already ≤100, so it's unaffected.)

Both raised to 131 to match `AvatarPicker` and `utils/defaultAvatar.ts` (`MAX_AVATAR_ID = 131`).

Auto-seed distribution (`UserService`, and the og fallback `(tokenId % 100) + 1`) is intentionally left at 1–100 — 101–131 is opt-in via the picker, not auto-assigned.

Extracted from #29 (@jay-south), which fixed the `users.ts` cap; the `og.ts` clamp was still open. Credit to jay-south for the avatar work.