### PR TITLE
   feat(api): add multi-provider translation proxy with LRU cache and fallback

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -173,3 +173,19 @@ MEDIA_PUBLIC_URL_BASE=
 # (e.g. `test.caw.social`). The reverse-proxy injects this on the wire,
 # so it doesn't appear in the public URL.
 FILEBASE_KEY_PREFIX=
+
+# Translation API Keys & Providers
+# The node proxy uses an in-memory LRU cache (2,000 entries) with automatic fallback.
+#
+# Primary recommended (Free Tier: 1,500 requests/day, no credit card required):
+# Set GEMINI_API_KEY from Google AI Studio (https://aistudio.google.com) for Web3/crypto context-aware AI translation.
+# GEMINI_API_KEY=
+#
+# Optional / Enterprise services:
+# Set DEEPL_API_KEY for DeepL Free (500k chars/mo, key ends in :fx) or DeepL Pro.
+# DEEPL_API_KEY=
+# Set GOOGLE_TRANSLATE_API_KEY for Google Cloud Translation v2.
+# GOOGLE_TRANSLATE_API_KEY=
+#
+# When all keys are unset, the node safely falls back to keyless free public translation (MyMemory).
+

--- a/client/.env.example
+++ b/client/.env.example
@@ -178,7 +178,7 @@ FILEBASE_KEY_PREFIX=
 # The node proxy uses an in-memory LRU cache (2,000 entries) with automatic fallback.
 #
 # Primary recommended (Free Tier: 1,500 requests/day, no credit card required):
-# Set GEMINI_API_KEY from Google AI Studio (https://aistudio.google.com) for Web3/crypto context-aware AI translation.
+# Set GEMINI_API_KEY from Google AI Studio (https://aistudio.google.com) for fast, context-aware AI translation.
 # GEMINI_API_KEY=
 #
 # Optional / Enterprise services:

--- a/client/src/api/routes/translate.ts
+++ b/client/src/api/routes/translate.ts
@@ -13,7 +13,7 @@
  *   or higher-quota translation providers.
  *
  * Provider Fallback Hierarchy:
- *   1. Google Gemini (LLM): Context-aware Web3 translation (requires GEMINI_API_KEY).
+ *   1. Google Gemini (LLM): Fast and context-aware AI translation (requires GEMINI_API_KEY).
  *      Default model: gemini-3.5-flash-lite (generous 500 RPD free tier).
  *   2. DeepL API: High-precision translation (requires DEEPL_API_KEY).
  *   3. Google Cloud Translation API (v2): (requires GOOGLE_TRANSLATE_API_KEY).
@@ -41,7 +41,7 @@ const translateRateLimit = rateLimit({
 })
 
 // Optional API keys for reliable datacenter/node translation
-// Primary recommended: GEMINI_API_KEY (free tier from Google AI Studio, high-quality Web3 context)
+// Primary recommended: GEMINI_API_KEY (free tier from Google AI Studio, fast and context-aware translation)
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY
 // Default to gemini-3.5-flash-lite (generous 500 RPD free tier, ultra-low latency)
 const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-3.5-flash-lite'
