### PR TITLE
fix(ActionProcessor): pass isReply to onCawCreated to prevent User.ca…

### DIFF
--- a/client/src/services/ActionProcessor/actionHandlers.ts
+++ b/client/src/services/ActionProcessor/actionHandlers.ts
@@ -412,6 +412,7 @@ export async function handleCawAction(
       action: 'CAW',
       originalCawId: quoteOriginalCawId,
       status: 'SUCCESS',
+      isReply: isReplyNotQuote,
     })
   } else if (existingCaw.status === 'PENDING' || existingCaw.status === 'FAILED') {
     // Optimistic counts already applied (PENDING) or were never rolled
@@ -1096,6 +1097,9 @@ export async function handleOtherAction(
   // Update counts via CountManager (same as regular caw).
   // For replies (parentCawId set), don't pass originalCawId — we don't want recawCount
   // bumped on the parent; commentCount is handled separately below.
+  // Quotes (RECAW with text) bump recawCount via onCawCreated; they must NOT
+  // also bump commentCount — that's reserved for true CAW replies.
+  const isReplyNotQuote = effectiveActionType !== 'RECAW'
   const otherOriginalCawId = (effectiveActionType === 'RECAW' && parentCawId) ? parentCawId : null
   await countManager.onCawCreated(tx, {
     id: newCaw.id,
@@ -1103,11 +1107,9 @@ export async function handleOtherAction(
     action: effectiveActionType === 'RECAW' ? 'RECAW' : 'CAW',
     originalCawId: otherOriginalCawId,
     status: 'SUCCESS',
+    isReply: Boolean(parentCawId && isReplyNotQuote),
   })
 
-  // Quotes (RECAW with text) bump recawCount via onCawCreated; they must NOT
-  // also bump commentCount — that's reserved for true CAW replies.
-  const isReplyNotQuote = effectiveActionType !== 'RECAW'
   if (parentCawId && isReplyNotQuote) {
     await countManager.onReplyCreated(tx, {
       cawId: parentCawId,

--- a/client/tests/services/CountManager.replyFlag.test.ts
+++ b/client/tests/services/CountManager.replyFlag.test.ts
@@ -1,0 +1,110 @@
+// Tests for CountManager.onCawCreated's isReply handling.
+//
+// Regression test for a bug where ActionProcessor's actionHandlers.ts
+// (handleCawAction / handleOtherAction) computed isReplyNotQuote but never
+// passed it to onCawCreated, causing every peer-mirrored reply to be
+// counted as a top-level post — inflating User.cawCount and causing
+// cawCount to diverge between nodes depending on whether a caw was
+// submitted locally (API route, which did pass isReply correctly) or
+// received via on-chain event replay (ActionProcessor, which did not).
+//
+// Verified against production data on cawnest.com (2026-09-06): a
+// peer-mirrored user's User.cawCount exactly equalled
+// (root/quote posts + replies + hidden posts) — i.e. every reply had
+// been folded into cawCount — while a locally-submitted user's
+// cawCount excluded their replies entirely, confirming the two code
+// paths diverged.
+
+import { expect } from 'chai'
+import { countManager } from '../../src/services/CountManager'
+
+interface FakeTx {
+  caw: { update: (args: any) => Promise<void> }
+  user: { update: (args: any) => Promise<void> }
+  cawUpdates: Array<{ id: number; data: any }>
+  userUpdates: Array<{ tokenId: number; data: any }>
+}
+
+function makeFakeTx(): FakeTx {
+  const cawUpdates: Array<{ id: number; data: any }> = []
+  const userUpdates: Array<{ tokenId: number; data: any }> = []
+  return {
+    cawUpdates,
+    userUpdates,
+    caw: {
+      update: async ({ where, data }: any) => {
+        cawUpdates.push({ id: where.id, data })
+      },
+    },
+    user: {
+      update: async ({ where, data }: any) => {
+        userUpdates.push({ tokenId: where.tokenId, data })
+      },
+    },
+  }
+}
+
+describe('CountManager.onCawCreated — isReply flag', () => {
+  it('increments user.cawCount for a top-level post (isReply omitted)', async () => {
+    const tx = makeFakeTx()
+    await countManager.onCawCreated(tx as any, {
+      id: 1001,
+      userId: 42,
+      action: 'CAW',
+      originalCawId: null,
+      status: 'SUCCESS',
+    })
+    expect(tx.userUpdates).to.deep.equal([
+      { tokenId: 42, data: { cawCount: { increment: 1 } } },
+    ])
+  })
+
+  it('does NOT increment user.cawCount for a reply (isReply: true)', async () => {
+    const tx = makeFakeTx()
+    await countManager.onCawCreated(tx as any, {
+      id: 1002,
+      userId: 42,
+      action: 'CAW',
+      originalCawId: null,
+      status: 'SUCCESS',
+      isReply: true,
+    })
+    expect(tx.userUpdates).to.deep.equal([])
+  })
+
+  it('regression: a reply with isReply omitted is wrongly counted as a top-level post', async () => {
+    // This reproduces the pre-fix bug condition: actionHandlers.ts computed
+    // isReplyNotQuote but never passed it through, so onCawCreated always
+    // saw isReply === undefined for peer-mirrored replies.
+    const tx = makeFakeTx()
+    await countManager.onCawCreated(tx as any, {
+      id: 1003,
+      userId: 42,
+      action: 'CAW',
+      originalCawId: null,
+      status: 'SUCCESS',
+      // isReply omitted entirely, as the buggy call site did
+    })
+    expect(tx.userUpdates).to.deep.equal([
+      { tokenId: 42, data: { cawCount: { increment: 1 } } },
+    ])
+  })
+
+  it('still bumps parent recawCount for a quote (CAW with originalCawId), independent of isReply', async () => {
+    const tx = makeFakeTx()
+    await countManager.onCawCreated(tx as any, {
+      id: 1004,
+      userId: 42,
+      action: 'CAW',
+      originalCawId: 999,
+      status: 'SUCCESS',
+      isReply: false,
+    })
+    expect(tx.userUpdates).to.deep.equal([
+      { tokenId: 42, data: { cawCount: { increment: 1 } } },
+    ])
+    expect(tx.cawUpdates).to.deep.equal([
+      { id: 999, data: { recawCount: { increment: 1 } } },
+    ])
+  })
+})


### PR DESCRIPTION
### Problem
`handleCawAction` and `handleOtherAction` in `ActionProcessor/actionHandlers.ts` both computed `isReplyNotQuote` (needed to decide whether to set `originalCawId` / bump `commentCount`), but never passed it through to `countManager.onCawCreated`. Since `onCawCreated`'s `isReply` parameter defaults to falsy when omitted, every reply arriving through `ActionProcessor` (peer-mirrored on-chain events) was counted as a top-level post, inflating `User.cawCount`.

The local submit path (`client/src/api/routes/actions.ts`) already passed `isReply` correctly, so a caw's effect on `cawCount` silently depended on whether it was submitted locally or received via chain replay — producing non-deterministic `User.cawCount` divergence between mirror nodes for the exact same set of underlying caws.

Because `/api/users/:username` derives the displayed post count as `cawCount - replyCount` (`replyCount` computed live from `SUCCESS` rows with a parent), a mirrored reply's inflated `cawCount` also surfaces as a second-order bug: deleting that reply (`hide:caw:`) removes it from the live `replyCount` subtraction while the stale +1 remains baked into `cawCount`, so the profile's visible Posts count increases by 1 when a reply is deleted.

### Verification (live production data on cawnest.com, audited 2026-09-06)

| User | Submission path | Root/quote posts (SUCCESS) | Replies (SUCCESS) | Hidden/removed | Actual total | `User.cawCount` |
|---|---|---|---|---|---|---|
| Peer user A | Peer-mirrored | 27 | 13 | 3 | 43 | **43** (every reply folded in) |
| Peer user B | Peer-mirrored | 14 | 14 | 8 | 36 | **35** (near-match; small gap from ongoing new posts) |
| Local user | Local (API route) | 4 | 2 | 12 | 18 | **15** (2 replies correctly excluded: 4 + 11) |

For peer-mirrored users, (root/quote posts + replies + hidden) exactly equals `User.cawCount`, confirming every reply was folded into the count. The locally-submitted user correctly excludes their replies. This gap is exactly the asymmetry between the local submit path and the `ActionProcessor` path.

Also audited a third `onCawCreated` call site (`handleRecawAction`) — confirmed no fix needed there, since `RECAW`-type actions (plain repost or quote) can never structurally be a comment reply; `isReply` being omitted there is correct as-is.

### Solution
Pass `isReply: isReplyNotQuote` (`handleCawAction`) and `isReply: Boolean(parentCawId && isReplyNotQuote)` (`handleOtherAction`) to `onCawCreated`. Also hoisted `handleOtherAction`'s `isReplyNotQuote` computation above its `onCawCreated` call (previously computed after, for the parent-`commentCount` branch only).

New test: `tests/services/CountManager.replyFlag.test.ts` (4 cases: top-level post increments `cawCount`, reply does not, the pre-fix bug condition reproduced with `isReply` omitted, and quote `recawCount` bump is independent of `isReply`).

`tsc --noEmit`: 1 pre-existing unrelated error in `RawEventsGatherer/listenForRawEvents.ts` (fixed separately in #115, not yet merged).

### Known Limitations
`api/routes/users.ts`'s displayed `cawCount` is computed as `Math.max(0, user.cawCount - replyCount) + recawCount`, a correction added under the (until now correct) assumption that the raw `cawCount` always included every reply. After this fix, newly-arriving replies are correctly excluded from the raw `cawCount`, so this display-side subtraction will start over-subtracting for new activity — replies that no longer inflate `cawCount` still get subtracted out at display time, causing the visible Posts count to drift downward over time as new replies accumulate. This subtraction should be removed as a follow-up once `cawCount` reliably excludes replies going forward. Also out of scope: this PR does not backfill already-inflated `User.cawCount` values for existing users (e.g. accumulated drift predating this fix) — a reconciliation pass would need to recompute `cawCount` from actual `Caw` table contents for affected users.

---
zinsanjp