### PR TITLE
fix(quicksign): drop the No limit spend option — 0 can't be signed

### DIFF
--- a/client/src/services/FrontEnd/src/components/QuickSignOptions.tsx
+++ b/client/src/services/FrontEnd/src/components/QuickSignOptions.tsx
@@ -280,11 +280,6 @@ const QuickSignOptions: React.FC<QuickSignOptionsProps> = ({
     )
   }
 
-  const handleNoLimit = () => {
-    onSpendLimitChange(BigInt(0))
-    if (onWalletProtectChange) onWalletProtectChange(true)
-  }
-
   return (
     <div className={`space-y-4 mt-4 p-4 rounded-xl border ${
       themed && !isDark ? 'bg-gray-50 border-gray-200' : ''
@@ -306,13 +301,6 @@ const QuickSignOptions: React.FC<QuickSignOptionsProps> = ({
                   {opt.label}
                 </button>
               ))}
-              <button
-                type="button"
-                onClick={handleNoLimit}
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-all cursor-pointer ${btnClass(spendLimit === 0n)}`}
-              >
-                No limit
-              </button>
             </>
           ) : (
             // Fallback if price not loaded yet — show raw CAW amounts
@@ -327,13 +315,6 @@ const QuickSignOptions: React.FC<QuickSignOptionsProps> = ({
                   {formatSpendLimit(BigInt(n))}
                 </button>
               ))}
