### PR TITLE
fix(FrontEnd): correct QuickSign tip-ceiling unit conversion and async overwrite race

### DIFF
--- a/client/src/services/FrontEnd/src/components/QuickSignOptions.tsx
+++ b/client/src/services/FrontEnd/src/components/QuickSignOptions.tsx
@@ -92,12 +92,18 @@ const QuickSignOptions: React.FC<QuickSignOptionsProps> = ({
   }, [cawPrice])
 
   // Per-action tip presets in dollars → CAW. Label is the dollar amount.
+  // Floored at 1000 CAW (not 1): this is the validator's minimum implicit-
+  // session-tip floor (see "Insufficient implicit session tip" rejection).
+  // A USD-derived preset below that would be rejected on-chain as
+  // underpriced even though the conversion itself is correct — same failure
+  // mode as the networkTipTargetWei unit-mismatch bug this preset sits next
+  // to, just triggered by price movement instead of a unit error.
   const tipDollarOptions = useMemo(() => {
     if (!cawPrice || cawPrice <= 0) return null
     return TIP_USD_PRESETS.map(p => ({
       ...p,
       label: fmtUsdSmall(p.usd).replace(/0+$/, '').replace(/\.$/, ''),
-      caw: BigInt(Math.max(1, Math.round(p.usd / cawPrice))),
+      caw: BigInt(Math.max(1000, Math.round(p.usd / cawPrice))),
     }))
   }, [cawPrice])
 