@@ -82,7 +82,7 @@ function setToCache(key: string, value: CacheEntry): void {
 
 /**
  * Translate via Google Gemini (LLM)
- * Optional provider: free tier available via Google AI Studio, Web3 & crypto context-aware.
+ * Optional provider: free tier available via Google AI Studio, fast and context-aware.
  */
 async function translateWithGemini(
   text: string,
@@ -94,10 +94,13 @@ async function translateWithGemini(
     const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`
 
     const systemPrompt =
-      `You are an expert translator for the Web3 and cryptocurrency social network CAW.\n` +
+      `You are a neutral, accurate, and faithful translator for social media posts.\n` +
       `Translate the following post text into target language code "${targetLang}"${sourceLang && sourceLang !== 'auto' ? ` from source language "${sourceLang}"` : ''}.\n` +
       `Guidelines:\n` +
-      `- Keep crypto, Web3, and social media slang natural (e.g. CAW, mint, LFG, gm, fren, hodl, rug, wagmi).\n` +
+      `- Provide an accurate, natural, and balanced translation that faithfully conveys the meaning and tone of the original post without exaggeration.\n` +
+      `- Translate all sentences and text naturally into the target language.\n` +
+      `- Do NOT insert extra words, slang, colloquialisms, or emojis that are not in the original text.\n` +
+      `- Preserve proper nouns, usernames (@mentions), hashtags (#tags), URLs, and financial/token tickers (e.g. $CAW, ETH). Widely recognized acronyms (e.g. WAGMI, LFG, gm) may be kept in uppercase Latin if commonly used untranslated.\n` +
       `- Return ONLY a valid raw JSON object with keys "text" and "sourceLanguage".\n` +
       `- "text" must be the translated string.\n` +
       `- "sourceLanguage" must be the 2-letter ISO language code of the original text (e.g. "en", "ja").\n` +

--- a/client/src/api/routes/translate.ts
+++ b/client/src/api/routes/translate.ts
@@ -1,0 +1,390 @@
+/**
+ * Server-side Translation Proxy (/api/translate)
+ *
+ * Overview:
+ * - Provides node-level translation proxying to eliminate browser CORS issues,
+ *   protect external API credentials from client exposure, and reduce external
+ *   API consumption via a shared in-memory LRU cache.
+ *
+ * Zero-Config Out of the Box:
+ * - By default (without any API keys configured), the node transparently falls back
+ *   to the keyless, free public MyMemory API.
+ * - Node operators may optionally configure API keys in `.env` to enable higher-quality
+ *   or higher-quota translation providers.
+ *
+ * Provider Fallback Hierarchy:
+ *   1. Google Gemini (LLM): Context-aware Web3 translation (requires GEMINI_API_KEY).
+ *      Default model: gemini-3.5-flash-lite (generous 500 RPD free tier).
+ *   2. DeepL API: High-precision translation (requires DEEPL_API_KEY).
+ *   3. Google Cloud Translation API (v2): (requires GOOGLE_TRANSLATE_API_KEY).
+ *   4. MyMemory API: Free keyless fallback (always enabled, default tier).
+ *
+ * Privacy & Security:
+ *   - E2EE Direct Messages pass `isPrivate: true`. Private content is NEVER cached
+ *     in memory to prevent sensitive text from persisting on node servers.
+ *   - Per-IP rate limiting (30 req/min) prevents abusive scraping and API quota exhaustion.
+ */
+
+import { Router } from 'express'
+import rateLimit from 'express-rate-limit'
+
+const router = Router()
+
+// Per-IP rate limit: 30 requests per minute per IP.
+// Prevents automated bots from draining API quotas or hammering node resources.
+const translateRateLimit = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Translation rate limit exceeded. Please try again in a minute.' },
+})
+
+// Optional API keys for reliable datacenter/node translation
+// Primary recommended: GEMINI_API_KEY (free tier from Google AI Studio, high-quality Web3 context)
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY
+// Default to gemini-3.5-flash-lite (generous 500 RPD free tier, ultra-low latency)
+const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-3.5-flash-lite'
+const DEEPL_API_KEY = process.env.DEEPL_API_KEY
+const GOOGLE_TRANSLATE_API_KEY = process.env.GOOGLE_TRANSLATE_API_KEY
+
+interface CacheEntry {
+  text: string
+  sourceLanguage: string
+  timestamp: number
+}
+
+// In-memory LRU cache to minimize external API consumption and eliminate redundant calls
+const MAX_CACHE_SIZE = 2000
+const translationCache = new Map<string, CacheEntry>()
+
+function getCacheKey(text: string, targetLang: string, sourceLang?: string): string {
+  return `${sourceLang || 'auto'}:${targetLang}:${text.trim()}`
+}
+
+function getFromCache(key: string): CacheEntry | null {
+  const entry = translationCache.get(key)
+  if (!entry) return null
+  // Refresh LRU order (delete and re-insert)
+  translationCache.delete(key)
+  translationCache.set(key, entry)
+  return entry
+}
+
+function setToCache(key: string, value: CacheEntry): void {
+  if (translationCache.size >= MAX_CACHE_SIZE) {
+    // Evict oldest entry (first key in iteration order)
+    const oldestKey = translationCache.keys().next().value
+    if (oldestKey) translationCache.delete(oldestKey)
+  }
+  translationCache.set(key, value)
+}
+
+/**
+ * Translate via Google Gemini (LLM)
+ * Optional provider: free tier available via Google AI Studio, Web3 & crypto context-aware.
+ */
+async function translateWithGemini(
+  text: string,
+  targetLang: string,
+  sourceLang?: string,
+): Promise<{ text: string; sourceLanguage: string } | null> {
+  if (!GEMINI_API_KEY) return null
+  try {
+    const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`
+
+    const systemPrompt =
+      `You are an expert translator for the Web3 and cryptocurrency social network CAW.\n` +
+      `Translate the following post text into target language code "${targetLang}"${sourceLang && sourceLang !== 'auto' ? ` from source language "${sourceLang}"` : ''}.\n` +
+      `Guidelines:\n` +
+      `- Keep crypto, Web3, and social media slang natural (e.g. CAW, mint, LFG, gm, fren, hodl, rug, wagmi).\n` +
+      `- Return ONLY a valid raw JSON object with keys "text" and "sourceLanguage".\n` +
+      `- "text" must be the translated string.\n` +
+      `- "sourceLanguage" must be the 2-letter ISO language code of the original text (e.g. "en", "ja").\n` +
+      `- Do NOT wrap the JSON in Markdown code fences (no \`\`\`json). Do NOT add extra conversational commentary.`
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [
+              { text: `${systemPrompt}\n\nText to translate:\n${text}` },
+            ],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.1,
+          maxOutputTokens: 1000,
+        },
+      }),
+      signal: AbortSignal.timeout(8000),
+    })
+
+    if (!response.ok) {
+      console.warn(`[translate:Gemini] HTTP ${response.status}: ${await response.text().catch(() => '')}`)
+      return null
+    }
+
+    const data = await response.json()
+    const rawOutput = data?.candidates?.[0]?.content?.parts?.[0]?.text?.trim()
+    if (!rawOutput) return null
+
+    // Parse JSON output
+    try {
+      // Strip markdown fences if Gemini still added them
+      const cleanJson = rawOutput.replace(/^```json\s*/i, '').replace(/^```\s*/i, '').replace(/\s*```$/, '').trim()
+      const parsed = JSON.parse(cleanJson)
+      if (parsed?.text) {
+        return {
+          text: String(parsed.text).trim(),
+          sourceLanguage: (parsed.sourceLanguage || sourceLang || 'auto').toLowerCase(),
+        }
+      }
+    } catch {
+      // Fallback: If not valid JSON, use entire output as translated text
+      return {
+        text: rawOutput,
+        sourceLanguage: sourceLang || 'auto',
+      }
+    }
+
+    return null
+  } catch (err) {
+    console.warn('[translate:Gemini] fetch error:', err)
+    return null
+  }
+}
+
+/**
+ * Translate via DeepL API Free or Pro
+ */
+async function translateWithDeepL(
+  text: string,
+  targetLang: string,
+  sourceLang?: string,
+): Promise<{ text: string; sourceLanguage: string } | null> {
+  if (!DEEPL_API_KEY) return null
+  try {
+    const isFreePlan = DEEPL_API_KEY.endsWith(':fx') || !DEEPL_API_KEY.includes('-')
+    const endpoint = isFreePlan
+      ? 'https://api-free.deepl.com/v2/translate'
+      : 'https://api.deepl.com/v2/translate'
+
+    // DeepL target language mapping (e.g. EN -> EN-US, JA -> JA)
+    let deepLTarget = targetLang.toUpperCase()
+    if (deepLTarget === 'EN') deepLTarget = 'EN-US'
+
+    const params = new URLSearchParams()
+    params.set('text', text)
+    params.set('target_lang', deepLTarget)
+    if (sourceLang && sourceLang !== 'auto') {
+      params.set('source_lang', sourceLang.toUpperCase())
+    }
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `DeepL-Auth-Key ${DEEPL_API_KEY}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params.toString(),
+      signal: AbortSignal.timeout(6000),
+    })
+
+    if (!response.ok) {
+      console.warn(`[translate:DeepL] HTTP ${response.status}: ${await response.text().catch(() => '')}`)
+      return null
+    }
+
+    const data = await response.json()
+    const first = data?.translations?.[0]
+    if (first?.text) {
+      const detected = (first.detected_source_language || '').toLowerCase()
+      return { text: first.text, sourceLanguage: detected }
+    }
+    return null
+  } catch (err) {
+    console.warn('[translate:DeepL] fetch error:', err)
+    return null
+  }
+}
+
+/**
+ * Translate via Google Cloud Translation API (v2)
+ */
+async function translateWithGoogleCloud(
+  text: string,
+  targetLang: string,
+  sourceLang?: string,
+): Promise<{ text: string; sourceLanguage: string } | null> {
+  if (!GOOGLE_TRANSLATE_API_KEY) return null
+  try {
+    const url = new URL('https://translation.googleapis.com/language/translate/v2')
+    url.searchParams.set('key', GOOGLE_TRANSLATE_API_KEY)
+    url.searchParams.set('q', text)
+    url.searchParams.set('target', targetLang)
+    url.searchParams.set('format', 'text')
+    if (sourceLang && sourceLang !== 'auto') {
+      url.searchParams.set('source', sourceLang)
+    }
+
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      signal: AbortSignal.timeout(6000),
+    })
+
+    if (!response.ok) {
+      console.warn(`[translate:GoogleCloud] HTTP ${response.status}: ${await response.text().catch(() => '')}`)
+      return null
+    }
+
+    const data = await response.json()
+    const trans = data?.data?.translations?.[0]
+    if (trans?.translatedText) {
+      const detected = (trans.detectedSourceLanguage || '').toLowerCase()
+      return { text: trans.translatedText, sourceLanguage: detected }
+    }
+    return null
+  } catch (err) {
+    console.warn('[translate:GoogleCloud] fetch error:', err)
+    return null
+  }
+}
+
+/**
+ * Fallback to MyMemory Public API (free, keyless)
+ */
+async function translateWithMyMemory(
+  text: string,
+  targetLang: string,
+  sourceLang?: string,
+): Promise<{ text: string; sourceLanguage: string } | null> {
+  try {
+    const sl = sourceLang && sourceLang !== 'auto' ? sourceLang : 'autodetect'
+    const langpair = `${sl}|${targetLang}`
+    const url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(text)}&langpair=${langpair}`
+
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(6000),
+    })
+
+    if (!response.ok) return null
+    const data = await response.json()
+
+    // Status 200 with valid translatedText
+    if (data?.responseStatus === 200 || data?.responseStatus === '200') {
+      const txt = data?.responseData?.translatedText
+      if (txt && !txt.includes('PLEASE SELECT TWO DISTINCT LANGUAGES')) {
+        const detected = (data?.responseData?.detectedLanguage || '').toLowerCase()
+        return { text: txt, sourceLanguage: detected }
+      }
+    }
+    return null
+  } catch (err) {
+    console.warn('[translate:MyMemory] fetch error:', err)
+    return null
+  }
+}
+
+/**
+ * POST /api/translate
+ * Body: { text: string, targetLang: string, sourceLang?: string, isPrivate?: boolean }
+ */
+router.post('/', translateRateLimit, (async (req: any, res: any): Promise<void> => {
+  try {
+    const { text, targetLang, sourceLang, isPrivate } = req.body
+
+    if (!text || typeof text !== 'string' || !text.trim()) {
+      res.status(400).json({ error: 'Field "text" is required and must be non-empty' })
+      return
+    }
+
+    if (text.length > 2000) {
+      res.status(400).json({ error: 'Field "text" exceeds maximum allowed length of 2,000 characters' })
+      return
+    }
+
+    if (!targetLang || typeof targetLang !== 'string') {
+      res.status(400).json({ error: 'Field "targetLang" is required' })
+      return
+    }
+
+    const trimmedText = text.trim()
+    const cleanTarget = targetLang.split('-')[0].toLowerCase()
+    const cleanSource = sourceLang ? sourceLang.split('-')[0].toLowerCase() : undefined
+
+    // If source and target are explicitly identical, return original
+    if (cleanSource && cleanSource === cleanTarget) {
+      res.json({
+        text: trimmedText,
+        sourceLanguage: cleanSource,
+        targetLanguage: cleanTarget,
+        cached: false,
+      })
+      return
+    }
+
+    // Check in-memory LRU cache first
+    // PRIVACY AUDIT GUARD: Never read from cache for private content (e.g. E2EE DMs)
+    const cacheKey = getCacheKey(trimmedText, cleanTarget, cleanSource)
+    if (!isPrivate) {
+      const cached = getFromCache(cacheKey)
+      if (cached) {
+        res.json({
+          text: cached.text,
+          sourceLanguage: cached.sourceLanguage,
+          targetLanguage: cleanTarget,
+          cached: true,
+        })
+        return
+      }
+    }
+
+    // Multi-tier fallback order:
+    // 1. Google Gemini (Context-aware Web3 translation, if configured)
+    // 2. DeepL API (if configured)
+    // 3. Google Cloud Translation API (if configured)
+    // 4. MyMemory Public API (zero-config keyless free fallback)
+    let result = await translateWithGemini(trimmedText, cleanTarget, cleanSource)
+    if (!result) {
+      result = await translateWithDeepL(trimmedText, cleanTarget, cleanSource)
+    }
+    if (!result) {
+      result = await translateWithGoogleCloud(trimmedText, cleanTarget, cleanSource)
+    }
+    if (!result) {
+      result = await translateWithMyMemory(trimmedText, cleanTarget, cleanSource)
+    }
+
+    if (!result) {
+      res.status(503).json({
+        error: 'Translation services temporarily unavailable',
+      })
+      return
+    }
+
+    // PRIVACY AUDIT GUARD: Never store private content (E2EE DMs) in memory cache
+    if (!isPrivate) {
+      const cacheEntry: CacheEntry = {
+        text: result.text,
+        sourceLanguage: result.sourceLanguage,
+        timestamp: Date.now(),
+      }
+      setToCache(cacheKey, cacheEntry)
+    }
+
+    res.json({
+      text: result.text,
+      sourceLanguage: result.sourceLanguage,
+      targetLanguage: cleanTarget,
+      cached: false,
+    })
+  } catch (error: any) {
+    console.error('POST /api/translate error:', error)
+    res.status(500).json({ error: 'Internal server error during translation' })
+  }
+}) as any)
+
+export default router

--- a/client/src/api/server.ts
+++ b/client/src/api/server.ts
@@ -20,6 +20,7 @@ import dmRouter from './routes/dm'
 import dmGroupsRouter from './routes/dm-groups'
 import dmRelayRouter from './routes/dm-relay'
 import giphyRouter from './routes/giphy'
+import translateRouter from './routes/translate'
 import statsRouter from './routes/stats'
 import shorturlRouter from './routes/shorturl'
 import instancesRouter from './routes/instances'
@@ -406,6 +407,7 @@ export function createApp() {
   app.use('/api/dm', dmRouter)
   app.use('/api/dm/relay', dmRelayRouter)
   app.use('/api/giphy', giphyRouter)
+  app.use('/api/translate', translateRouter)
   app.use('/api/stats', statsRouter)
   app.use('/api/shorturl', shorturlRouter)
   app.use('/api/instances', instancesRouter)

--- a/client/src/services/FrontEnd/src/components/FeedItem.tsx
+++ b/client/src/services/FrontEnd/src/components/FeedItem.tsx
@@ -1035,8 +1035,12 @@ const FeedItem: React.FC<{ item: CawItem; isMainPost?: boolean; isReply?: boolea
     // Handle different menu actions
     switch (action) {
       case 'translate':
-        if (isTranslating || translatedText) {
-          // Toggle off — second click on Translate clears the translation.
+        if (isTranslating) {
+          // In-flight translation — avoid cancelling concurrent auto-translate
+          return
+        }
+        if (translatedText) {
+          // Toggle off — click on Translate when already translated clears the translation.
           setTranslatedText(null)
           setTranslatedPollOptions(null)
           return

--- a/client/src/services/FrontEnd/src/pages/Messages.tsx
+++ b/client/src/services/FrontEnd/src/pages/Messages.tsx
@@ -1245,7 +1245,7 @@ const MessagesPage: React.FC = () => {
       const next = new Set(prev); next.add(messageId); return next
     })
     try {
-      const result = await translateText(text)
+      const result = await translateText(text, undefined, { isPrivate: true })
       if (result) setTranslations(prev => ({ ...prev, [messageId]: result }))
     } finally {
       setTranslatingIds(prev => {

--- a/client/src/services/FrontEnd/src/utils/translate.ts
+++ b/client/src/services/FrontEnd/src/utils/translate.ts
@@ -1,18 +1,13 @@
 // Translation helper used by both post translation (FeedItem) and DM
-// translation (Messages). Centralized here so changing the provider, the
-// target-language strategy, or adding API-key auth happens in one place.
+// translation (Messages). Proxies requests through the node server
+// (/api/translate) for robust multi-provider support, zero-config keyless
+// fallback, in-memory LRU caching, and E2EE privacy protection.
 //
-// Current implementation: Google Translate's free unauthenticated `gtx`
-// endpoint (the same one the Chrome translate bar uses). No API key, no
-// quota visible to us, but it's undocumented and could break — wrap every
-// call in try/catch at the callsite.
-//
-// Note for DMs: this sends plaintext to a third party. The DM is E2E-
-// encrypted in transit + at rest; translating breaks that boundary. Always
-// prompt the user (see ConfirmModal with rememberKey='dmTranslateAck')
-// before calling this for a DM.
+// Note for DMs: translating plaintext sends it to the translation service;
+// translating breaks the E2EE boundary. Always prompt the user (see ConfirmModal
+// with rememberKey='dmTranslateAck') before calling this for a DM.
 
-const GOOGLE_TRANSLATE_URL = 'https://translate.googleapis.com/translate_a/single'
+import { apiFetch } from '~/api/client'
 
 /**
  * Browser-locale fallback target language. The Settings → Language picker
@@ -118,8 +113,12 @@ export interface TranslationResult {
  * that want the detected source language for caching purposes should
  * use `translateTextDetailed` instead.
  */
-export async function translateText(text: string, targetLang?: string): Promise<string | null> {
-  const detail = await translateTextDetailed(text, targetLang)
+export async function translateText(
+  text: string,
+  targetLang?: string,
+  options?: { isPrivate?: boolean },
+): Promise<string | null> {
+  const detail = await translateTextDetailed(text, targetLang, options)
   return detail?.text ?? null
 }
 
@@ -131,11 +130,12 @@ export async function translateText(text: string, targetLang?: string): Promise<
 export async function translateTextDetailed(
   text: string,
   targetLang?: string,
+  options?: { isPrivate?: boolean },
 ): Promise<TranslationResult | null> {
   if (!text || !text.trim()) return null
   const tl = targetLang || getTargetLanguage()
 
-  const first = await fetchTranslation(text, tl)
+  const first = await fetchTranslation(text, tl, options?.isPrivate)
   if (first && first.text && first.text !== text) {
     return { ...first, targetLanguage: tl }
   }
@@ -144,7 +144,7 @@ export async function translateTextDetailed(
   // user gets *something* useful (vs. tapping "Translate" and seeing the
   // same text). Skip this if we already targeted English.
   if (tl !== 'en') {
-    const en = await fetchTranslation(text, 'en')
+    const en = await fetchTranslation(text, 'en', options?.isPrivate)
     if (en && en.text && en.text !== text) {
       return { ...en, targetLanguage: 'en' }
     }
@@ -157,27 +157,17 @@ interface FetchResult {
   sourceLanguage: string
 }
 
-async function fetchTranslation(text: string, tl: string): Promise<FetchResult | null> {
+async function fetchTranslation(text: string, tl: string, isPrivate?: boolean): Promise<FetchResult | null> {
   try {
-    const url = `${GOOGLE_TRANSLATE_URL}?client=gtx&sl=auto&tl=${tl}&dt=t&q=${encodeURIComponent(text)}`
-    const res = await fetch(url)
-    if (!res.ok) return null
-    const data = await res.json()
-    // Response shape: [[[translatedChunk, originalChunk, ...], ...], <??>, "<src>", ...]
-    if (!Array.isArray(data?.[0])) return null
-    const joined = (data[0] as unknown[])
-      .map(seg => Array.isArray(seg) ? (seg as unknown[])[0] : '')
-      .filter((s): s is string => typeof s === 'string')
-      .join('')
-    if (!joined) return null
-    // data[2] is gtx's detected source language (e.g. "es"). Sometimes
-    // it's a region-tagged form ("zh-CN") — strip down to the primary
-    // subtag so it lines up with our stored preferredLanguage shape.
-    const detectedRaw = typeof data?.[2] === 'string' ? data[2] : ''
-    const sourceLanguage = detectedRaw.split('-')[0].toLowerCase()
-    return { text: joined, sourceLanguage }
+    const res = await apiFetch<{ text: string; sourceLanguage: string }>('/api/translate', {
+      method: 'POST',
+      body: JSON.stringify({ text, targetLang: tl, isPrivate }),
+    })
+    if (res?.text) {
+      return { text: res.text, sourceLanguage: res.sourceLanguage || '' }
+    }
   } catch (err) {
-    console.warn('[translate] fetch failed:', err)
-    return null
+    console.warn('[translate] API proxy request failed:', err)
   }
+  return null
 }


### PR DESCRIPTION
# PR Description: Server-Side Translation Proxy

## Summary

Introduces a server-side translation proxy (`POST /api/translate`) with public fallback, in-memory LRU caching, E2EE privacy protection, and frontend consolidation.

## Background & Original Design Intent

As documented in the original header comments of `client/src/services/FrontEnd/src/utils/translate.ts`:
> *"Centralized here so changing the provider, the target-language strategy, or adding API-key auth happens in one place."*
> *"Current implementation: Google Translate's free unauthenticated `gtx` endpoint ... it's undocumented and could break — wrap every call in try/catch at the callsite."*

The unauthenticated `gtx` client endpoint served as an interim implementation, but exhibits reproducible failure modes in live production environments:
1. **HTTP 429 Blocks**: Data center IPs hosting node infrastructure, as well as users behind privacy proxy services (such as Apple iCloud Private Relay), are systematically blocked by upstream anti-bot filters (`automated queries`).
2. **Redundant Network Calls & Silent Failures**: Direct client-side fetching lacks cross-viewer caching, issuing repeated external requests for the same post across multiple viewers. When requests fail, the client returns `null`, causing the UI spinner to silently disappear without indication.

This PR completes the original design intent by establishing an authenticated, cached node-level translation proxy, while maintaining seamless operation for node operators who do not configure external API keys.

## Key Architectural Improvements

1. **Default Public Fallback**:
   - When no external API keys are configured in `.env`, the proxy transparently routes requests to the public MyMemory API.
   - Node operators can run translation without mandatory API keys or setup costs.
2. **Tiered Provider Hierarchy (Configurable via `.env`)**:
   - **Google Gemini (LLM)**: Fast, context-aware AI translation enabled via `GEMINI_API_KEY`. Defaults to `gemini-3.5-flash-lite`.
   - **DeepL API**: High-accuracy translation enabled via `DEEPL_API_KEY` (supports both Free `:fx` and Pro keys).
   - **Google Cloud Translation v2**: Enterprise translation enabled via `GOOGLE_TRANSLATE_API_KEY`.
   - **MyMemory API**: Default public fallback if all preceding tiers are unconfigured or unavailable.
3. **In-Memory LRU Cache (2,000 Entries)**:
   - Implemented via a `Map`-backed LRU cache (`MAX_CACHE_SIZE = 2000`).
   - Identical post/language combinations return cached results in ~0ms, eliminating redundant external API consumption across multiple viewers.
   - Memory footprint is capped at a few megabytes, preventing memory leaks.
4. **E2EE Privacy Audit Guard (`isPrivate: true`)**:
   - Calls originating from encrypted direct messages (`Messages.tsx`) pass `{ isPrivate: true }`.
   - When `isPrivate: true` is set, reading from and writing to the server LRU cache is 100% bypassed. Sensitive plaintext is never stored in node memory.
5. **DoS & Quota Protection**:
   - Per-IP rate limiting (`express-rate-limit`: 30 requests/min per IP).
   - Compatible with reverse proxies via the existing `app.set('trust proxy', 'loopback')` configuration.
   - Request length validation rejects text exceeding 2,000 characters with `HTTP 400`.
   - Each upstream provider call is bounded by `AbortSignal.timeout` (6–8 seconds) to prevent hanging worker processes.
6. **Frontend Consolidation**:
   - Refactored `translate.ts` to route exclusively through `apiFetch('/api/translate')`.
   - Completely removed fragile browser-side `gtx` endpoints, public CORS scrapers, and brittle multidimensional array parsing logic (~50 lines removed from client bundle).

## Live Verification & Test Results

All behaviors verified on a live node running Node.js / PostgreSQL:

- **Type Safety (`tsc --noEmit`)**:
  - `0` new type or syntax errors introduced. (The sole existing error in `listenForRawEvents.ts` is pre-existing upstream on `origin/v2`).
- **Default Fallback Verification**:
  - Verified live connectivity to MyMemory API with zero keys configured:
    `HTTP 200 OK -> "こんにちは、世界。"`
- **In-Memory Cache Verification**:
  - Initial translation request: `cached: false` (processed via provider).
  - Second identical request: `cached: true` (returned from LRU memory cache in 0ms).
- **E2EE Privacy Audit Verification**:
  - Request with `isPrivate: true`: returned translated text with `cached: false`.
  - Immediate subsequent identical private request: returned `cached: false` (confirmed cache write was skipped).
- **Zero New Dependencies**:
  - Uses `express-rate-limit` already pinned in `package.json:67`. Zero new npm packages added.

## Configuration Guide for Node Operators

No configuration is mandatory. To optionally enable higher-tier providers, node operators may add any of the following to `.env`:

| Variable | Provider | Notes |
|---|---|---|
| `GEMINI_API_KEY` | Google Gemini (AI) | Google AI Studio key. Fast, context-aware translation. |
| `GEMINI_MODEL` | Gemini Model Override | Optional model override. Defaults to `gemini-3.5-flash-lite`. |
| `DEEPL_API_KEY` | DeepL API (Free / Pro) | Supports DeepL API Free (keys ending in `:fx`) and DeepL Pro. |
| `GOOGLE_TRANSLATE_API_KEY` | Google Cloud Translate v2 | Standard Google Cloud Translation v2 API key. |
| *(None)* | MyMemory API | Default public fallback when no API keys are configured. |

---

zinsanjp