-              <button
-                type="button"
-                onClick={handleNoLimit}
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-all cursor-pointer ${btnClass(spendLimit === 0n)}`}
-              >
-                No limit
-              </button>
             </>
           )}
         </div>

--- a/client/src/services/FrontEnd/src/hooks/useSessionKey.ts
+++ b/client/src/services/FrontEnd/src/hooks/useSessionKey.ts
@@ -69,7 +69,6 @@ export const SPEND_LIMIT_OPTIONS = [
   { label: '50M',  value: BigInt(50_000_000) },
   { label: '100M', value: BigInt(100_000_000) },
   { label: '500M', value: BigInt(500_000_000) },
-  { label: 'No limit', value: BigInt(0) },
 ]
 
 const MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December']


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Problem</h2>
<p>Enabling Quick Sign with <strong>No limit</strong> selected always fails. Reported by @Zinsanjp.</p>
<p><code>SessionMessageParser._parseSpendLimitValue</code> rejects a parsed value of 0 outright:</p>
<pre><code class="language-solidity">function _parseSpendLimitValue(bytes memory line) internal pure returns (uint256) {
  if (line.length &lt; 5) revert BadParse();
  uint256 number = 0;
  uint256 i = 0;
  while (i &lt; line.length &amp;&amp; line[i] &gt;= 0x30 &amp;&amp; line[i] &lt;= 0x39) {
    number = number * 10 + (uint8(line[i]) - 0x30);
    i++;
  }
  if (number == 0) revert BadParse();   // &lt;-- here
  ...
}
</code></pre>
<p>The frontend writes <code>0M CAW</code> into the signed message (<code>formatSpendLimitForMessage</code> returns <code>'0M'</code> when <code>n === 0</code>), so <code>registerSessionPersonal</code> reverts before the session is ever written.</p>
<p><code>0 CAW</code> hits the same line — the check is on the parsed number, before the suffix is even read — so <strong>there is no spelling of 0 that the parser accepts</strong>.</p>
<h2>Reproduced</h2>
<p>On <code>tencawffee.com</code>, selecting No limit and enabling:</p>
<pre><code>[Sessions] Error processing b0fff4db-...: execution reverted (unknown custom error)
(action="estimateGas", data="0xb3ed74d7", ...)
</code></pre>
<p><code>0xb3ed74d7</code> is the selector for <code>BadParse()</code>. Decoding the message that was submitted confirms the line:</p>
<pre><code>Enable Quick Sign
------------------
Spend limit:
0M CAW          &lt;--
...
</code></pre>
<p>The UI shows only a generic "Something went wrong. Please try again." — the revert reason doesn't reach it. Not addressed here, but worth noting: the same failure would have been obvious in seconds with the custom error surfaced.</p>
<h2>Why remove rather than teach the parser about 0</h2>
<p>The rest of the stack does handle 0 as unlimited, and correctly:</p>

layer | treatment of spendLimit == 0
-- | --
SPEND_LIMIT_OPTIONS (UI) | unlimited
SessionMessageParser:165 | revert BadParse()
CawProfileLedger._writeWalletSession | accepted — the param doc says 0 = unlimited
CawActions._applyAction:1377 | if (spendLimit > 0) — skips the cap entirely


<p>Only the message parser rejects it, and it sits in front of the others on the one registration path the frontend uses (<code>sessions.ts</code> calls <code>registerSessionPersonal</code>; the EIP-712 <code>registerSession</code> entry point isn't wired up). So the option is unreachable in practice.</p>
<p>Teaching the parser to accept 0 would need a contract redeploy. Removing the option doesn't, and — separately from the bug — an unbounded session key is the one shape where a leaked key has no ceiling on what it can spend. Every remaining preset is finite.</p>
<h2>On the walletProtect coupling</h2>
<p><code>handleNoLimit</code> did two things:</p>
<pre><code class="language-js">const handleNoLimit = () =&gt; {
  onSpendLimitChange(BigInt(0))
  if (onWalletProtectChange) onWalletProtectChange(true)
}
</code></pre>
<p>The second line is a deliberate trade — if the spend ceiling is gone, at least force the key to be encrypted at rest. That's the only place <code>walletProtect</code> is turned on automatically; the default is <code>false</code> and the checkbox is otherwise manual.</p>
<p>Removing No limit removes the condition that trade fires on, so the coupling goes with it. Flagging it explicitly because it does mean one fewer path to <code>walletProtect</code> being enabled, and I'd rather that be a decision than a side effect. Two follow-ups below relate.</p>
<h2>Follow-ups, not in this PR</h2>
<p><strong>1. A free-form spend-limit input.</strong> With No limit gone, the ceiling is whatever the largest dollar preset resolves to. A typed input — same shape as the one already above the tip presets — would give the "I want a bigger ceiling" case somewhere to go. Two constraints if anyone picks this up:</p>
<ul>
<li><code>_parseSpendLimitValue</code> requires an <code>M</code>/<code>K</code>/<code>B</code> suffix; a bare integer or a decimal reverts. <code>formatSpendLimitForMessage</code> already rounds up to whole millions, so a typed value would be silently rounded — worth previewing the rounded figure in the UI rather than leaving it to be discovered on-chain.</li>
<li>0 must be rejected at input, or this bug comes straight back through the new door.</li>
</ul>
<p><strong>2. Whether <code>walletProtect</code> should default on.</strong> Related to the coupling above, but a wider question than this PR — it changes the flow for every user, not just the ones who would have picked No limit.</p>
<p><strong>3. <code>MAX_SESSION_SPEND</code> doesn't bound what the UI can produce.</strong> Worth knowing if anyone adds an upper-bound validation on the back of it:</p>
<pre><code class="language-solidity">/// @notice Absolute upper bound on any session spend limit. Prevents phishing
///         pages from submitting an inflated value (e.g. "999B CAW") after
///         showing the user a lower figure. Finding NEW-4.
uint256 internal constant MAX_SESSION_SPEND = 1_000_000_000 ether;   // 1e27
</code></pre>
<p>The <code>ether</code> suffix makes the constant 1e27, while everything it's compared against is in whole tokens — the parser returns whole tokens (<code>"5M CAW"</code> → <code>5_000_000</code>), and <code>CawActions</code> accumulates <code>actionCost</code> in whole tokens too (<code>actionCost += wholeTokens</code>). So <code>999B CAW</code> (9.99e11) passes, as does anything the UI can currently produce: the <code>$100</code> preset resolves to ~3.6B CAW at today's price, and I confirmed a session at that value registers successfully on <code>tencawffee.com</code>.</p>
<p>Not touched here — it needs a redeploy, and nothing is failing because of it. Raising it so that a future <code>spendLimit &lt;= MAX_SESSION_SPEND</code> check in the frontend isn't written against a number that doesn't mean what it reads as.</p>
<h2>Testing</h2>
<p><code>tsc --noEmit</code> clean. Verified on <code>tencawffee.com</code> that the remaining presets still register — including <code>$100</code>, which is the largest and now the effective ceiling.</p></body></html><!--EndFragment-->
</body>
</html>