### PR TITLE
docs(backlog): X-gate and ungated signup dead-end at the username step

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -349,6 +349,39 @@ The replication path was rewritten as the optimistic archive + trustless `CawCha
 
 ## Frontend
 
+### X-gate and ungated signup dead-end at the username step
+
+`UsernameStep`'s `canProceed` requires `giftCaw !== undefined`. `giftCaw` is only
+ever set by the `useEffect` in `Onboarding.tsx` that opens with `if (!codeValid ||
+!normalizedCode) return`, and `normalizedCode` is `searchParams.get('code')`. The
+two code-less gates therefore reach the username step and stop: Next carries the
+`disabled` attribute, no spinner (`giftLoading` never leaves `false`), no message.
+
+Measured on tencawffee.com — same build, three gates, valid available names:
+
+| gate | giftCawDefined | canProceed |
+| --- | --- | --- |
+| invite code | true | **true** |
+| X gate | false | false |
+| ungated | false | false |
+
+The other four terms of `canProceed` are identical across all three.
+
+`e362e69b` (2026-06-08) introduced the requirement — before it `canProceed` was
+`usernameAvailable === true`. `19597d91` (X gate, 06-12) and `091eda4d` (ungated,
+06-14) each wire their gate open and thread their token through to
+`bootstrapNewUser`, but neither touches `UsernameStep.tsx`.
+
+The server accepts all three shapes, so the request simply never gets made. What
+the fix should be isn't obvious from outside: `consumeXQualifiedToken` returns
+`{ xUserId, xHandle }` only, so there is no gift figure on the X path to feed the
+FE — `depositAmountCAW` arrives from the client and is bounded by
+`SPONSOR_MAX_DEPOSIT_CAW`.
+
+Also worth deciding: `/onboarding` has no invite-code input field. A code reaches
+the app only through `?code=` in the URL, so a visitor who lands without one has
+just the two dead ends.
+
 ### Re-enable tsc in the production build — SHIPPED (`c518891a`, 2026-05)
 
 **Status:** Re-enabled in `c518891a` — `tsc -b && vite build` is back in the


### PR DESCRIPTION
**Backlog entry only — no code changes.** Two of the three onboarding gates open, then dead-end one step later. Reporting rather than patching: the server side is ready, but what the frontend should send on the X path is a decision I can't make from the outside.

The diff is 33 lines in `PROJECT_BACKLOG.md` under `## Frontend`. Everything below is the detail behind it.

## Symptom

`/onboarding` reaches the username step, the name validates green ("available"), and **Next is `disabled`** — permanently. No spinner, no error, no message. The button carries the `disabled` attribute, so it isn't keyboard-reachable either. There is nothing the visitor can do.

This happens on the X-account gate and on the ungated free-signup path. The invite-code path works.

## Where it stops

`UsernameStep.tsx`:

```js
const canProceed =
  usernameAvailable === true &&
  !giftLoading &&
  giftCaw !== undefined &&
  !nameTooExpensive &&
  !belowMinLength
```

`Onboarding.tsx` — the only place `giftInfo` is ever set:

```js
useEffect(() => {
  if (!codeValid || !normalizedCode) return
  …
  setGiftInfo({ valid: true, giftCaw: BigInt(json.giftCaw), … })
}, [codeValid, normalizedCode])
```

`normalizedCode` comes from `searchParams.get('code')` and nowhere else. With no code in the URL the effect returns on its first line, `giftInfo` stays at its `useState(null)` initial value, and `giftCaw` is `undefined` forever.

`giftLoading` never flips either — it's `false` from mount to unmount. So the UI can't even show "loading"; from the outside it's a button that just doesn't work.

## Measured

Temporary `console.log` in `UsernameStep`, printing each term of `canProceed`. Same build, same session, three gates, valid available names in all three:

```
invite code   {"usernameAvailable":true,"giftLoading":false,"giftCawDefined":true,
               "nameTooExpensive":false,"belowMinLength":false,"canProceed":true}

X gate        {"usernameAvailable":true,"giftLoading":false,"giftCawDefined":false,
               "nameTooExpensive":false,"belowMinLength":false,"canProceed":false}

ungated       {"usernameAvailable":true,"giftLoading":false,"giftCawDefined":false,
               "nameTooExpensive":false,"belowMinLength":false,"canProceed":false}
```

Four of the five terms are identical across all three. `giftCawDefined` is the only difference, and it's the whole difference.

The code path also renders `Your invite includes 200M CAW ($5.09)` and `You'll receive 194.1M CAW deposited to your profile`; the other two render neither, which is the same absence showing through the UI.

(The diagnostic was removed and the tree rebuilt afterwards.)

## How the three arrived

```
2026-06-08  e362e69b  feat(onboarding): gift-driven sponsored deposit — no amount chooser
2026-06-12  19597d91  feat(signup): open sponsored mint via X-account gate (Layer 1)
2026-06-14  091eda4d  feat(onboarding): ungated free-signup path, off by default (#229)
```

`e362e69b` is where the gate appeared. Before it:

```js
const canProceed = usernameAvailable === true
```

after it, the five-term version above. Its message states the assumption plainly: *"The invite code defines a fixed CAW gift."* True at the time — the code path was the only path.

Four and six days later the two code-less paths landed. Neither touches `UsernameStep.tsx` — it isn't in either commit's file list. Both wire the gate open (`gateBlocked = codeInvalid && !xQualifiedToken && !(ungatedEnabled && ungatedChosen)`) and thread their token through to `bootstrapNewUser`, which is the correct half. The username step in between kept requiring a gift that only a code can supply.

`19597d91`'s own note — *"register /api/verify/x/signup-callback in the X dev app's redirect URIs before this works end to end"* — reads like the end-to-end pass was still pending when it merged.

## Server side is ready

`sponsor.ts` accepts all three shapes explicitly:

```js
// (1) invite code → gifted deposit; (2) X-qualified token → gifted deposit;
// (3) UNGATED — no code, no X → a free zero-deposit profile
```

and rejects both-at-once with *"the FE never sends both"*. The X branch consumes its token and the ungated branch forces `depositAmountCAW = 0`. Nothing here is blocked; the request just never gets made.

Worth noting for whoever fixes this: `consumeXQualifiedToken` returns `{ xUserId, xHandle }` only, and `xGate` is used solely to write the `WalletXLink` row. The server has no gift figure for the X path — `depositAmountCAW` arrives from the FE and is bounded by `SPONSOR_MAX_DEPOSIT_CAW`. So "what should `giftCaw` be on the X path" isn't answerable from the server as it stands, which is why I'm not sending a patch.

## Not a local patch

Both files on this node are byte-identical to `origin/v2`:

```
Onboarding.tsx     sha256 47a88c26048333f9…   (working tree = HEAD = origin/v2)
UsernameStep.tsx   sha256 d6435654d121366b…   (working tree = HEAD = origin/v2)
```

`git diff` and `git diff HEAD` both empty for these two.

## One thing that makes it worse

`/onboarding` has no invite-code input field. The gate screen renders the X button, optionally the free-signup button, and "back home" — that's all. A code only reaches the app through `?code=` in the URL.

So a visitor who lands on `/onboarding` without a code in hand has exactly the two paths that dead-end. Operators can work around it by always distributing full `?code=…` links, which is what I do, but it means the failure isn't a degraded corner — for that visitor it's the whole door.

## Not verified

Whether anyone completed an account through the X gate after 2026-06-08. I only have this node, and the account I made here went through the code path.

(Measured on tencawffee.com against `origin/v2`; three gates in one build, diagnostic removed afterwards, `.env` restored.)