--- a/client/src/services/FrontEnd/src/components/modals/QuickSignModal.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/QuickSignModal.tsx
@@ -74,11 +74,13 @@ const QuickSignModal: React.FC<QuickSignModalProps> = (props) => {
   const [tipCeiling, setTipCeiling] = useState<bigint>(() => getDefaultTipCeiling(getTipTiers().fast))
   const [dontShowAgain, setDontShowAgain] = useState(false)
   const [walletProtect, setWalletProtect] = useState(false)
+  const [userEditedTip, setUserEditedTip] = useState(false)
 
   // Reset state when modal opens; pre-fill tip ceiling from network target once loaded
   useEffect(() => {
     if (isOpen) {
       setError(null)
+      setUserEditedTip(false)
       // Reuse the shared default ($10 worth of CAW) so this matches the
       // /settings/session-keys default — don't hardcode a divergent figure.
       if (cawPrice > 0) setSpendLimit(getDefaultSpendLimit())
@@ -86,7 +88,15 @@ const QuickSignModal: React.FC<QuickSignModalProps> = (props) => {
       const networkDefault = networkTipCaw ?? tipCeilingFallbackCaw
       setTipCeiling(networkDefault)
     }
-  }, [isOpen, cawPrice, networkTipCaw, tipCeilingFallbackCaw])
+  }, [isOpen])
+
+  // networkTipCaw resolves asynchronously (on-chain read) — apply it once it
+  // arrives, but never clobber a value the user has since edited themselves.
+  useEffect(() => {
+    if (isOpen && !userEditedTip && networkTipCaw) {
+      setTipCeiling(networkTipCaw)
+    }
+  }, [networkTipCaw, isOpen, userEditedTip])
 
   const handleEnable = async () => {
     setLoading(true)
@@ -176,7 +186,10 @@ const QuickSignModal: React.FC<QuickSignModalProps> = (props) => {
             duration={duration}
             onDurationChange={setDuration}
             tipCeiling={tipCeiling}
-            onTipCeilingChange={setTipCeiling}
+            onTipCeilingChange={(v) => {
+              setUserEditedTip(true)
+              setTipCeiling(v)
+            }}
             walletProtect={walletProtect}
             onWalletProtectChange={setWalletProtect}
             themed

--- a/client/src/services/FrontEnd/src/components/modals/QuickSignRenewModal.tsx
+++ b/client/src/services/FrontEnd/src/components/modals/QuickSignRenewModal.tsx
@@ -70,6 +70,7 @@ const QuickSignRenewModal: React.FC = () => {
   const [duration, setDuration] = useState<number>(DEFAULT_SESSION_DURATION)
   const [tipCeiling, setTipCeiling] = useState<bigint>(() => getDefaultTipCeiling(getTipTiers().fast))
   const [walletProtect, setWalletProtect] = useState(false)
+  const [userEditedTip, setUserEditedTip] = useState(false)
 
   const wrongWallet = isConnected && activeToken && address
     ? activeToken.address.toLowerCase() !== address.toLowerCase()
@@ -81,10 +82,21 @@ const QuickSignRenewModal: React.FC = () => {
   // navigated away mid-renew.
   React.useEffect(() => {
     if (isOpen) {
+      setUserEditedTip(false)
       const networkDefault = networkTipCaw ?? tipCeilingFallbackCaw
       setTipCeiling(networkDefault)
     }
-  }, [isOpen, networkTipCaw, tipCeilingFallbackCaw])
+  }, [isOpen])
+
+  // networkTipCaw resolves asynchronously (on-chain read) — apply it once it
+  // arrives, but never clobber a value the user has since edited themselves.
+  // Same fix as QuickSignModal (this component mirrors it and had picked up
+  // the same async-overwrite race).
+  React.useEffect(() => {
+    if (isOpen && !userEditedTip && networkTipCaw) {
+      setTipCeiling(networkTipCaw)
+    }
+  }, [networkTipCaw, isOpen, userEditedTip])
 
   // Clear stale errors when connection state changes
   React.useEffect(() => { setError(null) }, [isConnected, address, chainId])
@@ -204,7 +216,10 @@ const QuickSignRenewModal: React.FC = () => {
             duration={duration}
             onDurationChange={setDuration}
             tipCeiling={tipCeiling}
-            onTipCeilingChange={setTipCeiling}
+            onTipCeilingChange={(v) => {
+              setUserEditedTip(true)
+              setTipCeiling(v)
+            }}
             walletProtect={walletProtect}
             onWalletProtectChange={setWalletProtect}
             themed

--- a/client/src/services/FrontEnd/src/hooks/useNetworkTipTargetAsCAW.test.ts
+++ b/client/src/services/FrontEnd/src/hooks/useNetworkTipTargetAsCAW.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for calculateTipCeilingFromOnChainTarget, the pure conversion function
+ * backing useNetworkTipTargetAsCAW.
+ *
+ * Regression test for a unit-mismatch bug: networkTipTargetWei is
+ * ETH-denominated (per CawActions.sol's "ethCap comes from
+ * CawProfileLedger.networkTipTargetWei" comment on _getTipCost), but the
+ * frontend previously divided it by 1e18 as if it were 18-decimal CAW-wei.
+ * Since 500,000,000,000 / 1e18 == 0, the code fell back to a hardcoded
+ * BigInt(1) (1 CAW) — far below the validator's 1000 CAW minimum implicit
+ * session tip, causing every session-signed action to be rejected as
+ * "underpriced" once the oracle first pushed a non-zero target (2026-09-04).
+ *
+ * Verified against real on-chain reads from cawnest.com's Base Sepolia RPC
+ * (2026-09-07): CawProfileLedger.networkTipTargetWei(1) = 500000000000;
+ * CawActions.tipState() = (lastUpdatedAt=1788639158, ratio=6790207473144214254423584).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { calculateTipCeilingFromOnChainTarget } from './useSessionKey'
+
+// Real values read from cawnest.com's RPC, 2026-09-07.
+const REAL_TIP_TARGET_WEI = 500000000000n
+const REAL_TIP_RATIO = 6790207473144214254423584n
+const REAL_LAST_UPDATED_AT = 1788639158n
+
+describe('calculateTipCeilingFromOnChainTarget — QuickSign tip ceiling unit fix', () => {
+  it('returns null (dormant) when tipTargetWei is 0', () => {
+    const result = calculateTipCeilingFromOnChainTarget(0n, 0n, REAL_TIP_RATIO, REAL_LAST_UPDATED_AT + 100n)
+    expect(result).toBeNull()
+  })
+
+  it('returns null (dormant) when tipRatio is 0', () => {
+    const result = calculateTipCeilingFromOnChainTarget(REAL_TIP_TARGET_WEI, REAL_LAST_UPDATED_AT, 0n, REAL_LAST_UPDATED_AT + 100n)
+    expect(result).toBeNull()
+  })
+
+  it('returns null (stale) when more than 24h have passed since lastUpdatedAt', () => {
+    const justOverStale = REAL_LAST_UPDATED_AT + 86400n + 1n
+    const result = calculateTipCeilingFromOnChainTarget(REAL_TIP_TARGET_WEI, REAL_LAST_UPDATED_AT, REAL_TIP_RATIO, justOverStale)
+    expect(result).toBeNull()
+  })
+
+  it('does NOT treat exactly 24h as stale (boundary)', () => {
+    const exactlyAtThreshold = REAL_LAST_UPDATED_AT + 86400n
+    const result = calculateTipCeilingFromOnChainTarget(REAL_TIP_TARGET_WEI, REAL_LAST_UPDATED_AT, REAL_TIP_RATIO, exactlyAtThreshold)
+    expect(result).not.toBeNull()
+  })
+
+  it('regression: real on-chain values no longer collapse to 1 CAW via naive /1e18 division', () => {
+    // The pre-fix bug: 500_000_000_000n / 10n**18n === 0n, forced to BigInt(1).
+    const naiveOldCalculation = REAL_TIP_TARGET_WEI / (10n ** 18n)
+    expect(naiveOldCalculation).toBe(0n) // confirms the bug's premise
+
+    // The fix converts via the on-chain ratio instead, and floors at the
+    // validator's 1000 CAW minimum rather than silently defaulting to 1.
+    const fresh = REAL_LAST_UPDATED_AT + 100n // well within the 24h window
+    const result = calculateTipCeilingFromOnChainTarget(REAL_TIP_TARGET_WEI, REAL_LAST_UPDATED_AT, REAL_TIP_RATIO, fresh)
+    expect(result).not.toBeNull()
+    expect(result! >= 1000n).toBe(true)
+  })
+
+  it('computes the exact UQ112.112 conversion before applying the 1000 CAW floor', () => {
+    // Raw conversion (ethCap << 112) / ratio / 1e18 = 382 for these real values —
+    // itself below the validator floor, confirming the floor is load-bearing,
+    // not just a defensive nicety.
+    const fresh = REAL_LAST_UPDATED_AT + 100n
+    const result = calculateTipCeilingFromOnChainTarget(REAL_TIP_TARGET_WEI, REAL_LAST_UPDATED_AT, REAL_TIP_RATIO, fresh)
+    const rawConverted = (REAL_TIP_TARGET_WEI << 112n) / REAL_TIP_RATIO / (10n ** 18n)
+    expect(rawConverted).toBe(382n)
+    expect(result).toBe(1000n) // floored up from 382
+  })
+})

--- a/client/src/services/FrontEnd/src/hooks/useSessionKey.ts
+++ b/client/src/services/FrontEnd/src/hooks/useSessionKey.ts
@@ -1065,6 +1065,58 @@ export async function registerSponsoredSession(opts: {
  *   - tipCeilingUsd: the USD equivalent (number), or 0 if prices unavailable
  *   - tipCeilingFallbackCaw: a $0.0009-denominated fallback in whole CAW (always defined)
  */
+// Mirrors CawActions._getTipCost's on-chain math exactly: networkTipTargetWei
+// is ETH-denominated (see CawActions.sol:1245's "ethCap comes from
+// CawProfileLedger.networkTipTargetWei" comment), converted to whole CAW via
+// CawActions.tipState's UQ112.112 WETH-per-CAW ratio — NOT via cawPrice/ethPrice
+// USD math, and NOT the same ratio as capState (tipState has no bindsNow gate
+// and is a separate on-chain slot; the two can diverge even though today they
+// happen to share a value). tipState.ratio === 0, or a lastUpdatedAt older than
+// CAP_STALE_THRESHOLD (24h), means the on-chain target is dormant/stale — the
+// contract itself falls back to the session's own perActionTipRate ceiling in
+// that case, so the frontend mirrors that by falling back to the USD default.
+const TIP_STALE_THRESHOLD_SECONDS = 86400 // 24h, mirrors CawActions.sol's CAP_STALE_THRESHOLD
+const VALIDATOR_MIN_IMPLICIT_TIP_CAW = 1000n // mirrors the "Insufficient implicit session tip" floor
+
+/**
+ * Pure calculation, exported for unit testing. Mirrors CawActions._getTipCost's
+ * on-chain math exactly: networkTipTargetWei is ETH-denominated (see
+ * CawActions.sol:1245's "ethCap comes from CawProfileLedger.networkTipTargetWei"
+ * comment), converted to whole CAW via CawActions.tipState's UQ112.112
+ * WETH-per-CAW ratio — NOT via cawPrice/ethPrice USD math, and NOT the same
+ * ratio as capState (tipState has no bindsNow gate and is a separate on-chain
+ * slot; the two can diverge even though today they happen to share a value).
+ * tipRatio === 0, or a lastUpdatedAt older than TIP_STALE_THRESHOLD_SECONDS,
+ * means the on-chain target is dormant/stale — the contract itself falls back
+ * to the session's own perActionTipRate ceiling in that case, so this mirrors
+ * that by returning null (caller falls back to the USD default).
+ */
+export function calculateTipCeilingFromOnChainTarget(
+  tipTargetWei: bigint,
+  tipLastUpdatedAt: bigint,
+  tipRatio: bigint,
+  nowSeconds: bigint,
+): bigint | null {
+  const isStale =
+    tipTargetWei === 0n ||
+    tipRatio === 0n ||
+    nowSeconds - tipLastUpdatedAt > BigInt(TIP_STALE_THRESHOLD_SECONDS)
+
+  if (isStale) return null
+
+  // Mirror CawActions._getTipCost: r = (ethCap << 112) / ratio / 1e18, floor 1.
+  const PRECISION_1E18 = 10n ** 18n
+  const converted = (tipTargetWei << 112n) / tipRatio / PRECISION_1E18
+  const wholeCAW = converted > 0n ? converted : 1n
+
+  // Floor at the validator's minimum implicit-session-tip floor. The on-chain
+  // conversion can legitimately land below this (e.g. a low ETH-denominated
+  // target relative to the live CAW/ETH ratio), and a value under the floor
+  // would be rejected by validators as "underpriced" even though the unit
+  // conversion itself is correct.
+  return wholeCAW > VALIDATOR_MIN_IMPLICIT_TIP_CAW ? wholeCAW : VALIDATOR_MIN_IMPLICIT_TIP_CAW
+}
+
 export function useNetworkTipTargetAsCAW(networkId: number = CLIENT_ID): {
   tipCeilingCaw: bigint | undefined
   tipCeilingUsd: number
@@ -1074,10 +1126,12 @@ export function useNetworkTipTargetAsCAW(networkId: number = CLIENT_ID): {
 
   // Fallback: $0.0009 worth of CAW — the recommended default per-action tip
   // (matches the $0.0009 ★ preset in QuickSignOptions; accepted by the most
-  // validators).
+  // validators). Floored at 1000 CAW: this is also the validator's minimum
+  // implicit-session-tip floor (see "Insufficient implicit session tip"
+  // rejection), so a USD-derived value below that would still be rejected.
   const USD_FALLBACK = 0.0009
   const tipCeilingFallbackCaw: bigint =
-    cawPrice > 0 ? BigInt(Math.max(1, Math.round(USD_FALLBACK / cawPrice))) : BigInt(1000)
+    cawPrice > 0 ? BigInt(Math.max(1000, Math.round(USD_FALLBACK / cawPrice))) : BigInt(1000)
 
   // networkTipTargetWei lives on CawProfileLedger (deployed at CAW_NAMES_L2_ADDRESS),
   // NOT on CawActions. Reading it off the wrong ABI/address silently fails and the
@@ -1091,21 +1145,33 @@ export function useNetworkTipTargetAsCAW(networkId: number = CLIENT_ID): {
     staleTime: 5 * 60 * 1000, // 5 minutes per project_infura_quota_dials
   } as any)
 
-  if (tipTargetWei === undefined || tipTargetWei === null) {
+  // tipState lives on CawActions — the ratio used to convert the ETH-denominated
+  // networkTipTargetWei above into whole CAW, exactly as _getTipCost does.
+  const { data: tipStateData } = useReadContract({
+    address: CAW_ACTIONS_ADDRESS as `0x${string}`,
+    abi: cawActionsAbi,
+    functionName: 'tipState',
+    chainId: baseSepolia.id,
+    staleTime: 5 * 60 * 1000,
+  } as any)
+
+  if (tipTargetWei === undefined || tipTargetWei === null || tipStateData === undefined || tipStateData === null) {
     return { tipCeilingCaw: undefined, tipCeilingUsd: 0, tipCeilingFallbackCaw }
   }
 
   const tipTargetBigInt = tipTargetWei as bigint
+  const [tipLastUpdatedAt, tipRatio] = tipStateData as [bigint, bigint]
+  const nowSeconds = BigInt(Math.floor(Date.now() / 1000))
 
-  // tipTargetWei is in CAW-wei (18 decimals) — convert to whole CAW tokens
-  // If the target is 0 on-chain, fall back to the USD-denominated default
-  if (tipTargetBigInt === 0n) {
+  const tipCeilingCawFromChain = calculateTipCeilingFromOnChainTarget(
+    tipTargetBigInt, tipLastUpdatedAt, tipRatio, nowSeconds,
+  )
+
+  if (tipCeilingCawFromChain === null) {
     return { tipCeilingCaw: tipCeilingFallbackCaw, tipCeilingUsd: USD_FALLBACK, tipCeilingFallbackCaw }
   }
 
-  const wholeCAW = tipTargetBigInt / BigInt(10 ** 18)
-  const tipCeilingCaw = wholeCAW > 0n ? wholeCAW : BigInt(1)
-
+  const tipCeilingCaw = tipCeilingCawFromChain
   // USD value: whole CAW * cawPrice
   const tipCeilingUsd = cawPrice > 0 ? Number(tipCeilingCaw) * cawPrice : 0
 


### PR DESCRIPTION
### Severity: High

Every session-signed action (posts, likes, recaws, follows, deletions) has been rejected on-chain as underpriced since `networkTipTargetWei` on `CawProfileLedger` first became non-zero. Any user whose Quick Sign session was registered or renewed on or after that point is affected — this is not an edge case, it's the default path for anyone using the feature at all.

Note on timing: an earlier draft of this investigation dated the trigger to 2026-09-04 (when a related on-chain ratio, `CawActions.tipState`, was believed to have been pushed). Checking `SessionKey` records directly shows sessions created as early as 2026-09-03 already carrying the broken `perActionTipRate = 1`, and the original buggy code path never reads `tipState` at all — it only depends on `networkTipTargetWei` being non-zero. The exact block/timestamp `networkTipTargetWei` first went non-zero is not pinned down here; the practical takeaway is that "was this session created before or after date X" is not a reliable way to know if a given session is affected — check its `perActionTipRate` directly instead.

### Impact & Real-World Evidence

Because the frontend applies optimistic UI updates, affected actions appear to succeed immediately. `DataCleaner`'s 30-minute sweep then silently deletes the unconfirmed rows and rolls back counters (`likeCount -1`, `cawCount -1`) with no error shown to the user — posts and likes simply vanish 30 minutes after being made, with no indication why.

Verified on `cawnest.com` production data before the fix:
- `TxQueue` showed 10 consecutive rejected actions (`cawonce` 151-161, spanning `CAW`/`LIKE`/`OTHER` action types), every one with `reason: "Insufficient implicit session tip: 1 < 1000 CAW"`.
- Live PM2 logs showed 3 likes, each rolled back exactly 30 minutes after being pressed:

```
10:51:33: creating pending like for user: 3 (Like ID: 782)
10:51:53: [Validator] Marking txQueue entry 182 as underpriced (tip): Insufficient implicit session tip: 1 < 1000 CAW
11:21:38: [CountManager] like 782: PENDING -> FAILED — rolling back counts
```

- A user's own post (`Caw` id 579) ended up `status: FAILED` and was cleaned up.
- Querying `SessionKey` directly on `cawnest.com` found 9 sessions currently registered with `perActionTipRate = 1`, spanning 4 distinct owner wallets and 8 accounts, all still live (not expired or revoked) as of this writing.

### Root Cause

`useNetworkTipTargetAsCAW` treated `networkTipTargetWei` as 18-decimal CAW-wei and divided by `1e18`. The value is actually ETH-denominated (see `CawActions.sol`'s `_getTipCost`: "ethCap comes from `CawProfileLedger.networkTipTargetWei`"), so `500,000,000,000 / 1e18 == 0`, and the ternary fallback forced a hardcoded `1 CAW` — far below the validator floor of 1000 CAW.

### Fix

- `useSessionKey.ts`: added `calculateTipCeilingFromOnChainTarget()`, a pure function mirroring `CawActions._getTipCost`'s UQ112.112 math exactly (`ethCap << 112 / ratio / 1e18`), reading `CawActions.tipState()` for the ratio rather than doing USD-denominated math via `ethPrice`/`cawPrice`. `tipState` is a separate on-chain slot from `capState` (the dynamic action-cost cap proposed separately in #112) — structurally similar but independently updated, so it cannot be assumed to share the same ratio going forward even though it does today. Staleness (more than 24h since last oracle push) is mirrored the same way: falls back to the USD-denominated default rather than a meaningless/stale CAW figure. Both the on-chain conversion and the USD fallback are now floored at 1000 CAW (the validator's minimum), not 1 — verified the on-chain conversion for the current live ratio genuinely lands below the floor (382 CAW), confirming the floor is load-bearing, not just a defensive nicety.
- `QuickSignModal.tsx` and `QuickSignRenewModal.tsx`: fixed an async overwrite race where the on-chain tip target, once resolved, unconditionally clobbered a value the user had already typed or selected via preset. Added a `userEditedTip` flag so the async default only applies before the user edits it. `QuickSignRenewModal`'s own comments note it mirrors `QuickSignModal` — it had copied the same race along with the pattern.
- `QuickSignOptions.tsx`: the dollar-denominated tip presets ($0.0009, $0.0005, $0.0002) had the identical unit-mismatch-adjacent bug — floored at 1 CAW instead of 1000. Found via a horizontal check of every call site; harmless at today's CAW price (presets currently compute to 7,000-32,000 CAW) but would silently underprice again on sufficient price movement — the same failure mode, triggered by a different cause.
- Audited every other `useNetworkTipTargetAsCAW` call site (`SessionKeySettings.tsx`, `Onboarding.tsx`, `PostMintOnboarding.tsx`) — confirmed each already guards against the same async-overwrite race correctly; no changes needed there.

### Verification

Deployed the fix to `cawnest.com` and re-enabled Quick Sign:
- Wallet signature prompt showed "Tip per action: 32282 CAW" (USD fallback path, tip oracle currently stale) and a subsequent real post confirmed on-chain immediately (`TxQueue` status `done`, no rejection reason, `implicitTip: 32267` — matching the signed ceiling).
- Also verified the on-chain-ratio path directly by temporarily lowering the staleness threshold against the live (otherwise-stale) oracle ratio: produced "Tip per action: 1000 CAW" for the $0.0009 preset (matching the hand-computed 382 CAW raw conversion, floored to 1000) and "7170 CAW" for the $0.0002 preset (matching the hand-computed 7171 CAW) — confirmed via real MetaMask signature prompts, then reverted the temporary threshold change.

New test: `useNetworkTipTargetAsCAW.test.ts` (6 cases covering dormant/stale/fresh states, the 24h boundary, and the exact real-world conversion values above).

### User Impact and Recovery

This bug only affects Quick Sign session-key signed actions. Actions signed manually via a wallet popup each time are unaffected and continue to work regardless of this fix.

Existing sessions already registered with a tip rate of 1 CAW are not automatically repaired by this fix. The code change only applies to newly registered or renewed sessions going forward. On cawnest.com, 9 such broken sessions across 4 distinct wallets and 8 accounts are still live as of this writing. Affected users need to re-enable Quick Sign (Settings, Session Keys, or the Quick Sign modal) after this fix is deployed. Doing so re-registers the session with a correctly computed tip ceiling. No on-chain or database migration is needed since the fix is purely forward-looking, gated by the user re-signing.

---
zinsanjp
