### PR TITLE
fix(raw-events): replace stale @ethersproject/abstract-provider import, close remaining ethers v6 Log type gaps

### DIFF
--- a/client/src/services/RawEventsGatherer/listenForRawEvents.ts
+++ b/client/src/services/RawEventsGatherer/listenForRawEvents.ts
@@ -1,6 +1,6 @@
 // src/services/RawEventsGatherer/listenForRawEvents.ts
 import { ContractEventPayload, WebSocketProvider, Contract, Interface, keccak256, toUtf8Bytes, getBytes, concat } from 'ethers'
-import type { Log } from '@ethersproject/abstract-provider'
+import type { Log } from 'ethers'
 import { CAW_ACTIONS_ADDRESS, CAW_ACTIONS_ERC1271_ADDRESS } from '../../abi/addresses'
 import { makeFallbackJsonRpcProvider, makeVerifiedFallbackJsonRpcProvider, makeWebSocketProvider, getL2HttpRpcUrls, getL2WsSecret, waitForRateLimit, redactRpcUrl } from '../../utils/rpcProvider'
 import { scanLogsForward } from '../../utils/chunkedLogs'
@@ -405,7 +405,7 @@ export default async function listenForRawEvents(
           transactionHash: ev.transactionHash,
           parentHash:      lastHash,
           data:            action,
-          topics:          ev.topics,
+          topics:          [ ...ev.topics ],
           contractAddress: ev.address
         })
       }


### PR DESCRIPTION
### Problem
`client/src/services/RawEventsGatherer/listenForRawEvents.ts` still imported `Log` from `@ethersproject/abstract-provider`, a package no longer installed since the ethers v6 migration. Every property access on `Log` values in this file typed as `any` instead of being checked against ethers v6's own `Log` shape — the single pre-existing `Cannot find module` error every prior PR in this project noted and tolerated project-wide (`tsc --noEmit` always reported exactly 1 known error).

### Root Cause
Follow-up to PR #63 (`logIndex` NaN-sort fix, already merged). While auditing this file for the ethers v6 migration, the stale `@ethersproject/abstract-provider` import was masking two real type gaps that only surface once resolved against ethers' own `Log` type:
1. `ev.logIndex` — ethers v6 renamed this to `.index`; already handled by PR #63's `(ev as any).index ?? (ev as any).logIndex ?? 0` fallback, confirmed still correct after the import switch.
2. `topics: ev.topics` assigned ethers v6's readonly `string[]` directly into `RawEventInput.topics` (mutable `string[]`) — a real `TS4104` error once the import pointed at the correct type.

### Solution
Switch the `Log` import to ethers' own type and spread `ev.topics` into a new mutable array (`[ ...ev.topics ]`), matching the same readonly-to-mutable pattern PR #63 already applied at two other call sites in this file.

### Verification
`tsc --noEmit` now completes with **zero errors** (previously always exactly 1, tolerated project-wide). `tests/services/chunkedLogsBackward.test.ts` unaffected (8/8 passing).

---
zinsanjp