### PR TITLE
fix(FrontEnd): gate action signing on CLIENT_ID_VALID; fix stale env.example

### DIFF
--- a/client/src/services/FrontEnd/env.example
+++ b/client/src/services/FrontEnd/env.example
@@ -1,8 +1,11 @@
 # FrontEnd Environment Variables for Development
 # Copy this file to .env and update the values as needed
 
-# Client ID for the frontend instance
-VITE_CLIENT_ID=1
+# Singleton Network ID for this front-end, baked in at build time.
+# Canonical var since the client->network rename; the legacy VITE_CLIENT_ID
+# name still works as a fallback, but new builds should set VITE_NETWORK_ID.
+# A build with neither leaves CLIENT_ID = NaN and blocks all action signing.
+VITE_NETWORK_ID=1
 
 # Validator tip amount in CAW tokens (not wei - will be multiplied by 10^18)
 # Default: 1000 CAW

--- a/client/src/services/FrontEnd/src/api/actions.ts
+++ b/client/src/services/FrontEnd/src/api/actions.ts
@@ -661,6 +661,13 @@ export function buildTypedData(params: ActionParams, tipOverride?: bigint, opts?
   if (code === undefined) {
     throw new Error(`Unknown actionType "${params.actionType}"`)
   }
+  if (!CLIENT_ID_VALID) {
+    throw new Error(
+      `[CLIENT_ID] Cannot sign action: Network ID is unset or invalid (CLIENT_ID=${CLIENT_ID}). ` +
+      'The frontend was built without VITE_NETWORK_ID (or legacy VITE_CLIENT_ID). ' +
+      'Rebuild with VITE_NETWORK_ID set in client/src/services/FrontEnd/.env.'
+    )
+  }
   // Clone the amounts array to avoid mutating the original
   const amounts = [...(params.amounts ?? [])];
 


### PR DESCRIPTION
## Problem

When the frontend is built without `VITE_NETWORK_ID` (or legacy `VITE_CLIENT_ID`),
`CLIENT_ID = Number(import.meta.env.VITE_NETWORK_ID ?? VITE_CLIENT_ID)` resolves to
`NaN`. `buildTypedData` inlines `networkId: CLIENT_ID` into every action's EIP-712
payload, so the `NaN` reaches wagmi/viem's uint encoder and `BigInt(NaN)` throws a
`RangeError`. On WebKit/JSC this surfaces as the opaque **"Not an integer"** from
deep inside `signTypedData`, with no hint that a missing build-time env is the cause.

Every action (post/like/follow/…) silently becomes impossible. Worse, a browser
still holding an older, correctly-built bundle keeps working — so it looks
device-specific and sends you chasing a client bug that isn't there.

## Fix

The maintainer already gates render-path contract reads on `CLIENT_ID_VALID`
(`StakingRewardsInfo`). This extends the same guard to the submit/sign choke point
(`buildTypedData`) so a bad build **fails fast with an actionable message** instead
of an opaque encoder error:

> [CLIENT_ID] Cannot sign action: Network ID is unset or invalid (CLIENT_ID=NaN).
> The frontend was built without VITE_NETWORK_ID (or legacy VITE_CLIENT_ID).
> Rebuild with VITE_NETWORK_ID set in client/src/services/FrontEnd/.env.

Also fixes `env.example`, which still advertised the pre-rename `VITE_CLIENT_ID` —
exactly what leads operators to build without `VITE_NETWORK_ID` set.

## Notes

Hit this in the wild on a self-hosted node: a rebuild without the env var baked a
`NaN` CLIENT_ID, and the only symptom was "Not an integer" on every signature. This
guard would have made the root cause obvious in seconds.